### PR TITLE
Minimal container restore implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,8 @@ before_install:
 - if test $TEST = alpine-build; then sudo docker build -t crun-alpine-build tests/alpine-build; fi
 - git clone --depth=1 git://github.com/lloyd/yajl
 - "(cd yajl && ./configure -p /usr && make && sudo make install)"
+# CRIU supports armhfp, aarch64, ppc64le, s390x and x86_64. The PPA has only packages for x86_64
+- if test $TRAVIS_CPU_ARCH = amd64; then sudo add-apt-repository -y ppa:criu/ppa; sudo apt-get -q update; sudo apt-get -y install criu; fi
 script:
 - if test $TEST = make-arm64 || test $TEST = make-amd64 || test $TEST = make-ppc64le || test $TEST = make-s390x; then ./autogen.sh && ./configure CFLAGS='-Wall -Werror' && make -j $(nproc) && make syntax-check; fi
 - if test $TEST = make-amd64-nosystemd; then ./autogen.sh && ./configure --disable-systemd CFLAGS='-Wall -Werror' && make -j $(nproc) && make syntax-check; fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,14 +50,14 @@ endif
 crun_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src
 crun_SOURCES = src/crun.c src/run.c src/delete.c src/kill.c src/pause.c src/unpause.c src/spec.c \
 		src/exec.c src/list.c src/create.c src/start.c src/state.c src/update.c src/ps.c \
-		src/checkpoint.c
+		src/checkpoint.c src/restore.c
 crun_LDADD = libcrun.la $(FOUND_LIBS)
 crun_LDFLAGS = $(CRUN_LDFLAGS)
 
 EXTRA_DIST = COPYING COPYING.libcrun README.md NEWS SECURITY.md rpm/crun.spec.in autogen.sh \
 	src/crun.h src/list.h src/run.h src/delete.h src/kill.h src/pause.h src/unpause.h \
 	src/create.h src/start.h src/state.h src/exec.h src/spec.h src/update.h src/ps.h \
-	src/checkpoint.h \
+	src/checkpoint.h src/restore.h \
 	src/libcrun/container.h src/libcrun/seccomp.h src/libcrun/ebpf.h src/libcrun/cgroup.h \
 	src/libcrun/linux.h src/libcrun/utils.h src/libcrun/error.h src/libcrun/criu.h\
 	src/libcrun/status.h src/libcrun/terminal.h src/libcrun/sig2str.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -89,6 +89,7 @@ LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/build-aux/tap-driver
 
 TESTS = tests/test_capabilities.py \
 	tests/test_cwd.py \
+	tests/test_checkpoint_restore.py \
 	tests/test_devices.py \
 	tests/test_hostname.py \
 	tests/test_limits.py \

--- a/src/crun.c
+++ b/src/crun.c
@@ -40,6 +40,7 @@
 #include "unpause.h"
 #include "ps.h"
 #include "checkpoint.h"
+#include "restore.h"
 
 static struct crun_global_arguments arguments;
 
@@ -95,6 +96,7 @@ enum
     COMMAND_UNPAUSE,
     COMMAND_PS,
     COMMAND_CHECKPOINT,
+    COMMAND_RESTORE,
   };
 
 struct commands_s commands[] =
@@ -116,6 +118,7 @@ struct commands_s commands[] =
      * testing for checkpoint support like Podman does.
      * Once it is ready for Podman, this can be renamed to 'checkpoint' */
     { COMMAND_CHECKPOINT, "_checkpoint", crun_command_checkpoint},
+    { COMMAND_RESTORE, "_restore", crun_command_restore},
     { 0, }
   };
 

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -80,6 +80,7 @@ struct libcrun_checkpoint_restore_s
   bool tcp_established;
   bool shell_job;
   bool ext_unix_sk;
+  bool detach;
 };
 typedef struct libcrun_checkpoint_restore_s libcrun_checkpoint_restore_t;
 
@@ -116,5 +117,7 @@ int libcrun_container_pause (libcrun_context_t *context, const char *id, libcrun
 int libcrun_container_unpause (libcrun_context_t *context, const char *id, libcrun_error_t *err);
 
 int libcrun_container_checkpoint (libcrun_context_t *context, const char *id, libcrun_checkpoint_restore_t * cr_options, libcrun_error_t *err);
+
+int libcrun_container_restore (libcrun_context_t *context, const char *id, libcrun_checkpoint_restore_t * cr_options, libcrun_error_t *err);
 
 #endif

--- a/src/libcrun/criu.h
+++ b/src/libcrun/criu.h
@@ -31,6 +31,11 @@ int libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status,
                                              libcrun_checkpoint_restore_t *cr_options,
                                              libcrun_error_t *err);
 
