### PR TITLE
libcrun: fix path resolution with symlinks

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -72,8 +72,8 @@ static struct symlink_s cgroup_symlinks[] = {
 # define TMPFS_MAGIC 0x01021994
 #endif
 
-int
-libcrun_get_cgroup_mode (libcrun_error_t *err)
+static int
+detect_cgroup_mode (libcrun_error_t *err)
 {
   struct statfs stat;
   int ret;
@@ -91,6 +91,24 @@ libcrun_get_cgroup_mode (libcrun_error_t *err)
   if (ret < 0)
     return CGROUP_MODE_LEGACY;
   return stat.f_type == CGROUP2_SUPER_MAGIC ? CGROUP_MODE_HYBRID : CGROUP_MODE_LEGACY;
+}
+
+int
+libcrun_get_cgroup_mode (libcrun_error_t *err)
+{
+  int tmp;
+  static int cgroup_mode = 0;
+
+  if (cgroup_mode)
+    return cgroup_mode;
+
+  tmp = detect_cgroup_mode (err);
+  if (UNLIKELY (tmp < 0))
+    return tmp;
+
+  cgroup_mode = tmp;
+
+  return cgroup_mode;
 }
 
 static int

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1493,6 +1493,10 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
       container_args.console_socket_fd = console_socket_fd;
     }
 
+  cgroup_mode = libcrun_get_cgroup_mode (err);
+  if (cgroup_mode < 0)
+    return cgroup_mode;
+
   pid = libcrun_run_linux_container (container, context->detach,
                                      container_init, &container_args,
                                      &sync_socket, err);
@@ -1509,10 +1513,6 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
   if (container_args.terminal_socketpair[1] >= 0)
     close_and_reset (&socket_pair_1);
-
-  cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (cgroup_mode < 0)
-    return cgroup_mode;
 
   cgroup_manager = CGROUP_MANAGER_CGROUPFS;
   if (context->systemd_cgroup)

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -53,9 +53,6 @@
 # define RLIMIT_RTTIME 15
 #endif
 
