### PR TITLE
state: report state 'paused'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ addons:
     - wget
     - go-md2man
     - libsystemd-dev
+    - gperf
 before_install:
 - git submodule update --init --recursive
 - if test $TEST = podman; then sudo docker build -t crun-podman tests/podman; fi

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -46,6 +46,7 @@ int libcrun_move_process_to_cgroup (pid_t pid, char *path, libcrun_error_t *err)
 int libcrun_update_cgroup_resources (int cgroup_mode, runtime_spec_schema_config_linux_resources *resources,
                                      char *path, libcrun_error_t *err);
 int libcrun_cgroups_create_symlinks (const char *target, libcrun_error_t *err);
+int libcrun_cgroup_is_container_paused (const char *cgroup_path, int cgroup_mode, bool *paused, libcrun_error_t *err);
 int libcrun_cgroup_pause_unpause (const char *path, const bool pause, libcrun_error_t *err);
 int libcrun_cgroup_read_pids (const char *path, bool recurse, pid_t **pids, libcrun_error_t *err);
 


### PR DESCRIPTION
it is not part of the OCI specs but it is what users of runc expect,
so add a "paused" state that is used when the container cgroup is
freezed.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>