### PR TITLE
libcrun: audit errno in crun_make_error calls

### DIFF
--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -130,9 +130,7 @@ crun_command_checkpoint (struct crun_global_arguments *global_args, int argc,
       if (UNLIKELY (path == NULL))
         libcrun_fail_with_error (0, "realloc failed");
 
-      ret = xasprintf (&cr_path, "%s/checkpoint", path);
-      if (UNLIKELY (ret == -1))
-        libcrun_fail_with_error (0, "xasprintf failed");
+      xasprintf (&cr_path, "%s/checkpoint", path);
 
       cr_options.image_path = cr_path;
     }

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -84,7 +84,7 @@ libcrun_get_cgroup_mode (libcrun_error_t *err)
   if (stat.f_type == CGROUP2_SUPER_MAGIC)
     return CGROUP_MODE_UNIFIED;
   if (stat.f_type != TMPFS_MAGIC)
-    return crun_make_error (err, errno, "invalid file system type on '/sys/fs/cgroup'");
+    return crun_make_error (err, 0, "invalid file system type on '/sys/fs/cgroup'");
   ret = statfs ("/sys/fs/cgroup/unified", &stat);
   if (ret < 0 && errno != ENOENT)
     return crun_make_error (err, errno, "statfs '/sys/fs/cgroup/unified'");
@@ -117,7 +117,7 @@ is_rwm (const char *str, libcrun_error_t *err)
         break;
 
       default:
-        return crun_make_error (err, errno, "invalid mode specified `%s`", str);
+        return crun_make_error (err, 0, "invalid mode specified `%s`", str);
       }
 
   return r && w && m ? 1 : 0;
@@ -1098,23 +1098,25 @@ int destroy_systemd_cgroup_scope (const char *scope, libcrun_error_t *err)
                           systemd_job_removed, &userdata);
   if (UNLIKELY (ret < 0))
     {
-      ret = crun_make_error (err, 0, "sd-bus message read");
+      ret = crun_make_error (err, -ret, "sd-bus message read");
       goto exit;
     }
 
-  if (UNLIKELY (sd_bus_message_new_method_call (bus, &m,
-                                                "org.freedesktop.systemd1",
-                                                "/org/freedesktop/systemd1",
-                                                "org.freedesktop.systemd1.Manager",
-                                                "StopUnit") < 0))
+  ret = sd_bus_message_new_method_call (bus, &m,
+                                        "org.freedesktop.systemd1",
+                                        "/org/freedesktop/systemd1",
+                                        "org.freedesktop.systemd1.Manager",
+                                        "StopUnit");
+  if (UNLIKELY (ret  < 0))
     {
-      ret = crun_make_error (err, 0, "set up dbus message");
+      ret = crun_make_error (err, -ret, "set up dbus message");
       goto exit;
     }
 
-  if (UNLIKELY (sd_bus_message_append (m, "ss", scope, "replace") < 0))
+  ret = sd_bus_message_append (m, "ss", scope, "replace");
+  if (UNLIKELY (ret < 0))
     {
-      ret = crun_make_error (err, 0, "sd-bus message append");
+      ret = crun_make_error (err, -ret, "sd-bus message append");
       goto exit;
     }
 
@@ -1127,7 +1129,7 @@ int destroy_systemd_cgroup_scope (const char *scope, libcrun_error_t *err)
   ret = sd_bus_message_read (reply, "o", &object);
   if (UNLIKELY (ret < 0))
     {
-      ret = crun_make_error (err, 0, "sd-bus message read");
+      ret = crun_make_error (err, -ret, "sd-bus message read");
       goto exit;
     }
 
@@ -1138,7 +1140,7 @@ int destroy_systemd_cgroup_scope (const char *scope, libcrun_error_t *err)
       ret = sd_bus_process (bus, NULL);
       if (UNLIKELY (ret < 0))
         {
-          ret = crun_make_error (err, 0, "sd-bus process");
+          ret = crun_make_error (err, -ret, "sd-bus process");
           break;
         }
 
