### PR TITLE
Revert "systemd: set collectmode=inactive-or-failed"

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -977,13 +977,6 @@ int enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *reso
         }
     }
 
-  sd_err = sd_bus_message_append (m, "(sv)", "CollectMode", "s", "inactive-or-failed");
-  if (UNLIKELY (sd_err < 0))
-    {
-      ret = crun_make_error (err, -sd_err, "sd-bus message append CollectMode");
-      goto exit;
-    }
-
   sd_err = sd_bus_message_append (m, "(sv)", "Description", "s", "libcrun container");
   if (UNLIKELY (sd_err < 0))
     {


### PR DESCRIPTION
it can be configured via an annotation.

This reverts commit a5841de12b449d8441948cbf9af8133cac5287ee.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>