### PR TITLE
utils: fix mount on not writeable path

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -441,15 +441,18 @@ crun_safe_ensure_at (bool dir, int dirfd, const char *dirpath, size_t dirpath_le
         {
           ret = openat (cwd, cur, O_CLOEXEC | O_CREAT | O_WRONLY, 0700);
           if (UNLIKELY (ret < 0))
-            return crun_make_error (err, errno, "create `%s`", path);
+            {
+              int saved_errno = errno;
+
+              /* If the previous openat fails, attempt to open the file in O_PATH mode.  */
+              ret = openat (cwd, cur, O_CLOEXEC | O_PATH);
+              if (ret < 0)
+                return crun_make_error (err, saved_errno, "create `%s`", path);
+            }
 
           close_and_replace (&wd_cleanup, ret);
 
-          ret = check_fd_under_path (dirpath, dirpath_len, ret, path, err);
-          if (UNLIKELY (ret < 0))
-            return ret;
-
-          return 0;
+          return check_fd_under_path (dirpath, dirpath_len, ret, path, err);
         }
 
       if (ret < 0)


### PR DESCRIPTION
Fix checking if a file is under the rootfs and allow to bind mount on
not writeable paths.  If the open(O_CREAT) fails, then attempt to open
the file in O_PATH mode.

commit 8e580bcb332a3dea7ef910ee297d1f595540b869 introduced the
regression.

Closes: https://github.com/containers/crun/issues/290

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>