### PR TITLE
Initial checkpoint support (no restore yet)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ libcrun_la_SOURCES = src/libcrun/utils.c \
 			src/libcrun/cloned_binary.c \
 			src/libcrun/container.c \
 			src/libcrun/cgroup.c \
+			src/libcrun/criu.c \
 			src/libcrun/linux.c \
 			src/libcrun/seccomp.c \
 			src/libcrun/ebpf.c \
@@ -48,15 +49,17 @@ endif
 
 crun_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src
 crun_SOURCES = src/crun.c src/run.c src/delete.c src/kill.c src/pause.c src/unpause.c src/spec.c \
-		src/exec.c src/list.c src/create.c src/start.c src/state.c src/update.c src/ps.c
+		src/exec.c src/list.c src/create.c src/start.c src/state.c src/update.c src/ps.c \
+		src/checkpoint.c
 crun_LDADD = libcrun.la $(FOUND_LIBS)
 crun_LDFLAGS = $(CRUN_LDFLAGS)
 
 EXTRA_DIST = COPYING COPYING.libcrun README.md NEWS SECURITY.md rpm/crun.spec.in autogen.sh \
 	src/crun.h src/list.h src/run.h src/delete.h src/kill.h src/pause.h src/unpause.h \
 	src/create.h src/start.h src/state.h src/exec.h src/spec.h src/update.h src/ps.h \
+	src/checkpoint.h \
 	src/libcrun/container.h src/libcrun/seccomp.h src/libcrun/ebpf.h src/libcrun/cgroup.h \
-	src/libcrun/linux.h src/libcrun/utils.h src/libcrun/error.h \
+	src/libcrun/linux.h src/libcrun/utils.h src/libcrun/error.h src/libcrun/criu.h\
 	src/libcrun/status.h src/libcrun/terminal.h src/libcrun/sig2str.h \
 	src/libcrun/intprops.h crun.1.md
 

--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,17 @@ AS_IF([test "x$with_python_bindings" = "xyes"], [
             LDFLAGS+=" -fPIC "
 ])
 
+dnl criu
+AC_ARG_ENABLE([criu], AS_HELP_STRING([--disable-criu], [Disable CRIU based checkpoint/restore support]))
+AS_IF([test "x$enable_criu" != "xno"], [
+            PKG_CHECK_MODULES([CRIU], [criu >= 3.13], [have_criu="yes"], [have_criu="no"
+			       AC_MSG_RESULT([CRIU headers not found, building without CRIU support])])
+	    AS_IF([test "$have_criu" = "yes"], [
+		   AC_DEFINE([HAVE_CRIU], 1, [Define if CRIU is available])
+		   AC_SEARCH_LIBS(criu_init_opts, [criu])
+	    ])
+], [AC_MSG_RESULT([CRIU support disabled per user request])])
+
 FOUND_LIBS=$LIBS
 LIBS=""
 
@@ -104,6 +115,7 @@ AC_SUBST([RPM_VERSION])
 AC_SEARCH_LIBS([argp_parse], [argp], [], [AC_MSG_ERROR([*** argp functions not found - install libargp or argp_standalone])])
 
 AM_CONDITIONAL([PYTHON_BINDINGS], [test "x$with_python_bindings" = "xyes"])
