### PR TITLE
linux: ignore errors creating /dev/console

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1863,7 +1863,22 @@ libcrun_set_terminal (libcrun_container_t *container, libcrun_error_t *err)
 
   ret = write_file ("/dev/console", NULL, 0, err);
   if (UNLIKELY (ret < 0))
-    return ret;
+    {
+      int ret_exists;
+      libcrun_error_t tmp_err = NULL;
+
+      ret_exists = crun_path_exists ("/dev/console", &tmp_err);
+      /* Always ignore errors from crun_path_exists.  */
+      if (UNLIKELY (ret_exists < 0))
+        crun_error_release (&tmp_err);
+
+      /* If the file doesn't exist or crun_path_exists failed, return the original error.  */
+      if (ret_exists <= 0)
+        return ret;
+
+      /* Otherwise ignore errors and try to bind mount on top of it.  */
+      crun_error_release (err);
+    }
 
   ret = do_mount (container, slave, "/dev/console", "devpts", MS_BIND, NULL, 0, err);
   if (UNLIKELY (ret < 0))


### PR DESCRIPTION
ignore errors if the file cannot be created as it might already
exist.  We are anyway going to create a mount on top of it and we'll
catch possible errors during the mount itself.

Closes: https://github.com/containers/crun/issues/150

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>