### PR TITLE
cgroup: drop warning for rootless

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,9 @@
-* FUTURE
-
 * crun-0.12.1
 - fix the order of clone syscall arguments on s390 and cris.
 - if no mode is specified use 0666 for devices.
 - fix running with a relative bundle directory.
 - fix some regressions in the mounts path resolution.
+- drop a warning when cgroup are not available for rootless.
 
 * crun-0.12
 

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -1080,9 +1080,6 @@ libcrun_cgroup_enter (runtime_spec_schema_config_linux_resources *resources, int
 
   if (rootless > 0 && (cgroup_mode != CGROUP_MODE_UNIFIED || manager != CGROUP_MANAGER_SYSTEMD))
     {
-      if (cgroup_mode == CGROUP_MODE_UNIFIED && manager != CGROUP_MANAGER_SYSTEMD)
-        libcrun_warning ("cannot configure rootless cgroup using the cgroupfs manager");
-
       /* Ignore cgroups errors and set there is no cgroup path to use.  */
       free (*path);
       *path = NULL;


### PR DESCRIPTION
Closes: https://github.com/containers/crun/issues/247

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
