### PR TITLE
libcrun: always use setsid

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -680,13 +680,13 @@ container_init_setup (void *args, const char *notify_socket,
         }
     }
 
+  ret = setsid ();
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "setsid");
+
   if (has_terminal)
     {
       cleanup_close int terminal_fd = -1;
-
-      ret = setsid ();
-      if (UNLIKELY (ret < 0))
-        return crun_make_error (err, errno, "setsid");
 
       fflush (stderr);
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2916,12 +2916,6 @@ libcrun_join_process (libcrun_container_t *container, pid_t pid_to_join, libcrun
   for (i = 0; all_namespaces[i]; i++)
     close_and_reset (&fds[i]);
 
-  if (detach && setsid () < 0)
-    {
-      crun_make_error (err, errno, "setsid");
-      goto exit;
-    }
-
   /* We need to fork once again to join the PID namespace.  */
   pid = fork ();
   if (UNLIKELY (pid < 0))


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>