### PR TITLE
Minimal fixes for checkpointing

### DIFF
--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -31,7 +31,7 @@
 #include "status.h"
 #include "utils.h"
 
-#define CRIU_LOG_FILE "dump.log"
+#define CRIU_CHECKPOINT_LOG_FILE "dump.log"
 
 int
 libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status,
@@ -133,13 +133,13 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status,
 
   /* Set up logging. */
   criu_set_log_level (4);
-  criu_set_log_file (CRIU_LOG_FILE);
+  criu_set_log_file (CRIU_CHECKPOINT_LOG_FILE);
   ret = criu_dump ();
   if (UNLIKELY (ret != 0))
     return crun_make_error (err, 0,
                             "CRIU checkpointing failed %d\n"
                             "Please check CRIU logfile %s/%s\n", ret,
-                            cr_options->work_path, CRIU_LOG_FILE);
+                            cr_options->work_path, CRIU_CHECKPOINT_LOG_FILE);
 
   return 0;
 }

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -120,9 +120,18 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status,
   /* Tell CRIU about external bind mounts. */
   for (i = 0; i < def->mounts_len; i++)
     {
-      if (strcmp (def->mounts[i]->type, "bind") == 0)
-        criu_add_ext_mount (def->mounts[i]->destination,
-                            def->mounts[i]->destination);
+      size_t j;
+
+      for (j = 0; j < def->mounts[i]->options_len; j++)
+        {
+          if (strcmp (def->mounts[i]->options[j], "bind") == 0
+              || strcmp (def->mounts[i]->options[j], "rbind") == 0)
+            {
+              criu_add_ext_mount (def->mounts[i]->destination,
+                                  def->mounts[i]->destination);
+              break;
+            }
+        }
     }
 
   /* Set boolean options . */

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -35,9 +35,9 @@
 
 int
 libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status,
-					 libcrun_container_t *container,
-					 libcrun_checkpoint_restore_t *
-					 cr_options, libcrun_error_t *err)
+                                         libcrun_container_t *container,
+                                         libcrun_checkpoint_restore_t *
+                                         cr_options, libcrun_error_t *err)
 {
   runtime_spec_schema_config_schema *def = container->container_def;
   cleanup_free char *path = NULL;


### PR DESCRIPTION
As mentioned in the #269 this contains a small fix for bind mount detection as well as some tab-spaces replacement for indentation and rename of a define for the upcoming container restore support.