### PR TITLE
systemd: set collectmode=inactive-or-failed

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -784,6 +784,13 @@ int enter_systemd_cgroup_scope (oci_container_linux_resources *resources, const 
         }
     }
 
+  sd_err = sd_bus_message_append (m, "(sv)", "CollectMode", "s", "inactive-or-failed");
+  if (UNLIKELY (sd_err < 0))
+    {
+      ret = crun_make_error (err, -sd_err, "sd-bus message append CollectMode");
+      goto exit;
+    }
+
   sd_err = sd_bus_message_append (m, "(sv)", "Description", "s", "libcrun container");
   if (UNLIKELY (sd_err < 0))
     {

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -757,7 +757,7 @@ int enter_systemd_cgroup_scope (oci_container_linux_resources *resources, const 
   sd_err = sd_bus_message_append (m, "ss", scope, "fail");
   if (UNLIKELY (sd_err < 0))
     {
-      ret = crun_make_error (err, -sd_err, "sd-bus message append");
+      ret = crun_make_error (err, -sd_err, "sd-bus message append scope");
       goto exit;
     }
 
@@ -779,7 +779,7 @@ int enter_systemd_cgroup_scope (oci_container_linux_resources *resources, const 
       sd_err = sd_bus_message_append (m, "(sv)", "Slice", "s", slice_name);
       if (UNLIKELY (sd_err < 0))
         {
-          ret = crun_make_error (err, -sd_err, "sd-bus message append");
+          ret = crun_make_error (err, -sd_err, "sd-bus message append Slice");
           goto exit;
         }
     }
@@ -794,14 +794,14 @@ int enter_systemd_cgroup_scope (oci_container_linux_resources *resources, const 
   sd_err = sd_bus_message_append (m, "(sv)", "Description", "s", "libcrun container");
   if (UNLIKELY (sd_err < 0))
     {
-      ret = crun_make_error (err, -sd_err, "sd-bus message append");
+      ret = crun_make_error (err, -sd_err, "sd-bus message append Description");
       goto exit;
     }
 
   sd_err = sd_bus_message_append (m, "(sv)", "PIDs", "au", 1, pid);
   if (UNLIKELY (sd_err < 0))
     {
-      ret = crun_make_error (err, -sd_err, "sd-bus message append");
+      ret = crun_make_error (err, -sd_err, "sd-bus message append PIDs");
       goto exit;
     }
 
@@ -810,7 +810,7 @@ int enter_systemd_cgroup_scope (oci_container_linux_resources *resources, const 
       sd_err = sd_bus_message_append (m, "(sv)", boolean_opts[i], "b", 1);
       if (UNLIKELY (sd_err < 0))
         {
-          ret = crun_make_error (err, -sd_err, "sd-bus message append");
+          ret = crun_make_error (err, -sd_err, "sd-bus message append %s", boolean_opts[i]);
           goto exit;
         }
     }


### PR DESCRIPTION
so it garbage collects failed units.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>