### PR TITLE
linux: resolve source paths

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -958,7 +958,7 @@ do_mounts (libcrun_container_t *container, const char *rootfs, libcrun_error_t *
 
       if (def->mounts[i]->source && (flags & MS_BIND))
         {
-          is_dir = crun_dir_p (def->mounts[i]->source, true, err);
+          is_dir = crun_dir_p (def->mounts[i]->source, false, err);
           if (UNLIKELY (is_dir < 0))
             return is_dir;
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1551,9 +1551,9 @@ copy_recursive_fd_to_fd (int srcdirfd, int destdirfd, const char *srcname, const
       /*
        * ALLPERMS is not defined by POSIX
        */
-      #ifndef ALLPERMS
-      #  define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO)
-      #endif
+#ifndef ALLPERMS
+# define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO)
+#endif
 
       ret = fchmodat (destdirfd, de->d_name, mode & ALLPERMS, AT_SYMLINK_NOFOLLOW);
       if (UNLIKELY (ret < 0))


### PR DESCRIPTION
make sure the the source path is resolved when checking the file
type.

regression introduced with b9a0f0b75e7999ecc7e0d4df90fed24b1de5ac4a

Closes: https://github.com/containers/toolbox/issues/330

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>