### PR TITLE
cgroup: fix running on CentOS 8

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -584,7 +584,7 @@ int systemd_finalize (oci_container_linux_resources *resources, int cgroup_mode,
 
   if (cgroup_mode == CGROUP_MODE_LEGACY)
     {
-      from = strstr (content, "::memory");
+      from = strstr (content, ":memory");
       if (UNLIKELY (from == NULL))
         return crun_make_error (err, -1, "cannot find memory controller for the current process");
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -414,7 +414,7 @@ do_mount (libcrun_container_t *container,
 
       if ((remount_flags & MS_RDONLY) == 0)
         {
-          ret = do_remount (target, remount_flags, data, err);
+          ret = do_remount (target, remount_flags, NULL, err);
           if (UNLIKELY (ret < 0))
             return ret;
         }
@@ -422,7 +422,7 @@ do_mount (libcrun_container_t *container,
         {
           struct remount_s *r;
 
-          r = make_remount (target, remount_flags, data, get_private_data (container)->remounts);
+          r = make_remount (target, remount_flags, NULL, get_private_data (container)->remounts);
           get_private_data (container)->remounts = r;
         }
     }


### PR DESCRIPTION
Closes: https://github.com/containers/crun/issues/160

a couple of fixes that prevented running on Linux 4.18.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>