@@ -1147,7 +1149,7 @@ int destroy_systemd_cgroup_scope (const char *scope, libcrun_error_t *err)
           ret = sd_bus_wait (bus, (uint64_t) -1);
           if (UNLIKELY (ret < 0))
             {
-              ret = crun_make_error (err, 0, "sd-bus wait");
+              ret = crun_make_error (err, -ret, "sd-bus wait");
               break;
             }
           continue;
@@ -1272,7 +1274,7 @@ libcrun_cgroup_enter (struct libcrun_cgroup_args *args, libcrun_error_t *err)
       if (UNLIKELY (ret < 0))
         return ret;
       if (len > 0)
-        return crun_make_error (err, errno, "cgroups in hybrid mode not supported, drop all controllers from cgroupv2");
+        return crun_make_error (err, 0, "cgroups in hybrid mode not supported, drop all controllers from cgroupv2");
     }
 
   switch (manager)
@@ -1486,7 +1488,7 @@ libcrun_cgroup_read_pids (const char *path, bool recurse, pid_t **pids, libcrun_
       break;
 
     default:
-      return crun_make_error (err, errno, "invalid cgroup mode %d", mode);
+      return crun_make_error (err, 0, "invalid cgroup mode %d", mode);
     }
 
   dirfd = open (cgroup_path, O_DIRECTORY | O_CLOEXEC);
