### PR TITLE
Explicitly enable and disable dependent libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ matrix:
   - env: TEST=coverity
   include:
     - arch: arm64
-      env: TEST=make
+      env: TEST=make-arm64
     - arch: amd64
-      env: TEST=make
+      env: TEST=make-amd64
     - arch: amd64
       env: TEST=podman
     - arch: amd64
@@ -18,7 +18,8 @@ matrix:
     - arch: amd64
       env: TEST=alpine-build
   matrix:
-  - TEST=make
+  - TEST=make-arm64
+  - TEST=make-amd64
   - TEST=podman
   - TEST=oci-validation
   - TEST=coverity
@@ -60,7 +61,8 @@ before_install:
 - git clone --depth=1 git://github.com/lloyd/yajl
 - "(cd yajl && ./configure -p /usr && make && sudo make install)"
 script:
-- if test $TEST = make; then ./autogen.sh && ./configure CFLAGS='-Wall -Werror' && make -j $(nproc) && make syntax-check; fi
+- if test $TEST = make-arm64; then ./autogen.sh && ./configure CFLAGS='-Wall -Werror' && make -j $(nproc) && make syntax-check; fi
+- if test $TEST = make-amd64; then ./autogen.sh && ./configure --disable-systemd CFLAGS='-Wall -Werror' && make -j $(nproc) && make syntax-check; fi
 - if test $TEST = podman; then sudo docker run --privileged --rm -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave -v $(pwd):/crun crun-podman; fi
 - if test $TEST = oci-validation; then sudo docker run --privileged --rm -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave -v $(pwd):/crun crun-oci-validation; fi
 - if test $TEST = coverity; then ./autogen.sh && eval "${COVERITY_SCAN_BUILD}"; fi

--- a/configure.ac
+++ b/configure.ac
@@ -19,35 +19,62 @@ AC_PROG_SED
 AC_PROG_CC
 AM_PATH_PYTHON
 
-AC_CHECK_HEADERS([sys/capability.h], [], [AC_MSG_ERROR([*** POSIX caps headers not found])])
 
 AC_CHECK_HEADERS([error.h])
 
 AC_CHECK_FUNCS(copy_file_range fgetxattr statx fgetpwent_r issetugid secure_getenv)
 
