### PR TITLE
seccomp: fix lookup for pseudo syscalls

### DIFF
--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -221,12 +221,8 @@ libcrun_generate_and_load_seccomp (libcrun_container_t *container, int outfd, ch
         {
           int syscall = seccomp_syscall_resolve_name (seccomp->syscalls[i]->names[j]);
 
-         /* If the syscall is not known and we are trying to enable it, assume the kernel
-            doesn't support it.
-            Differently, raise an error if we are trying to block it.
-         */
-         if (syscall < 0 && action == SCMP_ACT_ALLOW)
-           continue;
+          if (UNLIKELY (syscall == __NR_SCMP_ERROR))
+            return crun_make_error (err, 0, "invalid seccomp syscall '%s'", seccomp->syscalls[i]->names[j]);
 
           if (seccomp->syscalls[i]->args == NULL)
             {


### PR DESCRIPTION
seccomp_syscall_resolve_name returns a negative result to indicate a
pseudo syscall that is not present on the current architecture.

Handle correctly the return code so that the seccomp filter works well
when running on a non native arch.

Closes: https://github.com/containers/crun/issues/94

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>