### PR TITLE
cgroup: fix named hierarchies test

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -635,7 +635,7 @@ int systemd_finalize (oci_container_linux_resources *resources, int cgroup_mode,
       *(subpath - 1) = '\0';
 
       /* skip named hierarchies that have no cgroup controller */
-      if (strcmp(subsystem, "") == 0)
+      if (strchr (subsystem, '=') == 0)
         continue;
 
       if (strcmp (subpath, *path))


### PR DESCRIPTION
when running in cgroup 2 unified mode, make sure v1 named hierarchies
are not joined.

Closes: https://github.com/containers/crun/issues/205

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>