### PR TITLE
Fix "No rule to make target '../.version'"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -111,8 +111,8 @@ TESTS = tests/test_capabilities.py \
 dist-hook:
 	$(AM_V_GEN)echo $(VERSION) > $(distdir)/.tarball-version
 
-EXTRA_DIST += $(TESTS) tests/tests_utils.py build-aux/git-version-gen $(top_srcdir)/.version
-BUILT_SOURCES = $(top_srcdir)/.version
+EXTRA_DIST += $(TESTS) tests/tests_utils.py build-aux/git-version-gen .version
+BUILT_SOURCES = .version
 
 if HAVE_MD2MAN
 man1_MANS = crun.1


### PR DESCRIPTION
I'm not sure if this is the right solution, but if fixed the build error mentioned in #183.

Fixes #183 