### PR TITLE
linux: add function libcrun_set_sysctl_from_schema

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2315,9 +2315,8 @@ libcrun_set_oom (libcrun_container_t *container, libcrun_error_t *err)
 }
 
 int
-libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err)
+libcrun_set_sysctl_from_schema (runtime_spec_schema_config_schema *def, libcrun_error_t *err)
 {
-  runtime_spec_schema_config_schema *def = container->container_def;
   size_t i;
   cleanup_close int dirfd = -1;
 
@@ -2347,6 +2346,12 @@ libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err)
         return crun_make_error (err, errno, "write to /proc/sys/%s", name);
     }
   return 0;
+}
+
+int
+libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err)
+{
+  return libcrun_set_sysctl_from_schema (container->container_def, err);
 }
 
 static int

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -48,6 +48,7 @@ int libcrun_set_selinux_exec_label (runtime_spec_schema_config_schema_process *p
 int libcrun_set_apparmor_profile (runtime_spec_schema_config_schema_process *proc, libcrun_error_t *err);
 int libcrun_set_hostname (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_oom (libcrun_container_t *container, libcrun_error_t *err);
+int libcrun_set_sysctl_from_schema (runtime_spec_schema_config_schema *def, libcrun_error_t *err);
 int libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_terminal (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_join_process (libcrun_container_t *container, pid_t pid_to_join, libcrun_container_status_t *status, int detach, int *terminal_fd, libcrun_error_t *err);


### PR DESCRIPTION
allow to set sysctl directly from the OCI runtime configuration.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>