### PR TITLE
cgroup: support systemd properties via annotations

### DIFF
--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -36,12 +36,15 @@ enum
   };
 
 int libcrun_get_cgroup_mode (libcrun_error_t *err);
-int libcrun_cgroup_enter (runtime_spec_schema_config_linux_resources *resources, int cgroup_mode, char **path, const char *cgroup_path, int manager, pid_t pid, uid_t root_uid, gid_t root_gid, const char *id, libcrun_error_t *err);
+int libcrun_cgroup_enter (runtime_spec_schema_config_linux_resources *resources, json_map_string_string *annotations,
+                          int cgroup_mode, char **path, const char *cgroup_path, int manager, pid_t pid, uid_t root_uid,
+                          gid_t root_gid, const char *id, libcrun_error_t *err);
 int libcrun_cgroup_killall_signal (char *path, int signal, libcrun_error_t *err);
 int libcrun_cgroup_killall (char *path, libcrun_error_t *err);
 int libcrun_cgroup_destroy (const char *id, char *path, int manager, libcrun_error_t *err);
 int libcrun_move_process_to_cgroup (pid_t pid, char *path, libcrun_error_t *err);
-int libcrun_update_cgroup_resources (int cgroup_mode, runtime_spec_schema_config_linux_resources *resources, char *path, libcrun_error_t *err);
+int libcrun_update_cgroup_resources (int cgroup_mode, runtime_spec_schema_config_linux_resources *resources,
+                                     char *path, libcrun_error_t *err);
 int libcrun_cgroups_create_symlinks (const char *target, libcrun_error_t *err);
 int libcrun_cgroup_pause_unpause (const char *path, const bool pause, libcrun_error_t *err);
 int libcrun_cgroup_read_pids (const char *path, bool recurse, pid_t **pids, libcrun_error_t *err);

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1502,7 +1502,8 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   /* If we are root (either on the host or in a namespace), then chown the cgroup to root in the container user namespace.  */
   get_root_in_the_userns_for_cgroups (def, container->host_uid, container->host_gid, &root_uid, &root_gid);
 
-  ret = libcrun_cgroup_enter (def->linux ? def->linux->resources : NULL, cgroup_mode,
+  ret = libcrun_cgroup_enter (def->linux ? def->linux->resources : NULL, def->annotations,
+                              cgroup_mode,
                               &cgroup_path, def->linux ? def->linux->cgroups_path : "",
                               cgroup_manager, pid, root_uid, root_gid, context->id, err);
   if (UNLIKELY (ret < 0))
@@ -2517,6 +2518,7 @@ libcrun_container_restore (libcrun_context_t *context, const char *id,
                                       &root_gid);
 
   ret = libcrun_cgroup_enter (def->linux ? def->linux->resources : NULL,
+                              def->annotations,
                               cgroup_mode, &cgroup_path,
                               def->linux ? def->linux->cgroups_path : "",
                               cgroup_manager, status.pid, root_uid, root_gid,


### PR DESCRIPTION
add support for systemd properties passed through annotations in the
form:

"annotations": {
               "org.systemd.property.TimeoutStopUSec": "uint64 123456789",
                "org.systemd.property.CollectMode":"'inactive-or-failed'"
}

add a basic parser for the gvariant types to avoid a dependency on
glib.  The parser doesn't support complex types but it is just enough
for the types accepted by systemd.

Similar to https://github.com/opencontainers/runc/pull/2224

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>