### PR TITLE
criu: tell CRIU to not touch the network namespace

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -124,8 +124,8 @@ static struct linux_namespace_s namespaces[] =
    {NULL, NULL, 0}
   };
 
-static int
-find_namespace (const char *name)
+int
+libcrun_find_namespace (const char *name)
 {
   struct linux_namespace_s *it;
   for (it = namespaces; it->name; it++)
@@ -2399,7 +2399,7 @@ libcrun_run_linux_container (libcrun_container_t *container,
 
   for (i = 0; i < def->linux->namespaces_len; i++)
     {
-      int value = find_namespace (def->linux->namespaces[i]->type);
+      int value = libcrun_find_namespace (def->linux->namespaces[i]->type);
       if (UNLIKELY (value < 0))
         return crun_make_error (err, 0, "invalid namespace type: `%s`", def->linux->namespaces[i]->type);
 
@@ -2570,7 +2570,7 @@ libcrun_run_linux_container (libcrun_container_t *container,
     {
       cleanup_free char *cwd = NULL;
       int orig_index = namespaces_to_join_index[i];
-      int value = find_namespace (def->linux->namespaces[orig_index]->type);
+      int value = libcrun_find_namespace (def->linux->namespaces[orig_index]->type);
 
       /* The user namespace is handled differently and already joined at this point.  */
       if (value == CLONE_NEWUSER)
@@ -3009,7 +3009,7 @@ libcrun_configure_network (libcrun_container_t *container, libcrun_error_t *err)
 
   for (i = 0; i < def->linux->namespaces_len; i++)
     {
-      int value = find_namespace (def->linux->namespaces[i]->type);
+      int value = libcrun_find_namespace (def->linux->namespaces[i]->type);
       if (UNLIKELY (value < 0))
         return crun_make_error (err, 0, "invalid namespace type: `%s`", def->linux->namespaces[i]->type);
 

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -69,4 +69,6 @@ int libcrun_container_restore_linux (libcrun_container_status_t *status,
                                      libcrun_container_t *container,
                                      libcrun_checkpoint_restore_t *cr_options,
                                      libcrun_error_t *err);
+
+int libcrun_find_namespace (const char *name);
 #endif


### PR DESCRIPTION
CRIU can checkpoint and restore all namespaces. For the network namespace either special steps are needed to re-connect the network devices like veth back into the network namespace or, like when being driven by Podman, the network namespace if configured externally.

For checkpoint/restore with Podman we are telling CRIU to not checkpoint the network namespace settings and on restore we tell CRIU to use the network namespace provided by Podman/CNI by looking at config.json if the network namespace is defined by a 'path'.

With this the restored container will be running in the given network namespace.

With this Podman can checkpoint and restore a container on Fedora 31 using crun.

stdin and stdout are not yet correctly reconnected after restore, so a few more, hopefully small, changes are still necessary.

See #71 