### PR TITLE
container: do not fork on create

### DIFF
--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -192,7 +192,7 @@ container_create (PyObject *self, PyObject *args)
     return NULL;
 
   Py_BEGIN_ALLOW_THREADS;
-  ret = libcrun_container_create (ctx, ctr, &err);
+  ret = libcrun_container_create (ctx, ctr, LIBCRUN_RUN_OPTIONS_PREFORK, &err);
   Py_END_ALLOW_THREADS;
   if (ret < 0)
     return set_error (&err);

--- a/src/create.c
+++ b/src/create.c
@@ -130,5 +130,5 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
   if (getenv ("LISTEN_FDS"))
     crun_context.preserve_fds += strtoll (getenv ("LISTEN_FDS"), NULL, 10);
 
-  return libcrun_container_create (&crun_context, container, err);
+  return libcrun_container_create (&crun_context, container, 0, err);
 }

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -84,7 +84,7 @@ int libcrun_container_kill (libcrun_context_t *context, const char *id, int sign
 
 int libcrun_container_kill_all (libcrun_context_t *context, const char *id, int signal, libcrun_error_t *err);
 
-int libcrun_container_create (libcrun_context_t *context, libcrun_container_t *container, libcrun_error_t *err);
+int libcrun_container_create (libcrun_context_t *context, libcrun_container_t *container, unsigned int options, libcrun_error_t *err);
 
 int libcrun_container_start (libcrun_context_t *context, const char *id, libcrun_error_t *err);
 


### PR DESCRIPTION
do not fork the current process on create, this prevents creating
additional processes to wait for.

It solves a race when the OCI runtime caller has SUBREAPER set, such
as Buildah.  When the initial process exited, the container process
cannot be directly waited for as there are other processes to reap
first.

Closes: https://github.com/containers/crun/issues/215

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>