+int libcrun_container_restore_linux_criu (libcrun_container_status_t *status,
+                                          libcrun_container_t *container,
+                                          libcrun_checkpoint_restore_t *cr_options,
+                                          libcrun_error_t *err);
+
 #else
 
 static inline int
@@ -41,6 +46,16 @@ libcrun_container_checkpoint_linux_criu (arg_unused libcrun_container_status_t *
 {
   return crun_make_error (err, 0,
                           "Compiled without CRIU support. Checkpointing not available.");
+}
+
+static inline int
+libcrun_container_restore_linux_criu (arg_unused libcrun_container_status_t *status,
+                                      arg_unused libcrun_container_t *container,
+                                      arg_unused libcrun_checkpoint_restore_t *cr_options,
+                                      libcrun_error_t *err)
+{
+  return crun_make_error (err, 0,
+                          "Compiled without CRIU support. Restore not available.");
 }
 
 #endif

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3149,3 +3149,13 @@ libcrun_container_checkpoint_linux (libcrun_container_status_t *status,
   return libcrun_container_checkpoint_linux_criu (status, container,
                                                   cr_options, err);
 }
+
+int
+libcrun_container_restore_linux (libcrun_container_status_t *status,
+                                 libcrun_container_t *container,
+                                 libcrun_checkpoint_restore_t *cr_options,
+                                 libcrun_error_t *err)
+{
+  return libcrun_container_restore_linux_criu (status, container,
+                                               cr_options, err);
+}

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -63,4 +63,9 @@ int libcrun_container_checkpoint_linux (libcrun_container_status_t *status,
                                         libcrun_container_t *container,
                                         libcrun_checkpoint_restore_t *cr_options,
                                         libcrun_error_t *err);
+
+int libcrun_container_restore_linux (libcrun_container_status_t *status,
+                                     libcrun_container_t *container,
+                                     libcrun_checkpoint_restore_t *cr_options,
+                                     libcrun_error_t *err);
 #endif

--- a/src/restore.c
+++ b/src/restore.c
@@ -1,0 +1,141 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2020 Adrian Reber <areber@redhat.com>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE
+
+#include <config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <argp.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <regex.h>
+
+#include "crun.h"
+#include "libcrun/container.h"
+#include "libcrun/status.h"
+#include "libcrun/utils.h"
+#include "libcrun/sig2str.h"
+
+enum
+{
+  OPTION_IMAGE_PATH = 1000,
+  OPTION_WORK_PATH,
+  OPTION_TCP_ESTABLISHED,
+  OPTION_SHELL_JOB,
+  OPTION_EXT_UNIX_SK
+};
+
+static char doc[] = "OCI runtime";
+
+static libcrun_checkpoint_restore_t cr_options;
+
+static struct argp_option options[] = {
+  {"image-path", OPTION_IMAGE_PATH, "DIR", 0,
+   "path for saving criu image files", 0},
+  {"work-path", OPTION_WORK_PATH, "DIR", 0,
+   "path for saving work files and logs", 0},
+  {"tcp-established", OPTION_TCP_ESTABLISHED, 0, 0,
+   "allow open tcp connections", 0},
+  {"ext-unix-sk", OPTION_EXT_UNIX_SK, 0, 0, "allow external unix sockets", 0},
+  {"shell-job", OPTION_SHELL_JOB, 0, 0, "allow shell jobs", 0},
+  {"detach", 'd', 0, 0, "detach from the container's process", 0},
+  {0,}
+};
+
+static char args_doc[] = "restore CONTAINER";
+
+static error_t
+parse_opt (int key, char *arg arg_unused, struct argp_state *state arg_unused)
+{
+  switch (key)
+    {
+    case ARGP_KEY_NO_ARGS:
+      libcrun_fail_with_error (0, "please specify a ID for the container");
+
+    case OPTION_IMAGE_PATH:
+      cr_options.image_path = argp_mandatory_argument (arg, state);
+      break;
+
+    case OPTION_WORK_PATH:
+      cr_options.work_path = argp_mandatory_argument (arg, state);
+      break;
+
+    case OPTION_TCP_ESTABLISHED:
+      cr_options.tcp_established = true;
+      break;
+
+    case OPTION_EXT_UNIX_SK:
+      cr_options.ext_unix_sk = true;
+      break;
+
+    case OPTION_SHELL_JOB:
+      cr_options.shell_job = true;
+      break;
+
+    case 'd':
+      cr_options.detach = true;
+      break;
+
+    default:
+      return ARGP_ERR_UNKNOWN;
+    }
+
+  return 0;
+}
+
+static struct argp run_argp =
+  { options, parse_opt, args_doc, doc, NULL, NULL, NULL };
+
+int
+crun_command_restore (struct crun_global_arguments *global_args, int argc,
+                      char **argv, libcrun_error_t *err)
+{
+  cleanup_free char *cr_path = NULL;
+  int first_arg;
+  int ret;
+
+  libcrun_context_t crun_context = { 0, };
+
+  argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &cr_options);
+  crun_assert_n_args (argc - first_arg, 1, 2);
+
+  ret =
+    init_libcrun_context (&crun_context, argv[first_arg], global_args, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  if (cr_options.image_path == NULL)
+    {
+      cleanup_free char *path = NULL;
+
+      path = get_current_dir_name ();
+      if (UNLIKELY (path == NULL))
+        libcrun_fail_with_error (0, "realloc failed");
+
+      ret = xasprintf (&cr_path, "%s/checkpoint", path);
+      if (UNLIKELY (ret == -1))
+        libcrun_fail_with_error (0, "xasprintf failed");
+
+      cr_options.image_path = cr_path;
+    }
+
+  return libcrun_container_restore (&crun_context, argv[first_arg],
+                                    &cr_options, err);
+}

--- a/src/restore.h
+++ b/src/restore.h
@@ -1,0 +1,26 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2020 Adrian Reber <areber@redhat.com>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef RESTORE_H
+#define RESTORE_H
+
+#include "crun.h"
+
+int crun_command_restore (struct crun_global_arguments *global_args,
+                          int argc, char **argv, libcrun_error_t * error);
+
+#endif

--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -1,0 +1,90 @@
+#!/bin/env $PYTHON
+# crun - OCI runtime written in C
+#
+# Copyright (C) 2020 Adrian Reber <areber@redhat.com>
+# crun is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# crun is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with crun.  If not, see <http://www.gnu.org/licenses/>.
+
+import time
+import json
+import subprocess
+import os
+import shutil
+import sys
+from tests_utils import *
+
+def test_cr1():
+    if os.getuid() != 0:
+        return 77
+    if 'CRIU' not in get_crun_feature_string():
+        return 77
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'pause']
+    add_all_namespaces(conf)
+    # User namespace support not working yet for checkpoint/restore
+    conf['linux']['namespaces'].remove({'type':'user'})
+    for i in conf['mounts']:
+        # Also remove the cgroup mount as CRIU cgroup2 support
+        # has not been yet merged upstream
+        if i['type'] == 'cgroup':
+            conf['mounts'].remove(i)
+    cid = None
+    cr_dir = os.path.join(get_tests_root(), 'checkpoint')
+    try:
+        proc, cid = run_and_get_output(conf, all_dev_null=True, use_popen=True, detach=True)
+        for i in range(50):
+            try:
+                s = json.loads(run_crun_command(["state", cid]))
+                break
+            except Exception as e:
+                time.sleep(0.1)
+
+
+        if s['status'] != "running":
+            return -1
+        if s['id'] != cid:
+            return -1
+        cmdline_fd = open("/proc/%s/cmdline" % s['pid'], 'r')
+        first_cmdline = cmdline_fd.read()
+        cmdline_fd.close()
+
+        run_crun_command(["_checkpoint", "--image-path=%s" % cr_dir, cid])
+        s = json.loads(run_crun_command(["state", cid]))
+        if s['status'] != "stopped":
+            return -1
+
+        run_crun_command(["_restore", "-d", "--image-path=%s" % cr_dir, cid])
+
+        s = json.loads(run_crun_command(["state", cid]))
+        if s['status'] != "running":
+            return -1
+        if s['id'] != cid:
+            return -1
+        cmdline_fd = open("/proc/%s/cmdline" % s['pid'], 'r')
+        second_cmdline = cmdline_fd.read()
+        cmdline_fd.close()
+        if first_cmdline != second_cmdline:
+            return -1
+
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+
+    return 0
+
+all_tests = {
+    "checkpoint restore" : test_cr1,
+}
+
+if __name__ == "__main__":
+    tests_main(all_tests)


### PR DESCRIPTION
This is a minimal implementation of container restore. The biggest missing pieces are user namespace support and input/output handling. Besides many other missing things it does work for simple test containers as it can be seen in the included simple test for checkpoint/restore.

The test is skipped if the crun binary has not been built with CRIU support.