### PR TITLE
libocispec: sync from upstream

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -728,6 +728,9 @@ container_init (void *args, const char *notify_socket, int sync_socket,
   if (UNLIKELY (exec_path == NULL))
     return crun_make_error (err, errno, "executable path not specified");
 
+  if (def->process->user)
+    umask (def->process->user->umask);
+
   execv (exec_path, def->process->args);
 
   if (errno == ENOENT)
@@ -2158,6 +2161,9 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, oci_containe
           if (UNLIKELY (ret < 0))
             return ret;
         }
+
+      if (process->user)
+        umask (process->user->umask);
 
       TEMP_FAILURE_RETRY (write (pipefd1, "0", 1));
       close (pipefd1);

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -610,6 +610,13 @@ container_init_setup (void *args, const char *notify_socket,
   if (UNLIKELY (ret < 0))
     return ret;
 
+  if (container->container_def->linux && container->container_def->linux->personality)
+    {
+      ret = libcrun_set_personality (container->container_def->linux->personality, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+    }
+
   if (def->process && !def->process->no_new_privileges)
     {
       char **seccomp_flags = NULL;
@@ -2121,6 +2128,13 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, oci_containe
             crun_make_error (err, errno, "open executable");
 
           libcrun_fail_with_error ((*err)->status, "%s", (*err)->msg);
+        }
+
+      if (container->container_def->linux && container->container_def->linux->personality)
+        {
+          ret = libcrun_set_personality (container->container_def->linux->personality, err);
+          if (UNLIKELY (ret < 0))
+            return ret;
         }
 
       if (!process->no_new_privileges)

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -55,5 +55,6 @@ int libcrun_create_keyring (const char *name, libcrun_error_t *err);
 int libcrun_container_pause_linux (libcrun_container_status_t *status, libcrun_error_t *err);
 int libcrun_container_unpause_linux (libcrun_container_status_t *status, libcrun_error_t *err);
 int libcrun_container_enter_cgroup_ns (libcrun_container_t *container, libcrun_error_t *err);
+int libcrun_set_personality (oci_container_linux_personality *p, libcrun_error_t *err);
 
 #endif

--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -12,7 +12,7 @@ RUN yum install -y golang python git gcc automake autoconf libcap-devel \
     mkdir -p /root/go/src/github.com/containers && \
     chmod 755 /root && \
     (cd /root/go/src/github.com/containers && git clone https://github.com/containers/libpod && \
-     cd libpod && git reset --hard v1.6.4 && \
+     cd libpod && \
      make install.catatonit && \
      make)
 

--- a/tests/podman/run-tests.sh
+++ b/tests/podman/run-tests.sh
@@ -13,6 +13,8 @@ export OCI_RUNTIME=/crun/crun
 export CGROUP_MANAGER=cgroupfs
 export STORAGE_OPTIONS="--storage-driver=vfs"
 
+export GO111MODULE=off
+
 ulimit -u unlimited
 export TMPDIR=/var/tmp
 


### PR DESCRIPTION
sync latest version of libocispec, it inherits some updated runtime-spec.

and add support for specifying an umask.
    
Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>