### PR TITLE
tty: change owner to the specified UID

### DIFF
--- a/src/libcrun/terminal.c
+++ b/src/libcrun/terminal.c
@@ -42,7 +42,7 @@ libcrun_new_terminal (char **slave, libcrun_error_t *err)
 {
   char buf[64];
   int ret;
-  cleanup_close int fd = open ("/dev/ptmx", O_RDWR, O_NOCTTY | O_CLOEXEC);
+  cleanup_close int fd = open ("/dev/ptmx", O_RDWR | O_NOCTTY | O_CLOEXEC);
   if (UNLIKELY (fd < 0))
     return crun_make_error (err, errno, "open /dev/ptmx");
 


### PR DESCRIPTION
when running with a terminal and a user != root is specified, make
sure the ownership for the terminal is changed.

Closes: https://github.com/containers/crun/issues/174

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>