+AM_CONDITIONAL([CRIU_SUPPORT], [test "x$have_criu" = "xyes"])
 
 AC_CONFIG_FILES([Makefile rpm/crun.spec])
 

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -1,0 +1,143 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2020 Adrian Reber <areber@redhat.com>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE
+
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <argp.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <regex.h>
+
+#include "crun.h"
+#include "libcrun/container.h"
+#include "libcrun/status.h"
+#include "libcrun/utils.h"
+#include "libcrun/sig2str.h"
+
+enum
+{
+  OPTION_IMAGE_PATH = 1000,
+  OPTION_WORK_PATH,
+  OPTION_LEAVE_RUNNING,
+  OPTION_TCP_ESTABLISHED,
+  OPTION_SHELL_JOB,
+  OPTION_EXT_UNIX_SK
+};
+
+static char doc[] = "OCI runtime";
+
+static libcrun_checkpoint_restore_t cr_options;
+
+static struct argp_option options[] = {
+  {"image-path", OPTION_IMAGE_PATH, "DIR", 0,
+   "path for saving criu image files", 0},
+  {"work-path", OPTION_WORK_PATH, "DIR", 0,
+   "path for saving work files and logs", 0},
+  {"leave-running", OPTION_LEAVE_RUNNING, 0, 0,
+   "leave the process running after checkpointing", 0},
+  {"tcp-established", OPTION_TCP_ESTABLISHED, 0, 0,
+   "allow open tcp connections", 0},
+  {"ext-unix-sk", OPTION_EXT_UNIX_SK, 0, 0, "allow external unix sockets", 0},
+  {"shell-job", OPTION_SHELL_JOB, 0, 0, "allow shell jobs", 0},
+  {0,}
+};
+
+static char args_doc[] = "checkpoint CONTAINER";
+
+static error_t
+parse_opt (int key, char *arg arg_unused, struct argp_state *state arg_unused)
+{
+  switch (key)
+    {
+    case ARGP_KEY_NO_ARGS:
+      libcrun_fail_with_error (0, "please specify a ID for the container");
+
+    case OPTION_IMAGE_PATH:
+      cr_options.image_path = argp_mandatory_argument (arg, state);
+      break;
+
+    case OPTION_WORK_PATH:
+      cr_options.work_path = argp_mandatory_argument (arg, state);
+      break;
+
+    case OPTION_LEAVE_RUNNING:
+      cr_options.leave_running = true;
+      break;
+
+    case OPTION_TCP_ESTABLISHED:
+      cr_options.tcp_established = true;
+      break;
+
+    case OPTION_EXT_UNIX_SK:
+      cr_options.ext_unix_sk = true;
+      break;
+
+    case OPTION_SHELL_JOB:
+      cr_options.shell_job = true;
+      break;
+
+    default:
+      return ARGP_ERR_UNKNOWN;
+    }
+
+  return 0;
+}
+
+static struct argp run_argp =
+  { options, parse_opt, args_doc, doc, NULL, NULL, NULL };
+
+int
+crun_command_checkpoint (struct crun_global_arguments *global_args, int argc,
+                         char **argv, libcrun_error_t *err)
+{
+  cleanup_free char *cr_path = NULL;
+  int first_arg;
+  int ret;
+
+  libcrun_context_t crun_context = { 0, };
+
+  argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &cr_options);
+  crun_assert_n_args (argc - first_arg, 1, 2);
+
+  ret =
+    init_libcrun_context (&crun_context, argv[first_arg], global_args, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  if (cr_options.image_path == NULL)
+    {
+      cleanup_free char *path = NULL;
+
+      path = get_current_dir_name ();
+      if (UNLIKELY (path == NULL))
+        libcrun_fail_with_error (0, "realloc failed");
+
+      ret = xasprintf (&cr_path, "%s/checkpoint", path);
+      if (UNLIKELY (ret == -1))
+        libcrun_fail_with_error (0, "xasprintf failed");
+
+      cr_options.image_path = cr_path;
+    }
+
+  return libcrun_container_checkpoint (&crun_context, argv[first_arg],
+                                       &cr_options, err);
+}

--- a/src/checkpoint.h
+++ b/src/checkpoint.h
@@ -1,0 +1,26 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2020 Adrian Reber <areber@redhat.com>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef CHECKPOINT_H
+#define CHECKPOINT_H
+
+#include "crun.h"
+
+int crun_command_checkpoint (struct crun_global_arguments *global_args,
+                             int argc, char **argv, libcrun_error_t * error);
+
+#endif

--- a/src/crun.c
+++ b/src/crun.c
@@ -39,6 +39,7 @@
 #include "pause.h"
 #include "unpause.h"
 #include "ps.h"
+#include "checkpoint.h"
 
 static struct crun_global_arguments arguments;
 
@@ -93,6 +94,7 @@ enum
     COMMAND_PAUSE,
     COMMAND_UNPAUSE,
     COMMAND_PS,
+    COMMAND_CHECKPOINT,
   };
 
 struct commands_s commands[] =
@@ -110,6 +112,10 @@ struct commands_s commands[] =
     { COMMAND_UPDATE, "update", crun_command_update},
     { COMMAND_PAUSE, "pause", crun_command_pause},
     { COMMAND_UNPAUSE, "resume", crun_command_unpause},
+    /* Not calling it yet 'checkpoint' as this might confuse tools
+     * testing for checkpoint support like Podman does.
+     * Once it is ready for Podman, this can be renamed to 'checkpoint' */
+    { COMMAND_CHECKPOINT, "_checkpoint", crun_command_checkpoint},
     { 0, }
   };
 

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -72,6 +72,17 @@ typedef struct libcrun_container_status_s libcrun_container_status_t;
 typedef struct libcrun_container_s libcrun_container_t;
 typedef struct libcrun_context_s libcrun_context_t;
 
