### PR TITLE
crun: make sure the bundle directory is absolute

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -108,15 +108,27 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
 {
   int first_arg, ret;
   libcrun_container_t *container;
+  cleanup_free char *bundle_cleanup = NULL;
 
   crun_context.preserve_fds = 0;
   argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &crun_context);
 
   crun_assert_n_args (argc - first_arg, 1, 1);
 
-  if (bundle != NULL)
-    if (chdir (bundle) < 0)
-      libcrun_fail_with_error (errno, "chdir `%s` failed", bundle);
+  /* Make sure the bundle is an absolute path.  */
+  if (bundle)
+    {
+      if (bundle[0] != '/')
+        {
+          bundle_cleanup = realpath (bundle, NULL);
+          if (bundle_cleanup == NULL)
+            libcrun_fail_with_error (errno, "realpath `%s` failed", bundle);
+          bundle = bundle_cleanup;
+        }
+
+      if (chdir (bundle) < 0)
+        libcrun_fail_with_error (errno, "chdir `%s` failed", bundle);
+    }
 
   ret = init_libcrun_context (&crun_context, argv[first_arg], global_args, err);
   if (UNLIKELY (ret < 0))


### PR DESCRIPTION
if the specified bundle directory is a relative path, use realpath(3)
on it since the rest of the code assumes it is absolute.

Closes: https://github.com/containers/crun/issues/241

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>