### PR TITLE
linux: re-open /dev/null inside of the container

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -641,6 +641,10 @@ container_init_setup (void *args, const char *notify_socket,
   if (UNLIKELY (ret < 0))
     return ret;
 
+  ret = libcrun_reopen_dev_null (err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   if (clearenv ())
     return crun_make_error (err, errno, "clearenv");
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1761,6 +1761,40 @@ libcrun_do_pivot_root (libcrun_container_t *container, bool no_pivot, const char
   return 0;
 }
 
+/* If one of stdin, stdout, stderr are pointing to /dev/null on
+ * the outside of the container, this moves it to /dev/null inside
+ * of the container. This needs to run afer pivot/chroot-ing. */
+int
+libcrun_reopen_dev_null (libcrun_error_t * err)
+{
+  struct stat dev_null;
+  struct stat statbuf;
+  cleanup_close int fd;
+  int i;
+
+  /* Open /dev/null inside of the container. */
+  fd = open ("/dev/null", O_RDWR);
+  if (UNLIKELY (fd == -1))
+    return crun_make_error (err, errno, "failed open()ing /dev/null");
+
+  if (UNLIKELY (fstat (fd, &dev_null) == -1))
+      return crun_make_error (err, errno, "failed stat()ing /dev/null");
+
+  for (i = 0; i <= 2; i++)
+    {
+      if (UNLIKELY (fstat (i, &statbuf) == -1))
+	  return crun_make_error (err, errno, "failed stat()ing fd %d", i);
+      if (statbuf.st_rdev == dev_null.st_rdev)
+	{
+	  /* This FD is pointing to /dev/null. Point it to /dev/null inside
+	   * of the container. */
+	  if (UNLIKELY (dup2 (fd, i) == -1))
+	    return crun_make_error (err, errno, "failed dup2()ing %d", i);
+	}
+    }
+  return 0;
+}
+
 static int
 uidgidmap_helper (char *helper, pid_t pid, char *map_file, libcrun_error_t *err)
 {

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -40,6 +40,7 @@ pid_t libcrun_run_linux_container (libcrun_container_t *container,
 int get_notify_fd (libcrun_context_t *context, libcrun_container_t *container, int *notify_socket_out, libcrun_error_t *err);
 int libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_error_t *err);
 int libcrun_do_pivot_root (libcrun_container_t *container, bool no_pivot, const char *rootfs, libcrun_error_t *err);
+int libcrun_reopen_dev_null (libcrun_error_t *err);
 int libcrun_set_usernamespace (libcrun_container_t *container, pid_t pid, libcrun_error_t *err);
 int libcrun_set_caps (runtime_spec_schema_config_schema_process_capabilities *capabilities, uid_t uid, gid_t gid, int no_new_privileges, libcrun_error_t *err);
 int libcrun_set_rlimits (runtime_spec_schema_config_schema_process_rlimits_element **rlimits, size_t len, libcrun_error_t *err);


### PR DESCRIPTION
This is in preparation for the crun checkpoint/restore support.

Checkpointing a container with CRIU fails if the containers stdin,
stdout and stderr has been redirected to /dev/null, but /dev/null still
points to the device outside of the container. With this change stdin,
stdout and stderr will be pointing to /dev/null on the inside of the
container.

With this change it is possible to checkpoint a crun container.

Also see #71 