### PR TITLE
libcrun: fix creating a new cgroup ns

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -483,10 +483,6 @@ container_entrypoint_init (void *args, const char *notify_socket,
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = libcrun_container_enter_cgroup_ns (container, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
-
   ret = sync_socket_send_sync (sync_socket, false, err);
   if (UNLIKELY (ret < 0))
     return ret;

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1183,6 +1183,10 @@ libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_
       get_private_data (container)->remounts = r;
     }
 
+  ret = libcrun_container_enter_cgroup_ns (container, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   ret = do_mounts (container, rootfs, err);
   if (UNLIKELY (ret < 0))
     return ret;


### PR DESCRIPTION
create the new cgroup before mounting the cgroup, otherwise
/sys/fs/cgroup uses the old namespace.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>