### PR TITLE
linux: fix exec if a namespace is not available

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2751,6 +2751,9 @@ libcrun_join_process (libcrun_container_t *container, pid_t pid_to_join, libcrun
       fds[i] = open (ns_join, O_RDONLY);
       if (UNLIKELY (fds[i] < 0))
         {
+          /* If the namespace doesn't exist, just ignore it.  */
+          if (errno == ENOENT)
+            continue;
           ret = crun_make_error (err, errno, "open `%s`", ns_join);
           goto exit;
         }


### PR DESCRIPTION
if a namespace is not available in the kernel, just ignore the error
and do not try to join it.

It solves an issue when running on a kernel that doesn't have the
cgroupns.

Closes: https://github.com/containers/crun/issues/218

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>