### PR TITLE
test: hide mounts stderr

### DIFF
--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -36,7 +36,7 @@ def helper_mount(options):
     add_all_namespaces(conf)
     mount_opt = {"destination": "/var/dir", "type": "tmpfs", "source": "tmpfs", "options": [options]}
     conf['mounts'].append(mount_opt)
-    out, _ = run_and_get_output(conf)
+    out, _ = run_and_get_output(conf, hide_stderr=True)
     with tempfile.NamedTemporaryFile(mode='w', delete=True) as f:
         f.write(out)
         f.flush()


### PR DESCRIPTION
warnings in rootless mode will confuse the libmount parser.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>