### PR TITLE
build: fix systemd dependency

### DIFF
--- a/contrib/static-builder-x86_64/Dockerfile
+++ b/contrib/static-builder-x86_64/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf install -y git dnf-utils gcc meson ninja-build libseccomp-static libcap-
 
 FROM base AS systemd
 RUN mkdir /out && yum-builddep -y systemd && git clone --depth 1 https://github.com/systemd/systemd.git \
-    && mkdir systemd/build; cd systemd/build; meson ..; ninja version.h; ninja libsystemd.a; cp libsystemd.a /out
+    && mkdir systemd/build; cd systemd/build; meson .. --buildtype minsize --strip; ninja version.h; ninja libsystemd.a; cp libsystemd.a /out
 
 FROM base AS yajl
 RUN mkdir /out && git clone --depth=1 https://github.com/lloyd/yajl.git; cd yajl; ./configure LDFLAGS=-static; cd build; make -j $(nproc); find . -name '*.a' -exec cp \{\} /out \;

--- a/contrib/static-builder-x86_64/build.sh
+++ b/contrib/static-builder-x86_64/build.sh
@@ -6,6 +6,6 @@ cd /crun/static-build
 
 test -e ../configure || (cd /crun; ./autogen.sh)
 
-../configure CRUN_LDFLAGS='-all-static' LDFLAGS="-static-libgcc -static" LIBS="/usr/lib64/libcap.a /usr/lib64/libseccomp.a /usr/lib64/libsystemd.a /usr/lib64/libyajl_s.a"
+../configure CRUN_LDFLAGS='-all-static' LDFLAGS="-static-libgcc -static" LIBS="/usr/lib64/libsystemd.a /usr/lib64/librt.a /usr/lib64/libpthread.a /usr/lib64/libcap.a /usr/lib64/libseccomp.a /usr/lib64/libyajl_s.a"
 
 exec make -j $(nproc)


### PR DESCRIPTION
reorder dependencies so that systemd can be correctly linked.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>