### PR TITLE
static: build systemd without SELinux

### DIFF
--- a/contrib/static-builder-x86_64/Dockerfile
+++ b/contrib/static-builder-x86_64/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf install -y git dnf-utils gcc meson ninja-build libcap-static \
 
 FROM base AS systemd
 RUN mkdir /out && yum-builddep -y systemd && git clone --depth 1 https://github.com/systemd/systemd.git \
-    && mkdir systemd/build; cd systemd/build; meson .. --buildtype minsize --strip; ninja version.h; ninja libsystemd.a; cp libsystemd.a /out
+    && mkdir systemd/build; cd systemd/build; meson .. -Dselinux=false --buildtype minsize --strip; ninja version.h; ninja libsystemd.a; cp libsystemd.a /out
 
 FROM base AS yajl
 RUN mkdir /out && git clone --depth=1 https://github.com/lloyd/yajl.git; cd yajl; ./configure LDFLAGS=-static; cd build; make -j $(nproc); find . -name '*.a' -exec cp \{\} /out \;


### PR DESCRIPTION
we use systemd only to delegate the cgroups, so the SELinux support is
not necessary.  The SELinux support in crun is not affected.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>