-/* Defined in chroot_realpath.c  */
-char *chroot_realpath (const char *chroot, const char *path, char resolved_path[]);
-
 struct remount_s
 {
   struct remount_s *next;

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -368,7 +368,6 @@ libcrun_get_containers_list (libcrun_container_list_t **ret, const char *state_r
   libcrun_container_list_t *tmp = NULL;
   cleanup_free char *path = get_run_directory (state_root);
   cleanup_dir DIR *dir;
-  cleanup_free char *run_directory = get_run_directory (state_root);
 
   *ret = NULL;
   dir = opendir (path);
@@ -385,7 +384,7 @@ libcrun_get_containers_list (libcrun_container_list_t **ret, const char *state_r
       if (next->d_name[0] == '.')
         continue;
 
-      xasprintf (&status_file, "%s/%s/status", run_directory, next->d_name);
+      xasprintf (&status_file, "%s/%s/status", path, next->d_name);
       exists = crun_path_exists (status_file, err);
       if (exists < 0)
        {

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -41,9 +41,6 @@
 #include <linux/magic.h>
 #include <limits.h>
 
-#ifndef RESOLVE_BENEATH
-# define RESOLVE_BENEATH		0x08
-#endif
 #ifndef RESOLVE_IN_ROOT
 # define RESOLVE_IN_ROOT		0x10
 #endif
@@ -404,7 +401,7 @@ crun_ensure_directory_at (int dirfd, const char *path, int mode, bool nofollow, 
   return 0;
 }
 
-int
+static int
 check_fd_under_path (const char *rootfs, size_t rootfslen, int fd, const char *fdname, libcrun_error_t *err)
 {
   int ret;
@@ -432,6 +429,9 @@ close_and_replace (int *oldfd, int newfd)
   *oldfd = newfd;
 }
 
+/* Defined in chroot_realpath.c  */
+char *chroot_realpath (const char *chroot, const char *path, char resolved_path[]);
+
 int
 safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *path, int flags,
              int mode, libcrun_error_t *err)
@@ -439,10 +439,11 @@ safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *path,
   int ret;
   cleanup_close int fd = -1;
   static bool openat2_supported = true;
+  char buffer[PATH_MAX], *path_in_chroot;
 
   if (openat2_supported)
     {
-      ret = syscall_openat2 (dirfd, path, flags, mode, RESOLVE_IN_ROOT | RESOLVE_BENEATH);
+      ret = syscall_openat2 (dirfd, path, flags, mode, RESOLVE_IN_ROOT);
       if (ret < 0)
         {
           if (errno == ENOSYS)
@@ -456,10 +457,15 @@ safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *path,
     }
 
  fallback:
-  while (*path == '/')
-    path++;
+  path_in_chroot = chroot_realpath (rootfs, path, buffer);
+  if (path_in_chroot == NULL)
+    return crun_make_error (err, errno, "cannot resolve `%s` under rootfs", path);
 
-  ret = openat (dirfd, path, flags, mode);
+  path_in_chroot += rootfs_len;
+  while (*path_in_chroot == '/')
+    path_in_chroot++;
+
+  ret = openat (dirfd, path_in_chroot, flags, mode);
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "open `%s`", path);
 
@@ -540,7 +546,7 @@ crun_safe_ensure_at (bool dir, int dirfd, const char *dirpath, size_t dirpath_le
             return crun_make_error (err, errno, "mkdir `%s`", cur);
         }
 
-      cwd = safe_openat (cwd, dirpath, dirpath_len, cur, O_CLOEXEC | O_PATH, 0, err);
+      cwd = safe_openat (dirfd, dirpath, dirpath_len, npath, O_CLOEXEC | O_PATH, 0, err);
       if (UNLIKELY (cwd < 0))
         return cwd;
 
@@ -550,6 +556,7 @@ crun_safe_ensure_at (bool dir, int dirfd, const char *dirpath, size_t dirpath_le
         break;
 
       cur = it + 1;
+      *it = '/';
       it = strchr (cur, '/');
     }
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -296,7 +296,7 @@ get_file_type (mode_t *mode, bool nofollow, const char *path)
 int
 create_file_if_missing_at (int dirfd, const char *file, libcrun_error_t *err)
 {
-  cleanup_close int fd_write = openat (dirfd, file, O_CREAT | O_WRONLY, 0700);
+  cleanup_close int fd_write = openat (dirfd, file, O_CLOEXEC | O_CREAT | O_WRONLY, 0700);
   if (fd_write < 0)
     {
       mode_t mode;
@@ -304,25 +304,6 @@ create_file_if_missing_at (int dirfd, const char *file, libcrun_error_t *err)
 
       /* On errors, check if the file already exists.  */
       ret = get_file_type_at (dirfd, &mode, false, file);
-      if (ret == 0 && S_ISREG (mode))
-        return 0;
-
-      return crun_make_error (err, errno, "creating file `%s`", file);
-    }
-  return 0;
-}
-
-int
-create_file_if_missing (const char *file, libcrun_error_t *err)
-{
-  cleanup_close int fd_write = open (file, O_CLOEXEC | O_CREAT | O_WRONLY, 0700);
-  if (fd_write < 0)
-    {
-      mode_t mode;
-      int ret;
-
-      /* On errors, check if the file already exists.  */
-      ret = get_file_type (&mode, false, file);
       if (ret == 0 && S_ISREG (mode))
         return 0;
 
@@ -744,7 +725,6 @@ add_selinux_mount_label (char **retlabel, const char *data, const char *label, l
     }
   *retlabel = xstrdup (data);
   return 0;
-
 }
 
 static int

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -90,8 +90,6 @@ int detach_process ();
 
 int create_file_if_missing_at (int dirfd, const char *file, libcrun_error_t *err);
 
-int create_file_if_missing (const char *file, libcrun_error_t *err);
-
 int check_running_in_user_namespace (libcrun_error_t *err);
 
 int set_selinux_exec_label (const char *label, libcrun_error_t *err);

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -78,8 +78,6 @@ int crun_ensure_directory_at (int dirfd, const char *path, int mode, bool nofoll
 
 int crun_ensure_file_at (int dirfd, const char *path, int mode, bool nofollow, libcrun_error_t *err);
 
-int check_fd_under_path (const char *rootfs, size_t rootfslen, int fd, const char *fdname, libcrun_error_t *err);
-
 int crun_safe_ensure_directory_at (int dirfd, const char *dirpath, size_t dirpath_len, const char *path, int mode, libcrun_error_t *err);
 
 int crun_safe_ensure_file_at (int dirfd, const char *dirpath, size_t dirpath_len, const char *path, int mode, libcrun_error_t *err);


### PR DESCRIPTION
commit 95b6f8ac8eefeb8145e7e9163f267f18b596555e introduced a
regression where symlinks inside of the path resolution are not
resolved.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>