### PR TITLE
utils: differentiate errors for write_file{,at}

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -195,7 +195,7 @@ write_file_at (int dirfd, const char *name, const void *data, size_t len, libcru
   cleanup_close int fd = openat (dirfd, name, O_WRONLY | O_CREAT, 0700);
   int ret = 0;
   if (UNLIKELY (fd < 0))
-    return crun_make_error (err, errno, "writing file `%s`", name);
+    return crun_make_error (err, errno, "opening file `%s` for writing", name);
 
   if (len)
     {
@@ -213,7 +213,7 @@ write_file (const char *name, const void *data, size_t len, libcrun_error_t *err
   cleanup_close int fd = open (name, O_WRONLY | O_CREAT, 0700);
   int ret;
   if (UNLIKELY (fd < 0))
-    return crun_make_error (err, errno, "writing file `%s`", name);
+    return crun_make_error (err, errno, "opening file `%s` for writing", name);
 
   ret = TEMP_FAILURE_RETRY (write (fd, data, len));
   if (UNLIKELY (ret < 0))


### PR DESCRIPTION
otherwise it's hard to see what exactly is failing

Signed-off-by: Peter Hunt <pehunt@redhat.com>