@@ -1686,7 +1688,7 @@ write_blkio_resources (int dirfd, bool cgroup2, runtime_spec_schema_config_linux
   if (blkio->leaf_weight)
     {
       if (cgroup2)
-        return crun_make_error (err, errno, "cannot set leaf_weight with cgroupv2");
+        return crun_make_error (err, 0, "cannot set leaf_weight with cgroupv2");
       len = sprintf (fmt_buf, "%d", blkio->leaf_weight);
       ret = write_file_at (dirfd, "blkio.leaf_weight", fmt_buf, len, err);
       if (UNLIKELY (ret < 0))
@@ -2095,7 +2097,7 @@ write_memory_resources (int dirfd, bool cgroup2, runtime_spec_schema_config_linu
   if (memory->kernel)
     {
       if (cgroup2)
-        return crun_make_error (err, errno, "cannot set kernel memory with cgroupv2");
+        return crun_make_error (err, 0, "cannot set kernel memory with cgroupv2");
 
       len = sprintf (fmt_buf, "%lu", memory->kernel);
       ret = write_file_at (dirfd, "memory.kmem.limit_in_bytes", fmt_buf, len, err);

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -1152,12 +1152,6 @@ int destroy_systemd_cgroup_scope (const char *scope, libcrun_error_t *err)
             }
           continue;
         }
-
-      if (UNLIKELY (ret < 0))
-        {
-          ret = crun_make_error (err, 0, "sd-bus wait");
-          break;
-        }
     }
 exit:
   if (bus)

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -840,10 +840,10 @@ container_init (void *args, const char *notify_socket, int sync_socket,
     }
 
   if (UNLIKELY (def->process == NULL))
-    return crun_make_error (err, errno, "block 'process' not found");
+    return crun_make_error (err, 0, "block 'process' not found");
 
   if (UNLIKELY (exec_path == NULL))
-    return crun_make_error (err, errno, "executable path not specified");
+    return crun_make_error (err, 0, "executable path not specified");
 
   if (def->hooks && def->hooks->start_container_len)
     {
@@ -1126,7 +1126,7 @@ handle_notify_socket (int notify_socketfd, libcrun_error_t *err)
     {
       ret = sd_notify (0, ready_str);
       if (UNLIKELY (ret < 0))
-        return crun_make_error (err, errno, "sd_notify");
+        return crun_make_error (err, -ret, "sd_notify");
 
       return 1;
     }
@@ -1345,7 +1345,7 @@ open_seccomp_output (const char *id, int *fd, bool readonly, const char *state_r
         {
           if (errno == ENOENT)
             return 0;
-          return crun_make_error (err, 0, "open seccomp.bpf");
+          return crun_make_error (err, errno, "open seccomp.bpf");
         }
       *fd = ret;
     }
@@ -1353,7 +1353,7 @@ open_seccomp_output (const char *id, int *fd, bool readonly, const char *state_r
     {
       ret = TEMP_FAILURE_RETRY (open (dest_path, O_RDWR | O_CREAT, 0700));
       if (UNLIKELY (ret < 0))
-        return crun_make_error (err, 0, "open seccomp.bpf");
+        return crun_make_error (err, errno, "open seccomp.bpf");
       *fd = ret;
     }
 
@@ -1932,7 +1932,7 @@ libcrun_container_start (libcrun_context_t *context, const char *id, libcrun_err
     return ret;
 
   if (!ret)
-    return crun_make_error (err, errno, "container `%s` is not running", id);
+    return crun_make_error (err, 0, "container `%s` is not running", id);
 
   if (context->notify_socket)
     {

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -77,13 +77,13 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status,
 
   ret = mkdir (cr_options->image_path, 0700);
   if (UNLIKELY ((ret == -1) && (errno != EEXIST)))
-    return crun_make_error (err, 0,
+    return crun_make_error (err, errno,
                             "error creating checkpoint directory %s\n",
                             cr_options->image_path);
 
   image_fd = open (cr_options->image_path, O_DIRECTORY);
   if (UNLIKELY (image_fd == -1))
-    return crun_make_error (err, 0, "error opening checkpoint directory %s\n",
+    return crun_make_error (err, errno, "error opening checkpoint directory %s\n",
                             cr_options->image_path);
 
   criu_set_images_dir_fd (image_fd);
@@ -95,7 +95,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status,
     {
       work_fd = open (cr_options->work_path, O_DIRECTORY);
       if (UNLIKELY (work_fd == -1))
-        return crun_make_error (err, 0,
+        return crun_make_error (err, errno,
                                 "error opening CRIU work directory %s\n",
                                 cr_options->work_path);
 
@@ -188,7 +188,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status,
 
   image_fd = open (cr_options->image_path, O_DIRECTORY);
   if (UNLIKELY (image_fd == -1))
-    return crun_make_error (err, 0, "error opening checkpoint directory %s\n",
+    return crun_make_error (err, errno, "error opening checkpoint directory %s\n",
                             cr_options->image_path);
 
   criu_set_images_dir_fd (image_fd);
@@ -200,7 +200,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status,
     {
       work_fd = open (cr_options->work_path, O_DIRECTORY);
       if (UNLIKELY (work_fd == -1))
-        return crun_make_error (err, 0,
+        return crun_make_error (err, errno,
                                 "error opening CRIU work directory %s\n",
                                 cr_options->work_path);
 

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -111,9 +111,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status,
    * and all of its children. */
   criu_set_pid (status->pid);
 
-  ret = xasprintf (&path, "%s/%s", status->bundle, status->rootfs);
-  if (UNLIKELY (ret == -1))
-    libcrun_fail_with_error (0, "xasprintf failed");
+  xasprintf (&path, "%s/%s", status->bundle, status->rootfs);
 
   ret = criu_set_root (path);
   if (UNLIKELY (ret != 0))
@@ -239,14 +237,10 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status,
         criu_add_ext_mount (def->linux->masked_paths[i], "/dev/null");
     }
 
-  ret = xasprintf (&path, "%s/%s", status->bundle, status->rootfs);
-  if (UNLIKELY (ret == -1))
-    libcrun_fail_with_error (0, "xasprintf failed");
+  xasprintf (&path, "%s/%s", status->bundle, status->rootfs);
 
   /* Mount the container rootfs for CRIU. */
-  ret = xasprintf (&root, "%s/criu-root", status->bundle);
-  if (UNLIKELY (ret == -1))
-    libcrun_fail_with_error (0, "xasprintf failed");
+  xasprintf (&root, "%s/criu-root", status->bundle);
 
   ret = mkdir (root, 0755);
   if (UNLIKELY (ret == -1))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1310,7 +1310,7 @@ do_mounts (libcrun_container_t *container, int rootfsfd, const char *rootfs, lib
       if (extra_flags & OPTION_TMPCOPYUP)
         {
           if (strcmp (type, "tmpfs") != 0)
-            return crun_make_error (err, errno, "tmpcopyup can be used only with tmpfs");
+            return crun_make_error (err, 0, "tmpcopyup can be used only with tmpfs");
 
           copy_from_fd = openat (rootfsfd, target, O_DIRECTORY);
           if (UNLIKELY (copy_from_fd < 0))

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -127,7 +127,7 @@ libcrun_apply_seccomp (int infd, char **seccomp_flags, size_t seccomp_flags_len,
     return 0;
 
   if (UNLIKELY (lseek (infd, 0, SEEK_SET) == (off_t) -1))
-    return crun_make_error (err, 0, "lseek");
+    return crun_make_error (err, errno, "lseek");
 
 
   /* if no seccomp flag was specified use a sane default.  */
@@ -210,13 +210,13 @@ libcrun_generate_seccomp (libcrun_container_t *container, int outfd, unsigned in
 #ifdef SECCOMP_ARCH_RESOLVE_NAME
       arch_token = seccomp_arch_resolve_name (lowercase_arch);
       if (arch_token == 0)
-        return crun_make_error (err, 0, "seccomp unknown architecture %s", arch);
+        return crun_make_error (err, -ret, "seccomp unknown architecture %s", arch);
 #else
       arch_token = SCMP_ARCH_NATIVE;
 #endif
       ret = seccomp_arch_add (ctx, arch_token);
       if (ret < 0 && ret != -EEXIST)
-        return crun_make_error (err, 0, "seccomp adding architecture");
+        return crun_make_error (err, -ret, "seccomp adding architecture");
     }
 
   for (i = 0; i < seccomp->syscalls_len; i++)
@@ -293,7 +293,7 @@ libcrun_generate_seccomp (libcrun_container_t *container, int outfd, unsigned in
                                                 k,
                                                 arg_cmp);
                   if (UNLIKELY (ret < 0))
-                    return crun_make_error (err, 0, "seccomp_rule_add_array");
+                    return crun_make_error (err, -ret, "seccomp_rule_add_array");
                 }
               else
                 {
@@ -307,7 +307,7 @@ libcrun_generate_seccomp (libcrun_container_t *container, int outfd, unsigned in
                                                     1,
                                                     &arg_cmp[r]);
                       if (UNLIKELY (ret < 0))
-                        return crun_make_error (err, 0, "seccomp_rule_add_array");
+                        return crun_make_error (err, -ret, "seccomp_rule_add_array");
                     }
                 }
             }
@@ -318,7 +318,7 @@ libcrun_generate_seccomp (libcrun_container_t *container, int outfd, unsigned in
     {
       ret = seccomp_export_bpf (ctx, outfd);
       if (UNLIKELY (ret < 0))
-        return crun_make_error (err, 0, "seccomp_export_bpf");
+        return crun_make_error (err, -ret, "seccomp_export_bpf");
     }
 
   return 0;

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -104,9 +104,7 @@ read_pid_stat (pid_t pid, struct pid_stat *st, libcrun_error_t *err)
   cleanup_file FILE *f = NULL;
   cleanup_free char *pid_stat_file = NULL;
 
-  ret = xasprintf (&pid_stat_file, "/proc/%d/stat", pid);
-  if (UNLIKELY (ret == -1))
-    return crun_make_error (err, errno, "xasprintf failed");
+  xasprintf (&pid_stat_file, "/proc/%d/stat", pid);
 
   f = fopen (pid_stat_file, "r");
   if (f == NULL)

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -117,7 +117,7 @@ read_pid_stat (pid_t pid, struct pid_stat *st, libcrun_error_t *err)
     &(st->cstime), &(st->priority), &(st->nice), &(st->num_threads), &(st->itrealvalue),
     &(st->starttime));
   if (UNLIKELY (ret != 22))
-    return crun_make_error (err, errno, "fscanf failed");
+    return crun_make_error (err, 0, "fscanf failed");
 
   return 0;
 }
@@ -142,7 +142,7 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   xasprintf (&file_tmp, "%s.tmp", file);
   fd_write = open (file_tmp, O_CREAT | O_WRONLY, 0700);
   if (UNLIKELY (fd_write < 0))
-    return crun_make_error (err, 0, "cannot open status file");
+    return crun_make_error (err, errno, "cannot open status file");
 
   len = xasprintf (&data, "{\n    \"pid\" : %d,\n    \"process-start-time\" : %lld,\n    \"cgroup-path\" : \"%s\",\n    \"scope\" : \"%s\",\n    \"rootfs\" : \"%s\",\n    \"systemd-cgroup\" : %s,\n    \"bundle\" : \"%s\",\n    \"created\" : \"%s\",\n    \"detached\" : %s\n}\n",
                    status->pid,
@@ -155,12 +155,12 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
                    status->created,
                    status->detached ? "true" : "false");
   if (UNLIKELY (write (fd_write, data, len) < 0))
-    return crun_make_error (err, 0, "cannot write status file");
+    return crun_make_error (err, errno, "cannot write status file");
 
   close_and_reset (&fd_write);
 
   if (UNLIKELY (rename (file_tmp, file) < 0))
-    return crun_make_error (err, 0, "cannot rename status file");
+    return crun_make_error (err, errno, "cannot rename status file");
 
   return 0;
 }

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -135,7 +135,7 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
 
   ret = read_pid_stat (status->pid, &st, err);
   if (UNLIKELY (ret))
-    return crun_make_error (err, errno, "parse state file");
+    return ret;
 
   status->process_start_time = st.starttime;
 
@@ -435,7 +435,7 @@ libcrun_is_container_running (libcrun_container_status_t *status, libcrun_error_
           struct pid_stat st;
           ret = read_pid_stat (status->pid, &st, err);
           if (UNLIKELY (ret))
-            return crun_make_error (err, errno, "parse state file");
+            return ret;
 
           if (status->process_start_time != st.starttime || st.state == 'Z' || st.state == 'X')
             return 0; /* stopped */

--- a/src/restore.c
+++ b/src/restore.c
@@ -128,9 +128,7 @@ crun_command_restore (struct crun_global_arguments *global_args, int argc,
       if (UNLIKELY (path == NULL))
         libcrun_fail_with_error (0, "realloc failed");
 
-      ret = xasprintf (&cr_path, "%s/checkpoint", path);
-      if (UNLIKELY (ret == -1))
-        libcrun_fail_with_error (0, "xasprintf failed");
+      xasprintf (&cr_path, "%s/checkpoint", path);
 
       cr_options.image_path = cr_path;
     }


### PR DESCRIPTION
Motivated by seeing this error:
    
> cannot set kernel memory with cgroupv2: File exists
    
in which `EEXIST` is from some other operation.
    
This patchset:
 - removes error checks after xasprintf
 - removes double wrapping of errors 
 - removes `errno` where it's not appropriate to use it
 - adds `errno` where it's appropriate
 - adds `-ret` as `errno` for calls that return `-errno`
   (that is, most of `sd_*()` and `seccomp_*()` calls)

While at it, remove a few lines of unreachable code.    

:warning: All this needs a careful review.