### PR TITLE
kill: use freezer control when not using a PID namespace

### DIFF
--- a/crun.1.md
+++ b/crun.1.md
@@ -211,7 +211,7 @@ Show only the container ID.
 crun [global options] kill [options] CONTAINER SIGNAL
 
 **--all**
-Kill all the processes in the container.  Currently ignored.
+Kill all the processes in the container.
 
 **--regex**=**REGEX**
 Kill all the containers that satisfy the specified regex.

--- a/src/kill.c
+++ b/src/kill.c
@@ -45,6 +45,7 @@ enum
 
 struct kill_options_s
 {
+  bool all;
   bool regex;
 };
 
@@ -65,6 +66,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
   switch (key)
     {
     case 'a':
+      kill_options.all = true;
       break;
 
     case 'r':
@@ -131,6 +133,9 @@ crun_command_kill (struct crun_global_arguments *global_args, int argc, char **a
       regfree (&re);
       return 0;
     }
+
+  if (kill_options.all)
+    return libcrun_container_kill_all (&crun_context, argv[first_arg], signal, err);
 
   return libcrun_container_kill (&crun_context, argv[first_arg], signal, err);
 }

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -980,6 +980,10 @@ libcrun_cgroup_killall (char *path, libcrun_error_t *err)
   if (mode < 0)
     return mode;
 
