### PR TITLE
cgroup: create container under subcgroup

### DIFF
--- a/crun.1.md
+++ b/crun.1.md
@@ -311,6 +311,26 @@ list of additional groups if none is specified.
 Specify the offset to be written to /proc/self/timens_offsets when creating
 a time namespace.
 
+## `run.oci.systemd.subgroup=SUBGROUP`
+
+Override the name for the systemd sub cgroup created under the systemd
+scope, so the final cgroup will be like:
+
+```
+/sys/fs/cgroup/$PATH/$SUBGROUP
+```
+
+When it is set to the empty string, a sub cgroup is not created.
+
+If not specified, it defaults to `container` on cgroup v2, and to `""`
+on cgroup v1.
+
+e.g.
+
+```
+/sys/fs/cgroup//system.slice/foo-352700.scope/container
+```
+
 ## tmpcopyup mount options
 
 If the `tmpcopyup` option is specified for a tmpfs, then the path that

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -904,7 +904,7 @@ int enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *reso
     }
 
   if (slice == NULL || slice[0] == '\0')
-      xasprintf (&scope, "%s-%d.scope", id, getpid ());
+      xasprintf (&scope, "crun-%s.scope", id);
   else
     {
       char *n = strchr (slice, ':');

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -896,7 +896,7 @@ int enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *reso
     }
   boolean_opts[i++] = NULL;
 
-  sd_err = sd_bus_default (&bus);
+  sd_err = sd_bus_default_user (&bus);
   if (sd_err < 0)
     {
       sd_err = sd_bus_default_system (&bus);

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -41,6 +41,7 @@ struct libcrun_cgroup_args
   json_map_string_string *annotations;
   int cgroup_mode;
   char **path;
+  char **scope;
   const char *cgroup_path;
   int manager;
   pid_t pid;

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -48,6 +48,7 @@ struct libcrun_cgroup_args
   uid_t root_uid;
   gid_t root_gid;
   const char *id;
+  const char *systemd_subgroup;
 };
 
 int libcrun_get_cgroup_mode (libcrun_error_t *err);

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -35,10 +35,22 @@ enum
    CGROUP_MANAGER_DISABLED
   };
 
+struct libcrun_cgroup_args
+{
+  runtime_spec_schema_config_linux_resources *resources;
+  json_map_string_string *annotations;
+  int cgroup_mode;
+  char **path;
+  const char *cgroup_path;
+  int manager;
+  pid_t pid;
+  uid_t root_uid;
+  gid_t root_gid;
+  const char *id;
+};
+
 int libcrun_get_cgroup_mode (libcrun_error_t *err);
-int libcrun_cgroup_enter (runtime_spec_schema_config_linux_resources *resources, json_map_string_string *annotations,
-                          int cgroup_mode, char **path, const char *cgroup_path, int manager, pid_t pid, uid_t root_uid,
-                          gid_t root_gid, const char *id, libcrun_error_t *err);
+int libcrun_cgroup_enter (struct libcrun_cgroup_args *args, libcrun_error_t *err);
 int libcrun_cgroup_killall_signal (char *path, int signal, libcrun_error_t *err);
 int libcrun_cgroup_killall (char *path, libcrun_error_t *err);
 int libcrun_cgroup_destroy (const char *id, char *path, int manager, libcrun_error_t *err);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2701,7 +2701,7 @@ libcrun_run_linux_container (libcrun_container_t *container,
     {
       /* A PID and a time namespace is joined when a new process is created.  */
       pid_container = fork ();
-      if (UNLIKELY (ret < 0))
+      if (UNLIKELY (pid_container < 0))
         {
           crun_make_error (err, errno, "cannot fork");
           goto out;

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -146,10 +146,11 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   if (UNLIKELY (fd_write < 0))
     return crun_make_error (err, 0, "cannot open status file");
 
-  len = xasprintf (&data, "{\n    \"pid\" : %d,\n    \"process-start-time\" : %lld,\n    \"cgroup-path\" : \"%s\",\n    \"rootfs\" : \"%s\",\n    \"systemd-cgroup\" : %s,\n    \"bundle\" : \"%s\",\n    \"created\" : \"%s\",\n    \"detached\" : %s\n}\n",
+  len = xasprintf (&data, "{\n    \"pid\" : %d,\n    \"process-start-time\" : %lld,\n    \"cgroup-path\" : \"%s\",\n    \"scope\" : \"%s\",\n    \"rootfs\" : \"%s\",\n    \"systemd-cgroup\" : %s,\n    \"bundle\" : \"%s\",\n    \"created\" : \"%s\",\n    \"detached\" : %s\n}\n",
                    status->pid,
                    status->process_start_time,
                    status->cgroup_path ? status->cgroup_path : "",
+                   status->scope ? status->scope : "",
                    status->rootfs,
                    status->systemd_cgroup ? "true" : "false",
                    status->bundle,
@@ -204,6 +205,11 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
     if (UNLIKELY (tmp == NULL))
       return crun_make_error (err, 0, "'cgroup-path' missing in %s", file);
     status->cgroup_path = xstrdup (YAJL_GET_STRING (tmp));
+  }
+  {
+    const char *scope[] = { "scope", NULL };
+    tmp = yajl_tree_get (tree, scope, yajl_t_string);
+    status->scope = tmp ? xstrdup (YAJL_GET_STRING (tmp)) : NULL;
   }
   {
     const char *rootfs[] = { "rootfs", NULL };

--- a/src/libcrun/status.h
+++ b/src/libcrun/status.h
@@ -38,6 +38,7 @@ struct libcrun_container_status_s
   char *bundle;
   char *rootfs;
   char *cgroup_path;
+  char *scope;
   int systemd_cgroup;
   char *created;
   int detached;


### PR DESCRIPTION
systemd delegation works only for sub groups, so make sure the container is created in a sub group where we have full control without stepping on systemd management.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

