### PR TITLE
cgroup: use the memory controller to ready PIDs

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -1404,7 +1404,7 @@ libcrun_cgroup_read_pids (const char *path, bool recurse, pid_t **pids, libcrun_
 
     case CGROUP_MODE_HYBRID:
     case CGROUP_MODE_LEGACY:
-      xasprintf (&cgroup_path, "/sys/fs/cgroup/pids/%s", path);
+      xasprintf (&cgroup_path, "/sys/fs/cgroup/memory/%s", path);
       break;
 
     default:


### PR DESCRIPTION
the pid controller is not available on kernels older than 4.3.

Closes: https://github.com/containers/crun/issues/294

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>