### PR TITLE
error: always write errors to stderr

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -611,7 +611,7 @@ container_entrypoint (void *args, const char *notify_socket,
   cleanup_free const char *exec_path = NULL;
   entrypoint_args->sync_socket = sync_socket;
 
-  crun_set_output_handler (log_write_to_sync_socket, args);
+  crun_set_output_handler (log_write_to_sync_socket, args, false);
 
   ret = container_entrypoint_init (args, notify_socket, sync_socket, &exec_path, err);
   if (UNLIKELY (ret < 0))
@@ -657,7 +657,7 @@ container_entrypoint (void *args, const char *notify_socket,
       while (ret == 0);
     }
 
-  crun_set_output_handler (log_write_to_stream, stderr);
+  crun_set_output_handler (log_write_to_stderr, NULL, false);
 
   ret = close_fds_ge_than (entrypoint_args->context->preserve_fds + 3, err);
   if (UNLIKELY (ret < 0))
@@ -1591,7 +1591,7 @@ libcrun_container_run (libcrun_context_t *context, libcrun_container_t *containe
       TEMP_FAILURE_RETRY (write (pipefd1, &((*err)->status), sizeof ((*err)->status)));
       TEMP_FAILURE_RETRY (write (pipefd1, (*err)->msg, strlen ((*err)->msg) + 1));
 
-      crun_set_output_handler (log_write_to_stderr, NULL);
+      crun_set_output_handler (log_write_to_stderr, NULL, false);
       libcrun_fail_with_error ((*err)->status, "%s", (*err)->msg);
     }
   exit (ret);
@@ -1676,7 +1676,7 @@ libcrun_container_create (libcrun_context_t *context, libcrun_container_t *conta
   if (UNLIKELY (ret < 0))
     {
       libcrun_error ((*err)->status, "%s", (*err)->msg);
-      crun_set_output_handler (log_write_to_stderr, NULL);
+      crun_set_output_handler (log_write_to_stderr, NULL, false);
     }
 
   TEMP_FAILURE_RETRY (write (pipefd1, &ret, sizeof (ret)));

--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -43,6 +43,7 @@ enum
   };
 
 static int log_format;
+static bool log_also_to_stderr;
 
 int
 crun_make_error (libcrun_error_t *err, int status, const char *msg, ...)
@@ -199,7 +200,7 @@ init_logging (crun_output_handler *new_output_handler, void **new_output_handler
           break;
         }
     }
-  crun_set_output_handler (*new_output_handler, *new_output_handler_arg);
+  crun_set_output_handler (*new_output_handler, *new_output_handler_arg, log != NULL);
   return 0;
 }
 
@@ -270,10 +271,11 @@ libcrun_get_verbosity ()
 }
 
 void
-crun_set_output_handler (crun_output_handler handler, void *arg)
+crun_set_output_handler (crun_output_handler handler, void *arg, bool log_to_stderr)
 {
   output_handler = handler;
   output_handler_arg = arg;
+  log_also_to_stderr = log_to_stderr;
 }
 
 static char *
@@ -335,6 +337,9 @@ write_log (int errno_, bool warning, const char *msg, va_list args_list)
   ret = vasprintf (&output, msg, args_list);
   if (UNLIKELY (ret < 0))
     OOM ();
+
+  if (log_also_to_stderr)
+    log_write_to_stderr (errno_, output, warning, NULL);
 
   switch (log_format)
     {

--- a/src/libcrun/error.h
+++ b/src/libcrun/error.h
@@ -49,7 +49,7 @@ void oom_handler () __attribute__ ((noreturn));
 
 typedef void (*crun_output_handler) (int errno_, const char *msg, bool warning, void *arg);
 
-void crun_set_output_handler (crun_output_handler handler, void *arg);
+void crun_set_output_handler (crun_output_handler handler, void *arg, bool log_to_stderr);
 
 void log_write_to_journald (int errno_, const char *msg, bool warning, void *arg);
 


### PR DESCRIPTION
make sure errors are always written to stderr, even in case a
different --log=FILE is specified.

Closes: https://github.com/containers/crun/issues/102

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>