### PR TITLE
contrib, static-builder: install gperf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -117,7 +117,7 @@ git-version.h:
 	fi
 
 src/libcrun/signals.c: src/libcrun/signals.perf
-	${GPERF} -m 100 --null-strings --pic -tCEG -S1 $< > $@
+	${GPERF} --lookup-function-name libcrun_signal_in_word_set -m 100 --null-strings --pic -tCEG -S1 $< > $@
 
 dist-hook:
 	$(AM_V_GEN)echo $(VERSION) > $(distdir)/.tarball-version

--- a/contrib/static-builder-x86_64/Dockerfile
+++ b/contrib/static-builder-x86_64/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora AS base
 RUN dnf install -y git dnf-utils gcc meson ninja-build libcap-static \
     make python git gcc automake autoconf libcap-devel systemd-devel yajl-devel libseccomp-devel cmake \
-    go-md2man glibc-static python3-libmount libtool diffutils
+    go-md2man glibc-static python3-libmount libtool diffutils gperf
 
 FROM base AS systemd
 RUN mkdir /out && yum-builddep -y systemd && git clone --depth 1 https://github.com/systemd/systemd.git \

--- a/src/libcrun/signals.c
+++ b/src/libcrun/signals.c
@@ -1,5 +1,5 @@
 /* ANSI-C code produced by gperf version 3.1 */
-/* Command-line: gperf -m 100 --null-strings --pic -tCEG -S1 src/libcrun/signals.perf  */
+/* Command-line: gperf --lookup-function-name libcrun_signal_in_word_set -m 100 --null-strings --pic -tCEG -S1 src/libcrun/signals.perf  */
 /* Computed positions: -k'2,4,$' */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
@@ -369,7 +369,7 @@ static const struct signal_s wordlist[] =
   };
 
 const struct signal_s *
-in_word_set (register const char *str, register size_t len)
+libcrun_signal_in_word_set (register const char *str, register size_t len)
 {
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
@@ -590,7 +590,7 @@ str2sig (const char *name)
   if (has_prefix (name, "SIG"))
     name += 3;
 
-  s = in_word_set (name, strlen (name));
+  s = libcrun_signal_in_word_set (name, strlen (name));
   if (s == NULL)
     {
       long int value;

--- a/src/libcrun/signals.perf
+++ b/src/libcrun/signals.perf
@@ -101,7 +101,7 @@ str2sig (const char *name)
   if (has_prefix (name, "SIG"))
     name += 3;
 
-  s = in_word_set (name, strlen (name));
+  s = libcrun_signal_in_word_set (name, strlen (name));
   if (s == NULL)
     {
       long int value;


### PR DESCRIPTION
upstream version of libsseccomp needs gperf as dependency.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>