### PR TITLE
linux: use the correct path for notify socket

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1424,7 +1424,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
   container->context = context;
 
-  if (!detach)
+  if (!detach || context->notify_socket)
     {
       ret = prctl (PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0);
       if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1347,7 +1347,14 @@ get_notify_fd (libcrun_context_t *context, libcrun_container_t *container, int *
   char *host_path = NULL;
 
   if (container)
-    host_path = get_private_data (container)->host_notify_socket_path;
+    {
+      const char *parent_dir;
+
+      parent_dir = get_private_data (container)->host_notify_socket_path;
+
+      xasprintf (&host_notify_socket_path, "%s/notify", parent_dir);
+      host_path = host_notify_socket_path;
+    }
 
   *notify_socket_out = -1;
 


### PR DESCRIPTION
do not try to use the parent directory.

Closes: https://github.com/containers/crun/issues/262
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
