### PR TITLE
container: drop MS_RDONLY when not creating a bind mount

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -412,7 +412,7 @@ do_mount (libcrun_container_t *container,
 
       if ((remount_flags & MS_RDONLY) == 0)
         {
-          ret = do_remount (target, remount_flags, NULL, err);
+          ret = do_remount (target, remount_flags, data, err);
           if (UNLIKELY (ret < 0))
             return ret;
         }
@@ -420,7 +420,7 @@ do_mount (libcrun_container_t *container,
         {
           struct remount_s *r;
 
-          r = make_remount (target, remount_flags, NULL, get_private_data (container)->remounts);
+          r = make_remount (target, remount_flags, data, get_private_data (container)->remounts);
           get_private_data (container)->remounts = r;
         }
     }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -272,6 +272,68 @@ make_remount (const char *target, unsigned long flags, const char *data, struct 
 }
 
 static int
+do_remount (const char *target, unsigned long flags, const char *data, libcrun_error_t *err)
+{
+  int ret;
+
+  ret = mount ("none", target, "", flags, data);
+  if (UNLIKELY (ret < 0))
+    {
+      unsigned long remount_flags;
+      struct statfs sfs;
+
+      ret = statfs (target, &sfs);
+      if (UNLIKELY (ret < 0))
+        return crun_make_error (err, errno, "statfs '%s'", target);
+
+      remount_flags = sfs.f_flags & (MS_NOSUID | MS_NODEV | MS_NOEXEC);
+
+      ret = mount ("none", target, "", flags | remount_flags, data);
+      if (LIKELY (ret == 0))
+        return 0;
+
+      /* If it still fails try to add MS_RDONLY.  */
+      if (sfs.f_flags & MS_RDONLY)
+        {
+          remount_flags = sfs.f_flags & (MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_RDONLY);
+          ret = mount ("none", target, "", flags | remount_flags, data);
+        }
+      if (UNLIKELY (ret < 0))
+        return crun_make_error (err, errno, "remount '%s'", target);
+    }
+  return 0;
+}
+
+static int
+finalize_mounts (libcrun_container_t *container, libcrun_error_t *err)
+{
+  int ret = 0;
+  struct remount_s *r = get_private_data (container)->remounts;
+  while (r)
+    {
+      struct remount_s *next = r->next;
+
+      ret = do_remount (r->target, r->flags, r->data, err);
+      if (UNLIKELY (ret < 0))
+        goto cleanup;
+
+      free_remount (r);
+      r = next;
+    }
+
+ cleanup:
+  while (r)
+    {
+      struct remount_s *next = r->next;
+      free_remount (r);
+      r = next;
+    }
+
+  get_private_data (container)->remounts = NULL;
+  return ret;
+}
+
+static int
 do_mount (libcrun_container_t *container,
           const char *source,
           const char *target,
@@ -314,7 +376,7 @@ do_mount (libcrun_container_t *container,
                 return ret;
 
               ret = mount ("/sys", target, "/sys", MS_BIND | MS_REC | MS_SLAVE, data);
-              if (ret == 0)
+              if (LIKELY (ret == 0))
                 return 0;
             }
 
@@ -346,9 +408,21 @@ do_mount (libcrun_container_t *container,
 
   if (needs_remount)
     {
-      unsigned long remount_flags = mountflags & ~ALL_PROPAGATIONS;
-      struct remount_s *r = make_remount (target, MS_REMOUNT | MS_BIND | remount_flags, NULL, get_private_data (container)->remounts);
-      get_private_data (container)->remounts = r;
+      unsigned long remount_flags = MS_REMOUNT | MS_BIND | (mountflags & ~ALL_PROPAGATIONS);
+
+      if ((remount_flags & MS_RDONLY) == 0)
+        {
+          ret = do_remount (target, remount_flags, NULL, err);
+          if (UNLIKELY (ret < 0))
+            return ret;
+        }
+      else
+        {
+          struct remount_s *r;
+
+          r = make_remount (target, remount_flags, NULL, get_private_data (container)->remounts);
+          get_private_data (container)->remounts = r;
+        }
     }
 
   return ret;
@@ -791,62 +865,6 @@ get_default_flags (libcrun_container_t *container, const char *destination, char
       return MS_NOEXEC | MS_NOSUID | MS_NODEV;
 
   return 0;
-}
-
-static int
-finalize_mounts (libcrun_container_t *container, libcrun_error_t *err)
-{
-  int ret = 0;
-  struct remount_s *r = get_private_data (container)->remounts;
-  while (r)
-    {
-      struct remount_s *next = r->next;
-      ret = mount ("none", r->target, "", r->flags, r->data);
-      if (UNLIKELY (ret < 0))
-        {
-          unsigned long flags;
-          struct statfs sfs;
-
-          ret = statfs (r->target, &sfs);
-          if (UNLIKELY (ret < 0))
-            {
-              crun_make_error (err, errno, "statfs '%s'", r->target);
-              goto cleanup;
-            }
-
-          flags = sfs.f_flags & (MS_NOSUID | MS_NODEV | MS_NOEXEC);
-
-          ret = mount ("none", r->target, "", r->flags | flags, r->data);
-          if (LIKELY (ret == 0))
-            continue;
-
-          /* If it still fails try to add MS_RDONLY.  */
-          if (sfs.f_flags & MS_RDONLY)
-            {
-              flags = sfs.f_flags & (MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_RDONLY);
-              ret = mount ("none", r->target, "", r->flags | flags, r->data);
-            }
-          if (UNLIKELY (ret < 0))
-            {
-              crun_make_error (err, errno, "remount '%s'", r->target);
-              goto cleanup;
-            }
-        }
-
-      free_remount (r);
-      r = next;
-    }
-
- cleanup:
-  while (r)
-    {
-      struct remount_s *next = r->next;
-      free_remount (r);
-      r = next;
-    }
-
-  get_private_data (container)->remounts = NULL;
-  return ret;
 }
 
 static int

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -817,6 +817,15 @@ finalize_mounts (libcrun_container_t *container, libcrun_error_t *err)
           flags = sfs.f_flags & (MS_NOSUID | MS_NODEV | MS_NOEXEC);
 
           ret = mount ("none", r->target, "", r->flags | flags, r->data);
+          if (LIKELY (ret == 0))
+            continue;
+
+          /* If it still fails try to add MS_RDONLY.  */
+          if (sfs.f_flags & MS_RDONLY)
+            {
+              flags = sfs.f_flags & (MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_RDONLY);
+              ret = mount ("none", r->target, "", r->flags | flags, r->data);
+            }
           if (UNLIKELY (ret < 0))
             {
               crun_make_error (err, errno, "remount '%s'", r->target);


### PR DESCRIPTION
Partially revert "linux: Keep MS_RDONLY when remounting bind mount of
a read-only source"

Keep the MS_RDONLY flag only for bind mounts.

Prevents an issue with creating subsystems directories on cgroups v1.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>