### PR TITLE
Allow deletion of containers in 'created' state

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -961,7 +961,13 @@ container_delete_internal (libcrun_context_t *context, runtime_spec_schema_confi
           if (UNLIKELY (ret < 0))
             return ret;
           if (ret == 1)
-            return crun_make_error (err, 0, "the container `%s` is not in 'stopped' state", id);
+            {
+              ret = libcrun_status_has_read_exec_fifo (state_root, id, err);
+              if (UNLIKELY (ret < 0))
+                return ret;
+              if (! ret)
+                return crun_make_error (err, 0, "the container `%s` is not in 'stopped' state", id);
+            }
         }
       else
         {


### PR DESCRIPTION
When a container is created, but not started, its state is not `stopped`. This PR enables the deletion of such containers.
```
# crun create test
# crun delete test
2020-03-06T00:06:45.000022324Z: the container `test` is not in 'stopped' state
```
```
# runc create test
# runc delete test
```

In addition, the process start time is included in the status information for more accurate identification containers on the system.