### PR TITLE
build: fix build on Alpine

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,8 @@ libcrun_la_SOURCES = src/libcrun/utils.c \
 			src/libcrun/status.c \
 			src/libcrun/terminal.c \
 			src/libcrun/sig2str.c \
-			src/libcrun/chroot_realpath.c
+			src/libcrun/chroot_realpath.c \
+			src/libcrun/secure_getenv.c
 
 libcrun_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src
 libcrun_la_LIBADD = libocispec/libocispec.la

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ apt-get install -y make git gcc build-essential pkgconf libtool \
    go-md2man libtool autoconf python3 automake
 ```
 
+On Alpine
+```shell
+apk add gcc automake autoconf libtool gettext pkgconf git make musl-dev \
+    python3 libcap-dev libseccomp-dev yajl-dev argp-standalone go-md2man
+```
+
 Unless you are also building the Python bindings, Python is needed
 only by libocispec to generate the C parser at build time, it won't be
 used afterwards.

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_CHECK_HEADERS([sys/capability.h], [], [AC_MSG_ERROR([*** POSIX caps headers n
 
 AC_CHECK_HEADERS([error.h])
 
-AC_CHECK_FUNCS(copy_file_range bpf fgetxattr statx fgetpwent_r)
+AC_CHECK_FUNCS(copy_file_range bpf fgetxattr statx fgetpwent_r issetugid secure_getenv)
 
 AC_SEARCH_LIBS(cap_from_name, [cap], [AC_DEFINE([HAVE_CAP], 1, [Define if libcap is available])], [AC_MSG_ERROR([*** libcap headers not found])])
 AC_SEARCH_LIBS(seccomp_rule_add, [seccomp], [AC_DEFINE([HAVE_SECCOMP], 1, [Define if seccomp is available])], [AC_MSG_ERROR([*** libseccomp headers not found])])

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -43,6 +43,7 @@
 #include <libgen.h>
 #include <sys/wait.h>
 #include <sys/vfs.h>
+#include <limits.h>
 
 #ifndef RLIMIT_RTTIME
 # define RLIMIT_RTTIME 15

--- a/src/libcrun/secure_getenv.c
+++ b/src/libcrun/secure_getenv.c
@@ -1,0 +1,55 @@
+/* Look up an environment variable, returning NULL in insecure situations.
+
+   Copyright 2013-2019 Free Software Foundation, Inc.
+
+   This program is free software: you can redistribute it and/or modify it
+   under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+#include <config.h>
+
+#include <stdlib.h>
+
+#if !HAVE_SECURE_GETENV
+
+# if HAVE_ISSETUGID || (HAVE_GETUID && HAVE_GETEUID && HAVE_GETGID && HAVE_GETEGID)
+#  include <unistd.h>
+# endif
+
+char *
+secure_getenv (char const *name)
+{
+# if HAVE___SECURE_GETENV /* glibc */
+  return __secure_getenv (name);
+# elif HAVE_ISSETUGID /* OS X, FreeBSD, NetBSD, OpenBSD */
+  if (issetugid ())
+    return NULL;
+  return getenv (name);
+# elif HAVE_GETUID && HAVE_GETEUID && HAVE_GETGID && HAVE_GETEGID /* other Unix */
+  if (geteuid () != getuid () || getegid () != getgid ())
+    return NULL;
+  return getenv (name);
+# elif defined _WIN32 && ! defined __CYGWIN__ /* native Windows */
+  /* On native Windows, there is no such concept as setuid or setgid binaries.
+     - Programs launched as system services have high privileges, but they don't
+       inherit environment variables from a user.
+     - Programs launched by a user with "Run as Administrator" have high
+       privileges and use the environment variables, but the user has been asked
+       whether he agrees.
+     - Programs launched by a user without "Run as Administrator" cannot gain
+       high privileges, therefore there is no risk. */
+  return getenv (name);
+# else
+  return NULL;
+# endif
+}
+#endif

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -39,6 +39,7 @@
 #include <sys/sysmacros.h>
 #include <sys/vfs.h>
 #include <linux/magic.h>
+#include <limits.h>
 
 int
 close_and_reset (int *fd)
@@ -1514,6 +1515,13 @@ copy_recursive_fd_to_fd (int srcdirfd, int destdirfd, const char *srcname, const
       ret = fchownat (destdirfd, de->d_name, uid, gid, AT_SYMLINK_NOFOLLOW);
       if (UNLIKELY (ret < 0))
         return crun_make_error (err, errno, "chown %s/%s", destname, de->d_name);
+
+      /*
+       * ALLPERMS is not defined by POSIX
+       */
+      #ifndef ALLPERMS
+      #  define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO)
+      #endif
 
       ret = fchmodat (destdirfd, de->d_name, mode & ALLPERMS, AT_SYMLINK_NOFOLLOW);
       if (UNLIKELY (ret < 0))

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -135,4 +135,8 @@ int libcrun_initialize_selinux (libcrun_error_t *err);
 
 int libcrun_initialize_apparmor (libcrun_error_t *err);
 
+#if !HAVE_SECURE_GETENV
+char *secure_getenv (char const *name);
+#endif
+
 #endif


### PR DESCRIPTION
provide an alternative secure_getenv implementation when it is not available on system.  The implementation is taken from gnulib.

Closes: https://github.com/containers/crun/issues/139

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