+struct libcrun_checkpoint_restore_s
+{
+  char *image_path;
+  char *work_path;
+  bool leave_running;
+  bool tcp_established;
+  bool shell_job;
+  bool ext_unix_sk;
+};
+typedef struct libcrun_checkpoint_restore_s libcrun_checkpoint_restore_t;
+
 libcrun_container_t *libcrun_container_load_from_file (const char *path, libcrun_error_t *err);
 
 libcrun_container_t *libcrun_container_load_from_memory (const char *json, libcrun_error_t *err);
@@ -103,5 +114,7 @@ int libcrun_container_spec (bool root, FILE *out, libcrun_error_t *err);
 int libcrun_container_pause (libcrun_context_t *context, const char *id, libcrun_error_t *err);
 
 int libcrun_container_unpause (libcrun_context_t *context, const char *id, libcrun_error_t *err);
+
+int libcrun_container_checkpoint (libcrun_context_t *context, const char *id, libcrun_checkpoint_restore_t * cr_options, libcrun_error_t *err);
 
 #endif

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -1,0 +1,147 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2020 Adrian Reber <areber@redhat.com>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#define _GNU_SOURCE
+
+#include <config.h>
+
+#ifdef HAVE_CRIU
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <criu/criu.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "container.h"
+#include "status.h"
+#include "utils.h"
+
+#define CRIU_LOG_FILE "dump.log"
+
+int
+libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status,
+					 libcrun_container_t *container,
+					 libcrun_checkpoint_restore_t *
+					 cr_options, libcrun_error_t *err)
+{
+  runtime_spec_schema_config_schema *def = container->container_def;
+  cleanup_free char *path = NULL;
+  cleanup_close int image_fd = -1;
+  cleanup_close int work_fd = -1;
+  size_t i;
+  int ret;
+
+  if (geteuid ())
+    return crun_make_error (err, 0, "Checkpointing requires root");
+
+  /* No CRIU version or feature checking yet. In configure.ac there
+   * is a minimum CRIU version listed and so far it is good enough.
+   *
+   * The CRIU library also does not yet have an interface to CRIU
+   * the version of the binary. Right now it is only possible to
+   * query the version of the library via defines during buildtime.
+   *
+   * The whole CRIU library setup works this way, that the library
+   * is only a wrapper around RPC calls to the actual library. So
+   * if CRIU is updated and the SO of the library does not change,
+   * and crun is not rebuilt against the newer version, the version
+   * is still returning the values during buildtime and not from
+   * the actual running CRIU binary. The RPC interface between the
+   * library will not break, so no reason to worry, but it is not
+   * possible to detect (via the library) which CRIU version is
+   * actually being used. This needs to be added to CRIU upstream. */
+
+  ret = criu_init_opts ();
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, 0, "CRIU init failed with %d\n", ret);
+
+  if (UNLIKELY (cr_options->image_path == NULL))
+    return crun_make_error (err, 0, "image path not set\n");
+
+  ret = mkdir (cr_options->image_path, 0700);
+  if (UNLIKELY ((ret == -1) && (errno != EEXIST)))
+    return crun_make_error (err, 0,
+                            "error creating checkpoint directory %s\n",
+                            cr_options->image_path);
+
+  image_fd = open (cr_options->image_path, O_DIRECTORY);
+  if (UNLIKELY (image_fd == -1))
+    return crun_make_error (err, 0, "error opening checkpoint directory %s\n",
+                            cr_options->image_path);
+
+  criu_set_images_dir_fd (image_fd);
+
+  /* work_dir is the place CRIU will put its logfiles. If not explicitly set,
+   * CRIU will put the logfiles into the images_dir from above. No need for
+   * crun to set it if the user has not selected a specific directory. */
+  if (cr_options->work_path != NULL)
+    {
+      work_fd = open (cr_options->work_path, O_DIRECTORY);
+      if (UNLIKELY (work_fd == -1))
+        return crun_make_error (err, 0,
+                                "error opening CRIU work directory %s\n",
+                                cr_options->work_path);
+
+      criu_set_work_dir_fd (work_fd);
+    }
+  else
+    {
+      /* This is only for the error message later. */
+      cr_options->work_path = cr_options->image_path;
+    }
+
+  /* The main process of the container is the process CRIU will checkpoint
+   * and all of its children. */
+  criu_set_pid (status->pid);
+
+  ret = xasprintf (&path, "%s/%s", status->bundle, status->rootfs);
+  if (UNLIKELY (ret == -1))
+    libcrun_fail_with_error (0, "xasprintf failed");
+
+  ret = criu_set_root (path);
+  if (UNLIKELY (ret != 0))
+    return crun_make_error (err, 0, "error setting CRIU root to %s\n", path);
+
+  /* Tell CRIU about external bind mounts. */
+  for (i = 0; i < def->mounts_len; i++)
+    {
+      if (strcmp (def->mounts[i]->type, "bind") == 0)
+        criu_add_ext_mount (def->mounts[i]->destination,
+                            def->mounts[i]->destination);
+    }
+
+  /* Set boolean options . */
+  criu_set_leave_running (cr_options->leave_running);
+  criu_set_ext_unix_sk (cr_options->ext_unix_sk);
+  criu_set_shell_job (cr_options->shell_job);
+  criu_set_tcp_established (cr_options->tcp_established);
+
+  /* Set up logging. */
+  criu_set_log_level (4);
+  criu_set_log_file (CRIU_LOG_FILE);
+  ret = criu_dump ();
+  if (UNLIKELY (ret != 0))
+    return crun_make_error (err, 0,
+                            "CRIU checkpointing failed %d\n"
+                            "Please check CRIU logfile %s/%s\n", ret,
+                            cr_options->work_path, CRIU_LOG_FILE);
+
+  return 0;
+}
+
+#endif

