### PR TITLE
seccomp: honor seccomp flags

### DIFF
--- a/src/libcrun/seccomp.h
+++ b/src/libcrun/seccomp.h
@@ -26,7 +26,7 @@
 # include <oci_runtime_spec.h>
 # include "container.h"
 
-int libcrun_generate_and_load_seccomp (libcrun_container_t *container, int outfd, libcrun_error_t *err);
-int libcrun_apply_seccomp (int infd, libcrun_error_t *err);
+int libcrun_generate_and_load_seccomp (libcrun_container_t *container, int outfd, char **flags, size_t flags_len, libcrun_error_t *err);
+int libcrun_apply_seccomp (int infd, char **flags, size_t flags_len, libcrun_error_t *err);
 
 #endif


### PR DESCRIPTION
now the OCI runtime specs support to specify seccomp flags to use with the seccomp(2) syscall.

The accepted options are:

- SECCOMP_FILTER_FLAG_TSYNC
- SECCOMP_FILTER_FLAG_SPEC_ALLOW
- SECCOMP_FILTER_FLAG_LOG

If there is no selection for the flags to use (i.e. there is no seccomp->flags specified), a default configuration is used:

SECCOMP_FILTER_FLAG_LOG and SECCOMP_FILTER_FLAG_SPEC_ALLOW.

From the man page:

SECCOMP_FILTER_FLAG_LOG (since Linux 4.14)
  All filter return actions except SECCOMP_RET_ALLOW should be logged.
  An administrator may override this filter flag by preventing
  specific actions from being logged via the
  /proc/sys/kernel/seccomp/actions_logged file.

SECCOMP_FILTER_FLAG_SPEC_ALLOW (since Linux 4.17)
  Disable Speculative Store Bypass mitigation.


Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>