### PR TITLE
Report version in standard way following runc

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -166,7 +166,7 @@ static struct argp_option options[] =
 static void
 print_version (FILE *stream, struct argp_state *state)
 {
-  fprintf (stream, "%s\n", argp_program_version);
+  fprintf (stream, "%s version %s\n", PACKAGE_NAME, PACKAGE_VERSION);
   fprintf (stream, "spec: 1.0.0\n");
 #ifdef HAVE_SYSTEMD
   fprintf (stream, "+SYSTEMD ");


### PR DESCRIPTION
Reporting version as "crun version x.x.x" allows Docker to parse correctly as implemented on the PR https://github.com/moby/moby/pull/39940/.