### PR TITLE
status: Use process start time for identification

### DIFF
--- a/cfg.mk
+++ b/cfg.mk
@@ -13,7 +13,8 @@ local-checks-to-skip = \
     sc_prohibit_always_true_header_tests \
     sc_prohibit_intprops_without_use \
     sc_error_message_uppercase \
-    sc_GPL_version
+    sc_GPL_version \
+    sc_prohibit_atoi_atof
 
 
 #SHELL=bash -x

--- a/src/libcrun/status.h
+++ b/src/libcrun/status.h
@@ -34,6 +34,7 @@ typedef struct libcrun_container_list_s libcrun_container_list_t;
 struct libcrun_container_status_s
 {
   pid_t pid;
+  unsigned long long process_start_time;
   char *bundle;
   char *rootfs;
   char *cgroup_path;


### PR DESCRIPTION
In this PR is introduced a `process-start-time` status value for containers. This value, in addition to the PID value, is used to identify a container process.

This is analogous to the `init_process_start` state parameter used by runc.