-AC_SEARCH_LIBS(cap_from_name, [cap], [AC_DEFINE([HAVE_CAP], 1, [Define if libcap is available])], [AC_MSG_ERROR([*** libcap headers not found])])
-AC_SEARCH_LIBS(seccomp_rule_add, [seccomp], [AC_DEFINE([HAVE_SECCOMP], 1, [Define if seccomp is available])], [AC_MSG_ERROR([*** libseccomp headers not found])])
-AC_SEARCH_LIBS(seccomp_arch_resolve_name, [seccomp], [AC_DEFINE([SECCOMP_ARCH_RESOLVE_NAME], 1, [Define if seccomp_arch_resolve_name is available])], [ ])
-AC_SEARCH_LIBS(sd_listen_fds, [systemd], [AC_DEFINE([HAVE_SYSTEMD], 1, [Define if libsystemd is available])], [ ])
-
-AC_DEFINE([HAVE_SELINUX], 1, [Define if SELinux is available])
-AC_DEFINE([HAVE_APPARMOR], 1, [Define if AppArmor is available])
-
-AC_SEARCH_LIBS(yajl_tree_get, [yajl], [AC_DEFINE([HAVE_YAJL], 1, [Define if libyajl is available])], [AC_MSG_ERROR([*** libyajl headers not found])])
-
-AC_CHECK_HEADERS([linux/bpf.h])
-AS_IF([test "$ac_cv_header_linux_bpf_h" = "yes"], [
-	AC_MSG_CHECKING(compilation for eBPF)
-	AC_COMPILE_IFELSE(
-		[AC_LANG_SOURCE([[
-			#include <linux/bpf.h>
-			int program = BPF_PROG_TYPE_CGROUP_DEVICE;
-		]])],
-		[AC_MSG_RESULT(yes)
-		 AC_DEFINE([HAVE_EBPF], 1, [Define if eBPF is available])],
-		[AC_MSG_RESULT(no)])
+dnl libcap
+AC_ARG_ENABLE([caps],
+	AS_HELP_STRING([--disable-caps], [Ignore libcap and disable support]))
+AS_IF([test "x$enable_caps" != "xno"], [
+	AC_CHECK_HEADERS([sys/capability.h], [], [AC_MSG_ERROR([*** POSIX caps headers not found])])
+	AS_IF([test "$ac_cv_header_sys_capability_h" = "yes"], [
+		AC_SEARCH_LIBS(cap_from_name, [cap], [AC_DEFINE([HAVE_CAP], 1, [Define if libcap is available])], [AC_MSG_ERROR([*** libcap headers not found])])
+	])
 ])
 
+dnl libseccomp
+AC_ARG_ENABLE([seccomp],
+	AS_HELP_STRING([--disable-seccomp], [Ignore libseccomp and disable support]))
+AS_IF([test "x$enable_seccomp" != "xno"], [
+	AC_CHECK_HEADERS([seccomp.h], [], [AC_MSG_ERROR([*** Missing libseccomp headers])])
+	AS_IF([test "$ac_cv_header_seccomp_h" = "yes"], [
+		AC_SEARCH_LIBS(seccomp_rule_add, [seccomp], [AC_DEFINE([HAVE_SECCOMP], 1, [Define if seccomp is available])], [AC_MSG_ERROR([*** libseccomp headers not found])])
+		AC_SEARCH_LIBS(seccomp_arch_resolve_name, [seccomp], [AC_DEFINE([SECCOMP_ARCH_RESOLVE_NAME], 1, [Define if seccomp_arch_resolve_name is available])], [ ])
+	])
+])
+
+dnl libsystemd
+AC_ARG_ENABLE([systemd],
+	AS_HELP_STRING([--disable-systemd], [Ignore systemd and disable support]))
+AS_IF([test "x$enable_systemd" != "xno"], [
+	AC_CHECK_HEADERS([systemd/sd-bus.h], [], [AC_MSG_ERROR([*** Missing libsystemd headers])])
+	AS_IF([test "$ac_cv_header_systemd_sd_bus_h" = "yes"], [
+		AC_SEARCH_LIBS(sd_listen_fds, [systemd], [AC_DEFINE([HAVE_SYSTEMD], 1, [Define if libsystemd is available])], [AC_MSG_ERROR([*** Failed to find libsystemd])])
+	])
+])
+
+dnl ebpf
+AC_ARG_ENABLE([bpf],
+	AS_HELP_STRING([--disable-bpf], [Ignore eBPF and disable support]))
+AS_IF([test "x$enable_bpf" != "xno"], [
+	AC_CHECK_HEADERS([linux/bpf.h])
+	AS_IF([test "$ac_cv_header_linux_bpf_h" = "yes"], [
+		AC_MSG_CHECKING(compilation for eBPF)
+		AC_COMPILE_IFELSE(
+			[AC_LANG_SOURCE([[
+				#include <linux/bpf.h>
+				int program = BPF_PROG_TYPE_CGROUP_DEVICE;
+			]])],
+			[AC_MSG_RESULT(yes)
+			 AC_DEFINE([HAVE_EBPF], 1, [Define if eBPF is available])],
+			[AC_MSG_RESULT(no)])
+	])
+])
+
+
+AC_SEARCH_LIBS(yajl_tree_get, [yajl], [AC_DEFINE([HAVE_YAJL], 1, [Define if libyajl is available])], [AC_MSG_ERROR([*** libyajl headers not found])])
 PKG_CHECK_MODULES([YAJL], [yajl >= 2.0.0])
 
 AC_ARG_WITH([python-bindings], AS_HELP_STRING([--with-python-bindings], [build the Python bindings]))

--- a/src/crun.c
+++ b/src/crun.c
@@ -171,12 +171,8 @@ print_version (FILE *stream, struct argp_state *state arg_unused)
 #ifdef HAVE_SYSTEMD
   fprintf (stream, "+SYSTEMD ");
 #endif
-#ifdef HAVE_SELINUX
   fprintf (stream, "+SELINUX ");
-#endif
-#ifdef HAVE_APPARMOR
   fprintf (stream, "+APPARMOR ");
-#endif
 #ifdef HAVE_CAP
   fprintf (stream, "+CAP ");
 #endif

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -427,8 +427,6 @@ libcrun_initialize_apparmor (libcrun_error_t *err arg_unused)
   return apparmor_enabled;
 }
 
-#ifdef HAVE_SELINUX
-
 static int
 libcrun_is_selinux_enabled (libcrun_error_t *err)
 {
@@ -436,12 +434,10 @@ libcrun_is_selinux_enabled (libcrun_error_t *err)
     return crun_make_error (err, 0, "SELinux not initialized correctly");
   return selinux_enabled;
 }
-#endif
 
 int
 add_selinux_mount_label (char **retlabel, const char *data, const char *label, libcrun_error_t *err arg_unused)
 {
-#ifdef HAVE_SELINUX
   int ret;
 
   ret = libcrun_is_selinux_enabled (err);
@@ -456,7 +452,6 @@ add_selinux_mount_label (char **retlabel, const char *data, const char *label, l
         xasprintf (retlabel, "context=\"%s\"", label);
       return 0;
     }
-#endif
   *retlabel = xstrdup (data);
   return 0;
 
@@ -490,7 +485,6 @@ write_file_and_check_fs_type (const char *file, const char *data, size_t len, un
 int
 set_selinux_exec_label (const char *label, libcrun_error_t *err)
 {
-#ifdef HAVE_SELINUX
   int ret;
 
   ret = libcrun_is_selinux_enabled (err);
@@ -503,11 +497,9 @@ set_selinux_exec_label (const char *label, libcrun_error_t *err)
       if (UNLIKELY (ret < 0))
         return ret;
     }
-#endif
   return 0;
 }
 
-#ifdef HAVE_APPARMOR
 static int
 libcrun_is_apparmor_enabled (libcrun_error_t *err)
 {
@@ -515,12 +507,10 @@ libcrun_is_apparmor_enabled (libcrun_error_t *err)
     return crun_make_error (err, 0, "AppArmor not initialized correctly");
   return apparmor_enabled;
 }
-#endif
 
 int
 set_apparmor_profile (const char *profile, libcrun_error_t *err)
 {
-#ifdef HAVE_APPARMOR
   int ret;
 
   ret = libcrun_is_apparmor_enabled (err);
@@ -536,7 +526,6 @@ set_apparmor_profile (const char *profile, libcrun_error_t *err)
       if (UNLIKELY (ret < 0))
         return ret;
     }
-#endif
   return 0;
 }
 

--- a/tests/alpine-build/run-tests.sh
+++ b/tests/alpine-build/run-tests.sh
@@ -5,5 +5,5 @@ cd $1
 cd /crun
 git clean -fdx
 ./autogen.sh
-./configure CFLAGS='-Wall -Wextra -Werror' && make -j $(nproc)
+./configure CFLAGS='-Wall -Wextra -Werror' --disable-systemd && make -j $(nproc)
 


### PR DESCRIPTION
I'm in the process of adding crun to Gentoo/portage officially gentoo/gentoo#13430, and to get slightly better integration with portage use flags https://wiki.gentoo.org/wiki/Handbook:PPC/Working/USE, it would be nice to have a more granular configure step. I attempted to keep sane defaults for enabling and disabling features