### PR TITLE
utils: fix file existence check

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -305,7 +305,7 @@ enter_cgroup_subsystem (int cgroup_mode, pid_t pid, const char *subsystem, const
     }
   else
     {
-      ret = crun_path_exists (cgroup_path, 0, err);
+      ret = crun_path_exists (cgroup_path, err);
       if (UNLIKELY (ret < 0))
         return ret;
       if (ret == 0)
@@ -364,7 +364,7 @@ enter_cgroup (int cgroup_mode, pid_t pid, const char *path, int ensure_missing, 
         continue;
 
       sprintf (subsystem_path, "/sys/fs/cgroup/%s", subsystems[i]);
-      ret = crun_path_exists (subsystem_path, !ensure_missing, err);
+      ret = crun_path_exists (subsystem_path, err);
       if (UNLIKELY (ret < 0))
         return ret;
       if (ret == 0)

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -667,7 +667,7 @@ do_masked_and_readonly_paths (libcrun_container_t *container, const char *rootfs
       int dir;
       xasprintf (&path, "%s/%s", rootfs, def->linux->masked_paths[i]);
 
-      ret = crun_path_exists (path, 1, err);
+      ret = crun_path_exists (path, err);
       if (UNLIKELY (ret < 0))
         {
           if (errno != EACCES)
@@ -697,7 +697,7 @@ do_masked_and_readonly_paths (libcrun_container_t *container, const char *rootfs
 
       xasprintf (&path, "%s/%s", rootfs, def->linux->readonly_paths[i]);
 
-      ret = crun_path_exists (path, 1, err);
+      ret = crun_path_exists (path, err);
       if (UNLIKELY (ret < 0))
         {
           if (errno != EACCES)

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -163,7 +163,7 @@ libcrun_status_check_directories (const char *state_root, const char *id, libcru
   if (UNLIKELY (dir == NULL))
         return crun_make_error (err, 0, "cannot get state directory");
 
-  ret = crun_path_exists (dir, 0, err);
+  ret = crun_path_exists (dir, err);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -253,7 +253,7 @@ libcrun_get_containers_list (libcrun_container_list_t **ret, const char *state_r
         continue;
 
       xasprintf (&status_file, "%s/%s/status", run_directory, next->d_name);
-      exists = crun_path_exists (status_file, 1, err);
+      exists = crun_path_exists (status_file, err);
       if (exists < 0)
        {
          libcrun_free_containers_list (tmp);
@@ -352,5 +352,5 @@ libcrun_status_has_read_exec_fifo (const char *state_root, const char *id, libcr
 
   xasprintf (&fifo_path, "%s/exec.fifo", state_dir);
 
-  return crun_path_exists (fifo_path, 1, err);
+  return crun_path_exists (fifo_path, err);
 }

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -121,9 +121,9 @@ argp_mandatory_argument (char *arg, struct argp_state *state)
 }
 
 int
-crun_path_exists (const char *path, int readonly, libcrun_error_t *err)
+crun_path_exists (const char *path, libcrun_error_t *err)
 {
-  int ret = access (path, readonly ? R_OK : W_OK);
+  int ret = access (path, F_OK);
   if (ret < 0)
     return 0;
   return 1;

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -62,7 +62,7 @@ int xasprintf (char **str, const char *fmt, ...);
 
 char *argp_mandatory_argument (char *arg, struct argp_state *state);
 
-int crun_path_exists (const char *path, int readonly, libcrun_error_t *err);
+int crun_path_exists (const char *path, libcrun_error_t *err);
 
 int write_file (const char *name, const void *data, size_t len, libcrun_error_t *err);
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -84,7 +84,7 @@ crun_command_spec (struct crun_global_arguments *global_args, int argc, char **a
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = crun_path_exists ("config.json", 0, err);
+  ret = crun_path_exists ("config.json", err);
   if (ret < 0)
     return ret;
   if (ret)

--- a/tests/tests_libcrun_utils.c
+++ b/tests/tests_libcrun_utils.c
@@ -236,9 +236,11 @@ test_crun_path_exists ()
 {
 
   libcrun_error_t err = NULL;
-  if (crun_path_exists ("/dev/null", 1, &err) <= 0)
+  if (crun_path_exists ("/dev/null", &err) <= 0)
     return -1;
-  if (crun_path_exists ("/usr/foo/bin/ls", 1, &err) != 0)
+  if (crun_path_exists ("/usr/foo/bin/ls", &err) != 0)
+    return -1;
+  if (crun_path_exists ("/proc/sysrq-trigger", &err) != 1)
     return -1;
   return 0;
 }


### PR DESCRIPTION
simplify logic for crun_path_exists to not check for the file mode.
It was previously checking whether the file is either writeable or
readable.

This caused an issue with /proc/sysrq-trigger when running in a user
namespace, as the file that has mode 0200 is not owned by root in the
user namespace so crun_path_exists(F_READ) would report it as not
existing and skip to create a bind mount and make it read-only.

Closes: https://github.com/containers/crun/issues/74

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>