### PR TITLE
seccomp: move generation out of cgroup and do not fail on unknown syscalls

### DIFF
--- a/crun.1.md
+++ b/crun.1.md
@@ -288,7 +288,12 @@ Path to the file containing the resources to update.
 
 # Extensions to OCI
 
-## run.oci.keep_original_groups=1
+## `run.oci.seccomp_fail_unknown_syscall=1`
+
+If the annotation `run.oci.seccomp_fail_unknown_syscall` is present, then crun
+will fail when an unknown syscall is encountered in the seccomp configuration.
+
+## `run.oci.keep_original_groups=1`
 
 If the annotation `run.oci.keep_original_groups` is present, then crun
 will skip the `setgroups` syscall that is used to either set the

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1461,7 +1461,14 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
   if (seccomp_fd >= 0)
     {
-      ret = libcrun_generate_seccomp (container, seccomp_fd, err);
+       unsigned int seccomp_gen_options = 0;
+       const char *annotation;
+
+       annotation = find_annotation (container, "run.oci.seccomp_fail_unknown_syscall");
+       if (annotation && strcmp (annotation, "0") != 0)
+         seccomp_gen_options = LIBCRUN_SECCOMP_FAIL_UNKNOWN_SYSCALL;
+
+       ret = libcrun_generate_seccomp (container, seccomp_fd, seccomp_gen_options, err);
       if (UNLIKELY (ret < 0))
         {
           cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd);
@@ -1469,7 +1476,6 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
         }
       close_and_reset (&seccomp_fd);
     }
-
 
   ret = sync_socket_send_sync (sync_socket, true, err);
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1378,23 +1378,6 @@ deny_setgroups (libcrun_container_t *container, pid_t pid, libcrun_error_t *err)
   return ret;
 }
 
-static const char *
-find_annotation (libcrun_container_t *container, const char *name)
-{
-  size_t i;
-
-  if (container->container_def->annotations == NULL)
-    return NULL;
-
-  for (i = 0; i < container->container_def->annotations->len; i++)
-    {
-      if (strcmp (container->container_def->annotations->keys[i], name) == 0)
-        return container->container_def->annotations->values[i];
-    }
-
-  return NULL;
-}
-
 static int
 can_setgroups (libcrun_container_t *container, libcrun_error_t *err)
 {

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -125,6 +125,9 @@ libcrun_apply_seccomp (int infd, char **seccomp_flags, size_t seccomp_flags_len,
   if (infd < 0)
     return 0;
 
+  if (UNLIKELY (lseek (infd, 0, SEEK_SET) == (off_t) -1))
+    return crun_make_error (err, 0, "lseek");
+
 
   /* if no seccomp flag was specified use a sane default.  */
   if (seccomp_flags == NULL)
@@ -166,7 +169,7 @@ libcrun_apply_seccomp (int infd, char **seccomp_flags, size_t seccomp_flags_len,
 }
 
 int
-libcrun_generate_and_load_seccomp (libcrun_container_t *container, int outfd, char **flags, size_t flags_len, libcrun_error_t *err)
+libcrun_generate_seccomp (libcrun_container_t *container, int outfd, libcrun_error_t *err)
 {
   oci_container_linux_seccomp *seccomp = container->container_def->linux->seccomp;
   int ret;
@@ -271,8 +274,5 @@ libcrun_generate_and_load_seccomp (libcrun_container_t *container, int outfd, ch
         return crun_make_error (err, 0, "seccomp_export_bpf");
     }
 
-  if (UNLIKELY (lseek (outfd, 0, SEEK_SET) == (off_t) -1))
-    return crun_make_error (err, 0, "lseek");
-
-  return libcrun_apply_seccomp (outfd, flags, flags_len, err);
+  return 0;
 }

--- a/src/libcrun/seccomp.h
+++ b/src/libcrun/seccomp.h
@@ -26,7 +26,7 @@
 # include <oci_runtime_spec.h>
 # include "container.h"
 
-int libcrun_generate_and_load_seccomp (libcrun_container_t *container, int outfd, char **flags, size_t flags_len, libcrun_error_t *err);
+int libcrun_generate_seccomp (libcrun_container_t *container, int outfd, libcrun_error_t *err);
 int libcrun_apply_seccomp (int infd, char **flags, size_t flags_len, libcrun_error_t *err);
 
 #endif

--- a/src/libcrun/seccomp.h
+++ b/src/libcrun/seccomp.h
@@ -26,7 +26,12 @@
 # include <oci_runtime_spec.h>
 # include "container.h"
 
-int libcrun_generate_seccomp (libcrun_container_t *container, int outfd, libcrun_error_t *err);
+enum
+  {
+    LIBCRUN_SECCOMP_FAIL_UNKNOWN_SYSCALL = 1 << 0,
+  };
+
+int libcrun_generate_seccomp (libcrun_container_t *container, int outfd, unsigned int options, libcrun_error_t *err);
 int libcrun_apply_seccomp (int infd, char **flags, size_t flags_len, libcrun_error_t *err);
 
 #endif

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1618,3 +1618,20 @@ copy_recursive_fd_to_fd (int srcdirfd, int destdirfd, const char *srcname, const
 
   return 0;
 }
+
+const char *
+find_annotation (libcrun_container_t *container, const char *name)
+{
+  size_t i;
+
+  if (container->container_def->annotations == NULL)
+    return NULL;
+
+  for (i = 0; i < container->container_def->annotations->len; i++)
+    {
+      if (strcmp (container->container_def->annotations->keys[i], name) == 0)
+        return container->container_def->annotations->values[i];
+    }
+
+  return NULL;
+}

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -25,6 +25,7 @@
 # include "error.h"
 # include <dirent.h>
 # include <oci_runtime_spec.h>
+# include "container.h"
 
 # ifndef TEMP_FAILURE_RETRY
 #  define TEMP_FAILURE_RETRY(expression)                                \
@@ -138,5 +139,8 @@ int libcrun_initialize_apparmor (libcrun_error_t *err);
 #if !HAVE_SECURE_GETENV
 char *secure_getenv (char const *name);
 #endif
+
+const char *find_annotation (libcrun_container_t *container, const char *name);
+
 
 #endif


### PR DESCRIPTION
two separate changes I've put together on the same PR to avoid rebasing:

- The first one is to move seccomp generation out of the init process.  It improves memory usage for the init process and now containers (assuming the init process doesn't need more) can run with 250K memory max configured in the cgroup.

- The second one is to not fail on unknown syscalls specified to seccomp.  An annotation is added too keep the previous behaviour.

More details are in the commit messages.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
