### PR TITLE
cgroup: Ignore cgroupv1 /proc entries when cgroupv2 present

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -494,6 +494,10 @@ int systemd_finalize (oci_container_linux_resources *resources, int cgroup_mode,
       subpath = strchr (subsystem, ':') + 1;
       *(subpath - 1) = '\0';
 
+      /* skip named hierarchies that have no cgroup controller */
+      if (strcmp(subsystem, ""))
+        continue;
+
       if (strcmp (subpath, *path))
         {
           ret = enter_cgroup_subsystem (pid, subsystem, *path, 1, err);


### PR DESCRIPTION
/proc/self/cgroup may contain cgroupv1 entries even when cgroupv2 is
mounted on the host. When crun is in CGROUP_MODE_UNIFIED, ignore these
other entries and only enter cgroupv2

Closes: #106