### PR TITLE
linux: fix the order of clone syscall arguments on s390

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -132,7 +132,11 @@ find_namespace (const char *name)
 static int
 syscall_clone (unsigned long flags, void *child_stack)
 {
+#if defined __s390__ || defined __CRIS__
+  return (int) syscall (__NR_clone, child_stack, flags);
+#else
   return (int) syscall (__NR_clone, flags, child_stack);
+#endif
 }
 
 static int


### PR DESCRIPTION
When using podman on s390 (and, presumably, cris), the following error
occurs:

	writing file '/proc/{}/gid_map': Operation not permitted

The root cause is that the order of clone syscall arguments is wrong: on
s390 and cris they are reversed (see "C library/kernel differences"
section of `man 2 clone`), but crun uses the same order for all
architectures. The end result is that the container process is created
with stack == CLONE_NEWUSER and flags == 0, causing it to inherit its
parent's user namespace (which prevents writes to gid_map) and to almost
immediately segfault.

Fix by special-casing clone call sequence for s390 and cris.

See also: https://github.com/containers/libpod/commit/ca5114faf928

Edit: added ifdef cris and a link to the similar libpod commit.
Edit 2: fixed style.