--- a/src/libcrun/criu.h
+++ b/src/libcrun/criu.h
@@ -1,0 +1,47 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2020 Adrian Reber <areber@redhat.com>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CRIU_H
+#define CRIU_H
+
+#include <config.h>
+#include "container.h"
+#include "error.h"
+#include "utils.h"
+
+#ifdef HAVE_CRIU
+
+int libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status,
+                                             libcrun_container_t *container,
+                                             libcrun_checkpoint_restore_t *cr_options,
+                                             libcrun_error_t *err);
+
+#else
+
+static inline int
+libcrun_container_checkpoint_linux_criu (arg_unused libcrun_container_status_t *status,
+                                         arg_unused libcrun_container_t *container,
+                                         arg_unused libcrun_checkpoint_restore_t *cr_options,
+                                         libcrun_error_t *err)
+{
+  return crun_make_error (err, 0,
+                          "Compiled without CRIU support. Checkpointing not available.");
+}
+
+#endif
+#endif

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -39,6 +39,7 @@
 #include "terminal.h"
 #include "cgroup.h"
 #include "status.h"
+#include "criu.h"
 #include <sys/socket.h>
 #include <libgen.h>
 #include <sys/wait.h>
@@ -3112,4 +3113,14 @@ __attribute__((constructor)) static void libcrun_rexec(void)
       fprintf (stderr, "Failed to re-execute libcrun via memory file descriptor\n");
       _exit (EXIT_FAILURE);
     }
+}
+
+int
+libcrun_container_checkpoint_linux (libcrun_container_status_t *status,
+                                    libcrun_container_t *container,
+                                    libcrun_checkpoint_restore_t *cr_options,
+                                    libcrun_error_t *err)
+{
+  return libcrun_container_checkpoint_linux_criu (status, container,
+                                                  cr_options, err);
 }

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -59,4 +59,8 @@ int libcrun_container_enter_cgroup_ns (libcrun_container_t *container, libcrun_e
 int libcrun_set_personality (runtime_spec_schema_defs_linux_personality *p, libcrun_error_t *err);
 int libcrun_configure_network (libcrun_container_t *container, libcrun_error_t *err);
 
+int libcrun_container_checkpoint_linux (libcrun_container_status_t *status,
+                                        libcrun_container_t *container,
+                                        libcrun_checkpoint_restore_t *cr_options,
+                                        libcrun_error_t *err);
 #endif


### PR DESCRIPTION
See also #71 

As discussed in #71 this brings initial checkpoint support to crun. This does not yet support restoring of containers to be able to review code in smaller chunks.

The checkpoint sub-command is also called `_checkpoint` as Podman's checkpoint/restore support detection relies on `checkpoint` returning successfully. As long as not all feature necessary for Podman are implemented the `checkpoint` and `restore` command will not be available.

I will also add tests to this PR, but wanted to get it out for an initial review. Mainly to make sure I put the new code in the right places.

For testing I am currently running on Fedora 31 and running a RHEL 7 container on it:
```
# crun run -d rhel7-httpd &> /dev/null  < /dev/null
# crun list
NAME        PID       STATUS   BUNDLE PATH                            
rhel7-httpd 38124     running  /containers/rhel7-httpd           
# crun checkpoint rhel7-httpd
2020-02-14T17:09:24.000335932Z: unknown command checkpoint
# crun _checkpoint rhel7-httpd
# crun list
NAME        PID       STATUS   BUNDLE PATH                            
rhel7-httpd 0         stopped  /containers/rhel7-httpd
```
Right now it is not much more than a fancy stop command :wink: .

Without any additional parameter, CRIU will write the checkpoint in the current directory in a directory called `checkpoint` and in that directory there is a log file called `dump.log` with the result of the checkpointing.