### PR TITLE
linux: fix cgroup v1 mount with relative paths

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -620,6 +620,7 @@ do_mount_cgroup_v1 (libcrun_container_t *container,
   const cgroups_subsystem_t *subsystems = NULL;
   cleanup_free char *content = NULL;
   char *from;
+  cleanup_close int tmpfsdirfd = -1;
   char *saveptr = NULL;
 
   subsystems = libcrun_get_cgroups_subsystems (err);
@@ -629,6 +630,11 @@ do_mount_cgroup_v1 (libcrun_container_t *container,
   ret = do_mount (container, source, targetfd, target, "tmpfs", mountflags, "size=1024k", 0, err);
   if (UNLIKELY (ret < 0))
     return ret;
+
+  tmpfsdirfd = open_mount_target (container, target, err);
+  if (UNLIKELY (tmpfsdirfd < 0))
+    return tmpfsdirfd;
+  targetfd = tmpfsdirfd;
 
   ret = read_all_file ("/proc/self/cgroup", &content, NULL, err);
   if (UNLIKELY (ret < 0))


### PR DESCRIPTION
commit afeb06543e3c4846129d2039d61dede4f82e1db0 introduced the
regression.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>