### PR TITLE
container: print an error when a hook fails

### DIFF
--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -374,7 +374,6 @@ libcrun_error (int errno_, const char *msg, ...)
 
   write_log (errno_, false, msg, args_list);
   va_end (args_list);
-  exit (EXIT_FAILURE);
 }
 
 void __attribute__ ((noreturn))


### PR DESCRIPTION
when a hook fails, print an error message and state the exit code.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>