### PR TITLE
use oci.run domain for crun

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,7 +52,7 @@ crun_SOURCES = src/crun.c src/run.c src/delete.c src/kill.c src/pause.c src/unpa
 crun_LDADD = libcrun.la $(FOUND_LIBS)
 crun_LDFLAGS = $(CRUN_LDFLAGS)
 
-EXTRA_DIST = COPYING COPYING.libcrun README.md NEWS rpm/crun.spec.in autogen.sh \
+EXTRA_DIST = COPYING COPYING.libcrun README.md NEWS SECURITY.md rpm/crun.spec.in autogen.sh \
 	src/crun.h src/list.h src/run.h src/delete.h src/kill.h src/pause.h src/unpause.h \
 	src/create.h src/start.h src/state.h src/exec.h src/spec.h src/update.h src/ps.h \
 	src/libcrun/container.h src/libcrun/seccomp.h src/libcrun/ebpf.h src/libcrun/cgroup.h \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+## Reporting a Vulnerability
+
+If you discover a potential security issue in this project we ask that
+you notify us directly via email to security@oci.run (not affiliated
+with opencontainers.org).
+
+Please do **not** create a public issue.

--- a/crun.1.md
+++ b/crun.1.md
@@ -288,9 +288,9 @@ Path to the file containing the resources to update.
 
 # Extensions to OCI
 
-## io.crun.keep_original_groups=1
+## run.oci.keep_original_groups=1
 
-If the annotation `io.crun.keep_original_groups` is present, then crun
+If the annotation `run.oci.keep_original_groups` is present, then crun
 will skip the `setgroups` syscall that is used to either set the
 additional groups specified in the OCI configuration, or to reset the
 list of additional groups if none is specified.

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1408,7 +1408,7 @@ can_setgroups (libcrun_container_t *container, libcrun_error_t *err)
       const char *annotation;
 
       /* Skip setgroups if the annotation is set to anything different than "0".  */
-      annotation = find_annotation (container, "io.crun.keep_original_groups");
+      annotation = find_annotation (container, "run.oci.keep_original_groups");
       if (annotation)
         return strcmp (annotation, "0") == 0 ? 1 : 0;
     }


### PR DESCRIPTION
- use `run.oci` for the crun specific annotations.
- suggest `security@oci.run` for security reports.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
