### PR TITLE
cgroup: use rootfd for creating symlinks

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -553,13 +553,9 @@ enter_cgroup (int cgroup_mode, pid_t pid, const char *path, bool ensure_missing,
 }
 
 int
-libcrun_cgroups_create_symlinks (const char *target, libcrun_error_t *err)
+libcrun_cgroups_create_symlinks (int dirfd, libcrun_error_t *err)
 {
   int i;
-  cleanup_close int dirfd = open (target, O_DIRECTORY | O_RDONLY);
-
-  if (UNLIKELY (dirfd < 0))
-    return crun_make_error (err, errno, "cannot open /sys/fs/cgroup");
 
   for (i = 0; cgroup_symlinks[i].name; i++)
     {

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -59,7 +59,7 @@ int libcrun_cgroup_destroy (const char *id, char *path, int manager, libcrun_err
 int libcrun_move_process_to_cgroup (pid_t pid, char *path, libcrun_error_t *err);
 int libcrun_update_cgroup_resources (int cgroup_mode, runtime_spec_schema_config_linux_resources *resources,
                                      char *path, libcrun_error_t *err);
-int libcrun_cgroups_create_symlinks (const char *target, libcrun_error_t *err);
+int libcrun_cgroups_create_symlinks (int dirfd, libcrun_error_t *err);
 int libcrun_cgroup_is_container_paused (const char *cgroup_path, int cgroup_mode, bool *paused, libcrun_error_t *err);
 int libcrun_cgroup_pause_unpause (const char *path, const bool pause, libcrun_error_t *err);
 int libcrun_cgroup_read_pids (const char *path, bool recurse, pid_t **pids, libcrun_error_t *err);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -704,7 +704,7 @@ do_mount_cgroup_v1 (libcrun_container_t *container,
         }
     }
 
-  ret = libcrun_cgroups_create_symlinks (target, err);
+  ret = libcrun_cgroups_create_symlinks (targetfd, err);
   if (UNLIKELY (ret < 0))
     return ret;
 


### PR DESCRIPTION
we cannot directly use the target directory as it is relative to the
rootfs.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>