+  ret = libcrun_cgroup_pause_unpause (path, true, err);
+  if (UNLIKELY (ret < 0))
+    crun_error_release (err);
+
   switch (mode)
     {
     case CGROUP_MODE_UNIFIED:

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -37,6 +37,7 @@ enum
 
 int libcrun_get_cgroup_mode (libcrun_error_t *err);
 int libcrun_cgroup_enter (oci_container_linux_resources *resources, int cgroup_mode, char **path, const char *cgroup_path, int manager, pid_t pid, const char *id, libcrun_error_t *err);
+int libcrun_cgroup_killall_signal (char *path, int signal, libcrun_error_t *err);
 int libcrun_cgroup_killall (char *path, libcrun_error_t *err);
 int libcrun_cgroup_destroy (const char *id, char *path, int manager, libcrun_error_t *err);
 int libcrun_move_process_to_cgroup (pid_t pid, char *path, libcrun_error_t *err);

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -42,6 +42,7 @@ int libcrun_cgroup_destroy (const char *id, char *path, int manager, libcrun_err
 int libcrun_move_process_to_cgroup (pid_t pid, char *path, libcrun_error_t *err);
 int libcrun_update_cgroup_resources (int cgroup_mode, oci_container_linux_resources *resources, char *path, libcrun_error_t *err);
 int libcrun_cgroups_create_symlinks (const char *target, libcrun_error_t *err);
+int libcrun_cgroup_pause_unpause (const char *path, const bool pause, libcrun_error_t *err);
 
 typedef const char * cgroups_subsystem_t;
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -918,6 +918,25 @@ libcrun_container_kill (libcrun_context_t *context, const char *id, int signal, 
   return 0;
 }
 
+int
+libcrun_container_kill_all (libcrun_context_t *context, const char *id, int signal, libcrun_error_t *err)
+{
+  int ret;
+  const char *state_root = context->state_root;
+  cleanup_container_status libcrun_container_status_t status;
+
+  memset (&status, 0, sizeof (status));
+
+  ret = libcrun_read_container_status (&status, state_root, id, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = libcrun_cgroup_killall_signal (status.cgroup_path, signal, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+  return 0;
+}
+
 static int
 write_container_status (libcrun_container_t *container, libcrun_context_t *context, pid_t pid,
                         char *cgroup_path, char *created, libcrun_error_t *err)

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -793,6 +793,22 @@ run_poststop_hooks (libcrun_context_t *context, oci_container *def,
   return 0;
 }
 
+static bool
+has_namespace_in_definition (oci_container *def, const char *namespace)
+{
+  size_t i;
+
+  if (def->linux == NULL || def->linux->namespaces == NULL)
+    return false;
+
+  for (i = 0; i < def->linux->namespaces_len; i++)
+    {
+      if (strcmp (def->linux->namespaces[i]->type, namespace) == 0)
+        return true;
+    }
+  return false;
+}
+
 static int
 container_delete_internal (libcrun_context_t *context, oci_container *def, const char *id, bool force, bool only_cleanup, libcrun_error_t *err)
 {
@@ -818,22 +834,45 @@ container_delete_internal (libcrun_context_t *context, oci_container *def, const
 
   if (!only_cleanup && !status.detached)
     {
-      if (force)
-        {
-          ret = kill (status.pid, SIGKILL);
-          if (UNLIKELY (ret < 0) && errno != ESRCH)
-            {
-              crun_make_error (err, errno, "kill");
-              return ret;
-            }
-        }
-      else
+      if (! force)
         {
           ret = libcrun_is_container_running (&status, err);
           if (UNLIKELY (ret < 0))
             return ret;
           if (ret == 1)
             return crun_make_error (err, 0, "the container '%s' is not in 'stopped' state", id);
+        }
+      else
+        {
+          cleanup_free libcrun_container_t *container = NULL;
+
+          if (def == NULL)
+            {
+              ret = read_container_config_from_state (&container, state_root, id, err);
+              if (UNLIKELY (ret < 0))
+                return ret;
+
+              def = container->container_def;
+            }
+
+          /* If the container has a pid namespace, it is enough to kill the first
+             process (pid=1 in the namespace).
+          */
+          if (has_namespace_in_definition (def, "pid"))
+            {
+              ret = kill (status.pid, SIGKILL);
+              if (UNLIKELY (ret < 0) && errno != ESRCH)
+                {
+                  crun_make_error (err, errno, "kill cannot find process");
+                  return ret;
+                }
+            }
+          else
+            {
+              ret = libcrun_cgroup_killall (status.cgroup_path, err);
+              if (UNLIKELY (ret < 0))
+                return 0;
+            }
         }
     }
 

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -82,6 +82,8 @@ int libcrun_container_delete (libcrun_context_t *context, oci_container *def, co
 
 int libcrun_container_kill (libcrun_context_t *context, const char *id, int signal, libcrun_error_t *err);
 
+int libcrun_container_kill_all (libcrun_context_t *context, const char *id, int signal, libcrun_error_t *err);
+
 int libcrun_container_create (libcrun_context_t *context, libcrun_container_t *container, libcrun_error_t *err);
 
 int libcrun_container_start (libcrun_context_t *context, const char *id, libcrun_error_t *err);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2392,44 +2392,21 @@ libcrun_linux_container_update (libcrun_container_status_t *status, const char *
 }
 
 static int
-libcrun_container_pause_unpause_linux (libcrun_container_status_t *status, const char *id, const bool pause, libcrun_error_t *err)
+libcrun_container_pause_unpause_linux (libcrun_container_status_t *status, const bool pause, libcrun_error_t *err)
 {
-  int ret;
-  cleanup_free char *path = NULL;
-  int cgroup_mode;
-  const char *state = "";
-
-  cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (cgroup_mode < 0)
-    return cgroup_mode;
-
-  if (cgroup_mode == CGROUP_MODE_UNIFIED)
-    {
-      state = pause ? "1" : "0";
-      xasprintf (&path, "/sys/fs/cgroup/%s/cgroup.freeze", status->cgroup_path);
-    }
-  else
-    {
-      state = pause ? "FROZEN" : "THAWED";
-      xasprintf (&path, "/sys/fs/cgroup/freezer/%s/freezer.state", status->cgroup_path);
-    }
-
-  ret = write_file (path, state, strlen (state), err);
-  if (ret >= 0)
-    return 0;
-  return ret;
+  return libcrun_cgroup_pause_unpause (status->cgroup_path, pause, err);
 }
 
 int
 libcrun_container_pause_linux (libcrun_container_status_t *status, const char *id, libcrun_error_t *err)
 {
-  return libcrun_container_pause_unpause_linux (status, id, true, err);
+  return libcrun_container_pause_unpause_linux (status, true, err);
 }
 
 int
 libcrun_container_unpause_linux (libcrun_container_status_t *status, const char *id, libcrun_error_t *err)
 {
-  return libcrun_container_pause_unpause_linux (status, id, false, err);
+  return libcrun_container_pause_unpause_linux (status, false, err);
 }
 
 /* Protection for attacks like CVE-2019-5736.  */


### PR DESCRIPTION
with the new functions in place we can finally honor the `--all` option for kill