### PR TITLE
cgroups: chown cgroups to root in the user namespace

### DIFF
--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -36,7 +36,7 @@ enum
   };
 
 int libcrun_get_cgroup_mode (libcrun_error_t *err);
-int libcrun_cgroup_enter (oci_container_linux_resources *resources, int cgroup_mode, char **path, const char *cgroup_path, int manager, pid_t pid, const char *id, libcrun_error_t *err);
+int libcrun_cgroup_enter (oci_container_linux_resources *resources, int cgroup_mode, char **path, const char *cgroup_path, int manager, pid_t pid, uid_t root_uid, gid_t root_gid, const char *id, libcrun_error_t *err);
 int libcrun_cgroup_killall_signal (char *path, int signal, libcrun_error_t *err);
 int libcrun_cgroup_killall (char *path, libcrun_error_t *err);
 int libcrun_cgroup_destroy (const char *id, char *path, int manager, libcrun_error_t *err);

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -381,8 +381,8 @@ make_container (oci_container *container_def)
   memset (container, 0, sizeof (*container));
   container->container_def = container_def;
 
-  container->host_uid = getuid ();
-  container->host_gid = getgid ();
+  container->host_uid = geteuid ();
+  container->host_gid = getegid ();
 
   return container;
 }


### PR DESCRIPTION
when using a user namespace on cgroups v2, make sure the cgroup is owned by root in the namespace.

test case:

$ podman run --cgroupns private --uidmap=0:1:2000 --systemd \
    --rm -ti fedora /usr/sbin/init

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1758546

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
