### PR TITLE
utils: find_executable honors local dir paths

### DIFF
--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -125,7 +125,7 @@ int parse_json_file (yajl_val *out, const char *jsondata, struct parser_context 
 
 int has_prefix (const char *str, const char *prefix);
 
-const char *find_executable (const char *executable_path);
+const char *find_executable (const char *executable_path, const char *cwd);
 
 int copy_recursive_fd_to_fd (int srcfd, int destfd, const char *srcname, const char *destname, libcrun_error_t *err);
 


### PR DESCRIPTION
when the executable path has the form ./PATH, make sure the current
working directory is used as a prefix.

Closes: https://github.com/containers/crun/issues/133

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>