### PR TITLE
linux: force HOME to be set

### DIFF
--- a/cfg.mk
+++ b/cfg.mk
@@ -12,6 +12,7 @@ local-checks-to-skip = \
     sc_unmarked_diagnostics \
     sc_prohibit_always_true_header_tests \
     sc_prohibit_intprops_without_use \
+    sc_error_message_uppercase
 
 
 #SHELL=bash -x

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_CHECK_HEADERS([sys/capability.h], [], [AC_MSG_ERROR([*** POSIX caps headers n
 
 AC_CHECK_HEADERS([error.h])
 
-AC_CHECK_FUNCS(copy_file_range bpf fgetxattr statx)
+AC_CHECK_FUNCS(copy_file_range bpf fgetxattr statx fgetpwent_r)
 
 AC_SEARCH_LIBS(cap_from_name, [cap], [AC_DEFINE([HAVE_CAP], 1, [Define if libcap is available])], [AC_MSG_ERROR([*** libcap headers not found])])
 AC_SEARCH_LIBS(seccomp_rule_add, [seccomp], [AC_DEFINE([HAVE_SECCOMP], 1, [Define if seccomp is available])], [AC_MSG_ERROR([*** libseccomp headers not found])])

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -508,6 +508,13 @@ container_entrypoint_init (void *args, const char *notify_socket,
           return crun_make_error (err, errno, "putenv '%s'", def->process->env[i]);
     }
 
+  if (getenv ("HOME") == NULL)
+    {
+      ret = set_home_env (container->container_uid);
+      if (UNLIKELY (ret < 0))
+        libcrun_warning ("cannot set HOME environment variable");
+    }
+
   if (def->process && def->process->args)
     {
       *exec_path = find_executable (def->process->args[0]);
@@ -1976,6 +1983,13 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, oci_containe
       for (i = 0; i < process->env_len; i++)
         if (putenv (process->env[i]) < 0)
           libcrun_fail_with_error ( errno, "putenv '%s'", process->env[i]);
+
+      if (getenv ("HOME") == NULL)
+        {
+          ret = set_home_env (container->container_uid);
+          if (UNLIKELY (ret < 0))
+            libcrun_warning ("cannot set HOME environment variable");
+        }
 
       if (process->selinux_label)
         {

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -131,4 +131,6 @@ const char *find_executable (const char *executable_path);
 
 int copy_recursive_fd_to_fd (int srcfd, int destfd, const char *srcname, const char *destname, libcrun_error_t *err);
 
+int set_home_env (uid_t uid);
+
 #endif


### PR DESCRIPTION
if the HOME environment variable is not set, try to read it from the
/etc/passwd file.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>