### PR TITLE
fix Dockerfile (trailing slashes)

### DIFF
--- a/contrib/static-builder-x86_64/Dockerfile
+++ b/contrib/static-builder-x86_64/Dockerfile
@@ -14,8 +14,8 @@ FROM base AS seccomp
 RUN mkdir /out && git clone --depth=1 https://github.com/seccomp/libseccomp.git; cd libseccomp; ./autogen.sh; ./configure --enable-static; make -j $(nproc); find . -name '*.a' -exec cp \{\} /out \;
 
 FROM base
-COPY --from=systemd /out/* /usr/lib64
-COPY --from=yajl /out/* /usr/lib64
-COPY --from=seccomp /out/* /usr/lib64
+COPY --from=systemd /out/* /usr/lib64/
+COPY --from=yajl /out/* /usr/lib64/
+COPY --from=seccomp /out/* /usr/lib64/
 COPY build.sh /usr/bin/build.sh
 CMD /usr/bin/build.sh


### PR DESCRIPTION
when building the Dockerfile I get 

```
When using COPY with more than one source file, the destination must be a directory and end with a /
```

adding the trailing slashes gets me a successful build.