### PR TITLE
crun: allow to override config file name

### DIFF
--- a/crun.1.md
+++ b/crun.1.md
@@ -124,6 +124,9 @@ crun [global options] create [options] CONTAINER
 **--bundle**=**BUNDLE**
 Path to the OCI bundle, by default it is the current directory.
 
+**--config**=**FILE**
+Override the configuration file to use.  The default value is **config.json**.
+
 **--console-socket**=**SOCKET**
 Path to a UNIX socket that will receive the master end of the tty for
 the container.
@@ -143,6 +146,9 @@ crun [global options] run [options] CONTAINER
 
 **--bundle**=**BUNDLE**
 Path to the OCI bundle, by default it is the current directory.
+
+**--config**=**FILE**
+Override the configuration file to use.  The default value is **config.json**.
 
 **--console-socket**=**SOCKET**
 Path to a UNIX socket that will receive the master end of the tty for

--- a/src/create.c
+++ b/src/create.c
@@ -1,7 +1,7 @@
 /*
  * crun - OCI runtime written in C
  *
- * Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * Copyright (C) 2017, 2018, 2019, 2020 Giuseppe Scrivano <giuseppe@scrivano.org>
  * crun is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -45,6 +45,7 @@ static libcrun_context_t crun_context;
 static struct argp_option options[] =
   {
    {"bundle", 'b', 0, 0, "container bundle (default \".\")", 0},
+   {"config", 'f', "FILE", 0, "override the config file name", 0},
    {"console-socket", OPTION_CONSOLE_SOCKET, "SOCK", 0, "path to a socket that will receive the master end of the tty", 0},
    {"preserve-fds", OPTION_PRESERVE_FDS, 0, 0, "pass additional FDs to the container", 0},
    {"no-pivot", OPTION_NO_PIVOT, 0, 0, "do not use pivot_root", 0},
@@ -58,6 +59,8 @@ static char doc[] = "OCI runtime";
 
 static char args_doc[] = "create [OPTION]... CONTAINER";
 
+static const char *config_file = "config.json";
+
 static error_t
 parse_opt (int key, char *arg, struct argp_state *state)
 {
@@ -65,6 +68,10 @@ parse_opt (int key, char *arg, struct argp_state *state)
     {
     case 'b':
       bundle = crun_context.bundle = argp_mandatory_argument (arg, state);
+      break;
+
+    case 'f':
+      config_file = argp_mandatory_argument (arg, state);
       break;
 
     case OPTION_CONSOLE_SOCKET:
@@ -134,7 +141,7 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
   if (UNLIKELY (ret < 0))
     return ret;
 
-  container = libcrun_container_load_from_file ("config.json", err);
+  container = libcrun_container_load_from_file (config_file, err);
   if (container == NULL)
     libcrun_fail_with_error (0, "error loading config.json");
 

--- a/src/run.c
+++ b/src/run.c
@@ -1,7 +1,7 @@
 /*
  * crun - OCI runtime written in C
  *
- * Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * Copyright (C) 2017, 2018, 2019, 2020 Giuseppe Scrivano <giuseppe@scrivano.org>
  * crun is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -47,6 +47,7 @@ static libcrun_context_t crun_context;
 static struct argp_option options[] =
   {
    {"bundle", 'b', 0, 0, "container bundle (default \".\")", 0},
+   {"config", 'f', "FILE", 0, "override the config file name", 0},
    {"detach", 'd', 0, 0, "detach from the parent", 0},
    {"console-socket", OPTION_CONSOLE_SOCKET, "SOCKET", 0, "path to a socket that will receive the master end of the tty", 0},
    {"preserve-fds", OPTION_PRESERVE_FDS, 0, 0, "pass additional FDs to the container", 0},
@@ -59,6 +60,8 @@ static struct argp_option options[] =
 
 static char args_doc[] = "run [OPTION]... CONTAINER";
 
+static const char *config_file = "config.json";
+
 static error_t
 parse_opt (int key, char *arg, struct argp_state *state)
 {
@@ -66,6 +69,10 @@ parse_opt (int key, char *arg, struct argp_state *state)
     {
     case 'd':
       crun_context.detach = true;
+      break;
+
+    case 'f':
+      config_file = argp_mandatory_argument (arg, state);
       break;
 
     case 'b':
@@ -135,7 +142,7 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
         libcrun_fail_with_error (errno, "chdir `%s` failed", bundle);
     }
 
-  container = libcrun_container_load_from_file ("config.json", err);
+  container = libcrun_container_load_from_file (config_file, err);
   if (container == NULL)
     return -1;
 


### PR DESCRIPTION
add a new option to create/run to override the default config.json
value.

Closes: https://github.com/containers/crun/issues/308

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>