### PR TITLE
[WIP] CVE-2019-16884: container: use open fd to host /proc and /sys

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1591,7 +1591,7 @@ read_caps (unsigned long caps[2], char **values, size_t len, libcrun_error_t *er
 }
 
 int
-libcrun_set_selinux_exec_label (libcrun_container_t *container, libcrun_error_t *err)
+libcrun_set_selinux_exec_label (libcrun_container_t *container, int host_proc_fd, libcrun_error_t *err)
 {
   char *label;
 
@@ -1601,11 +1601,11 @@ libcrun_set_selinux_exec_label (libcrun_container_t *container, libcrun_error_t 
   label = container->container_def->process->selinux_label;
   if (label == NULL)
     return 0;
-  return set_selinux_exec_label (label, err);
+  return set_selinux_exec_label (host_proc_fd, label, err);
 }
 
 int
-libcrun_set_apparmor_profile(libcrun_container_t *container, libcrun_error_t *err)
+libcrun_set_apparmor_profile (libcrun_container_t *container, int host_proc_fd, int host_sys_fd, libcrun_error_t *err)
 {
   char *profile;
 
@@ -1615,7 +1615,7 @@ libcrun_set_apparmor_profile(libcrun_container_t *container, libcrun_error_t *er
   profile = container->container_def->process->apparmor_profile;
   if (profile == NULL)
     return 0;
-  return set_apparmor_profile (profile, err);
+  return set_apparmor_profile (host_proc_fd, host_sys_fd, profile, err);
 }
 
 int

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -43,8 +43,8 @@ int libcrun_do_pivot_root (libcrun_container_t *container, bool no_pivot, const 
 int libcrun_set_usernamespace (libcrun_container_t *container, pid_t pid, libcrun_error_t *err);
 int libcrun_set_caps (oci_container_process_capabilities *capabilities, uid_t uid, gid_t gid, int no_new_privileges, libcrun_error_t *err);
 int libcrun_set_rlimits (oci_container_process_rlimits_element **rlimits, size_t len, libcrun_error_t *err);
-int libcrun_set_selinux_exec_label (libcrun_container_t *container, libcrun_error_t *err);
-int libcrun_set_apparmor_profile (libcrun_container_t *container, libcrun_error_t *err);
+int libcrun_set_selinux_exec_label (libcrun_container_t *container, int host_root_fd, libcrun_error_t *err);
+int libcrun_set_apparmor_profile (libcrun_container_t *container, int host_proc_fd, int host_sys_fd, libcrun_error_t *err);
 int libcrun_set_hostname (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_oom (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err);

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -83,13 +83,11 @@ int create_file_if_missing (const char *file, libcrun_error_t *err);
 
 int check_running_in_user_namespace (libcrun_error_t *err);
 
-int set_selinux_exec_label (const char *label, libcrun_error_t *err);
+int set_selinux_exec_label (int host_root_fd, const char *label, libcrun_error_t *err);
 
 int add_selinux_mount_label (char **ret, const char *data, const char *label, libcrun_error_t *err);
 
-int set_apparmor_profile (const char *profile, libcrun_error_t *err);
-
-int is_apparmor_enabled(void);
+int set_apparmor_profile (int host_proc_fd, int host_sys_fd, const char *profile, libcrun_error_t *err);
 
 int read_all_fd (int fd, const char *description, char **out, size_t *len, libcrun_error_t *err);
 
@@ -117,7 +115,7 @@ size_t format_default_id_mapping (char **ret, uid_t container_id, uid_t host_id,
 
 int run_process_with_stdin_timeout_envp (char *path, char **args, const char *cwd, int timeout, char **envp, char *stdin, size_t stdin_len, libcrun_error_t *err);
 
-int close_fds_ge_than (int n, libcrun_error_t *err);
+int close_fds_ge_than (int proc_fd, int n, libcrun_error_t *err);
 
 void get_current_timestamp (char *out);
 


### PR DESCRIPTION
use an open fd to refer to the host /proc and /sys when setting up the
SELinux and the AppArmor labels.

Addresses CVE-2019-16884.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>