### PR TITLE
linux: bring network device up

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -572,6 +572,10 @@ container_init_setup (void *args, const char *notify_socket,
   if (UNLIKELY (ret < 0))
     return ret;
 
+  ret = libcrun_configure_network (container, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   rootfs = realpath (def->root->path, NULL);
   if (UNLIKELY (rootfs == NULL))
     {

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -56,5 +56,6 @@ int libcrun_container_pause_linux (libcrun_container_status_t *status, libcrun_e
 int libcrun_container_unpause_linux (libcrun_container_status_t *status, libcrun_error_t *err);
 int libcrun_container_enter_cgroup_ns (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_personality (runtime_spec_schema_defs_linux_personality *p, libcrun_error_t *err);
+int libcrun_configure_network (libcrun_container_t *container, libcrun_error_t *err);
 
 #endif


### PR DESCRIPTION
when a new network namespace is created, bring the "lo" device up.

Closes: https://github.com/containers/crun/issues/237

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>