### PR TITLE
cgroup: fix a few issues found while running CRI-O integration tests

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -170,9 +170,8 @@ enable_controllers (runtime_spec_schema_config_linux_resources *resources, const
 
       xasprintf (&cgroup_path, "/sys/fs/cgroup%s", tmp_path);
       ret = mkdir (cgroup_path, 0755);
-      if (ret < 0 && errno != EEXIST) {
+      if (ret < 0 && errno != EEXIST)
         return crun_make_error (err, errno, "create `%s`", cgroup_path);
-      }
 
       if (next_slash)
         {
@@ -1289,7 +1288,6 @@ libcrun_cgroup_destroy (const char *id, char *path, int systemd_cgroup, libcrun_
 {
   int ret;
   size_t i;
-  ssize_t path_len;
   int mode;
   const cgroups_subsystem_t *subsystems;
 
@@ -1320,45 +1318,27 @@ libcrun_cgroup_destroy (const char *id, char *path, int systemd_cgroup, libcrun_
   if (UNLIKELY (ret < 0))
     crun_error_release (err);
 
-  path_len = strlen (path);
-  while (1)
+  if (mode == CGROUP_MODE_UNIFIED)
     {
-      if (mode == CGROUP_MODE_UNIFIED)
+      cleanup_free char *cgroup_path = NULL;
+
+      xasprintf (&cgroup_path, "/sys/fs/cgroup/%s", path);
+      rmdir (cgroup_path);
+    }
+  else
+    {
+      for (i = 0; subsystems[i]; i++)
         {
           cleanup_free char *cgroup_path = NULL;
 
-          xasprintf (&cgroup_path, "/sys/fs/cgroup/%s", path);
-          if (rmdir (cgroup_path) < 0)
-            break;
+          if (mode == CGROUP_MODE_LEGACY && strcmp (subsystems[i], "unified") == 0)
+            continue;
+
+          xasprintf (&cgroup_path, "/sys/fs/cgroup/%s/%s", subsystems[i], path);
+
+          rmdir (cgroup_path);
         }
-      else
-        {
-          bool cleaned_any = false;
-
-          for (i = 0; subsystems[i]; i++)
-            {
-              cleanup_free char *cgroup_path = NULL;
-
-              if (mode == CGROUP_MODE_LEGACY && strcmp (subsystems[i], "unified") == 0)
-                continue;
-
-              xasprintf (&cgroup_path, "/sys/fs/cgroup/%s/%s", subsystems[i], path);
-
-              if (rmdir (cgroup_path) == 0)
-                cleaned_any = true;
-            }
-
-          if (!cleaned_any)
-            break;
-        }
-
-      if (path_len <= 1)
-       break;
-
-      for (; path_len > 1 && path[path_len] != '/'; path_len--);
-      if (path_len > 1)
-       path[path_len] = '\0';
-   }
+    }
 
   return 0;
 }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2917,6 +2917,12 @@ libcrun_join_process (libcrun_container_t *container, pid_t pid_to_join, libcrun
   for (i = 0; all_namespaces[i]; i++)
     close_and_reset (&fds[i]);
 
+  if (setsid () < 0)
+    {
+      crun_make_error (err, errno, "setsid");
+      goto exit;
+    }
+
   /* We need to fork once again to join the PID namespace.  */
   pid = fork ();
   if (UNLIKELY (pid < 0))


### PR DESCRIPTION
fix some issues found while running the CRI-O integration tests on cgroupv2 using the cgroupfs backend.

Test PR: https://github.com/cri-o/cri-o/pull/3292

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
