### PR TITLE
crun checkpoint/restore support (almost ready for Podman)

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1057,6 +1057,7 @@ write_container_status (libcrun_container_t *container, libcrun_context_t *conte
                         char *cgroup_path, char *scope, char *created, libcrun_error_t *err)
 {
   cleanup_free char *cwd = get_current_dir_name ();
+  char *external_descriptors = libcrun_get_external_descriptors (container);
   libcrun_container_status_t status = {.pid = pid,
                                        .cgroup_path = cgroup_path,
                                        .scope = scope,
@@ -1064,7 +1065,8 @@ write_container_status (libcrun_container_t *container, libcrun_context_t *conte
                                        .bundle = cwd,
                                        .created = created,
                                        .systemd_cgroup = context->systemd_cgroup,
-                                       .detached = context->detach};
+                                       .detached = context->detach,
+                                       .external_descriptors = external_descriptors};
   if (cwd == NULL)
     OOM ();
   return libcrun_write_container_status (context->state_root, context->id, &status, err);

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2534,6 +2534,7 @@ libcrun_container_restore (libcrun_context_t *context, const char *id,
   cleanup_free char *scope = NULL;
   uid_t root_uid = -1;
   gid_t root_gid = -1;
+  char created[35];
   int ret;
 
   container = libcrun_container_load_from_file ("config.json", err);
@@ -2617,9 +2618,11 @@ libcrun_container_restore (libcrun_context_t *context, const char *id,
       }
   }
 
+  get_current_timestamp (created);
+  context->detach = cr_options->detach;
   ret = write_container_status (container, context, status.pid,
-                                status.cgroup_path, status.scope,
-                                status.created, err);
+                                cgroup_path, scope,
+                                created, err);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2560,8 +2560,8 @@ libcrun_container_restore (libcrun_context_t *context, const char *id,
     return ret;
 
   /* The CRIU restore code uses bundle and rootfs of status. */
-  status.bundle = xstrdup(context->bundle);
-  status.rootfs = xstrdup (def->root->path);
+  status.bundle = (char *)context->bundle;
+  status.rootfs = def->root->path;
 
   ret = libcrun_container_restore_linux (&status, container, cr_options, err);
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -264,7 +264,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status,
               criu_add_ext_mount (def->mounts[i]->destination,
                                   def->mounts[i]->source);
               break;
-          }
+            }
         }
     }
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3116,6 +3116,13 @@ libcrun_container_restore_linux (libcrun_container_status_t *status,
                                  libcrun_checkpoint_restore_t *cr_options,
                                  libcrun_error_t *err)
 {
-  return libcrun_container_restore_linux_criu (status, container,
-                                               cr_options, err);
+  int ret;
+  ret = libcrun_container_restore_linux_criu (status, container,
+                                              cr_options, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  get_private_data (container)->external_descriptors = status->external_descriptors;
+
+  return 0;
 }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -49,6 +49,11 @@
 #include <sys/personality.h>
 #include <net/if.h>
 
+#include <yajl/yajl_tree.h>
+#include <yajl/yajl_gen.h>
+
+#define YAJL_STR(x) ((const unsigned char *) (x))
+
 #ifndef RLIMIT_RTTIME
 # define RLIMIT_RTTIME 15
 #endif
@@ -82,6 +87,10 @@ struct private_data_s
 
   char *tmpmountdir;
   char *tmpmountfile;
+
+  /* Used to save stdin, stdout, stderr during checkpointing to descriptors.json
+   * and needed during restore. */
+  char *external_descriptors;
 };
 
 struct linux_namespace_s
@@ -2320,6 +2329,50 @@ open_terminal (libcrun_container_t *container, char **slave, libcrun_error_t *er
   return ret;
 }
 
+char *
+libcrun_get_external_descriptors (libcrun_container_t *container)
+{
+  return get_private_data (container)->external_descriptors;
+}
+
+static int
+save_external_descriptors (libcrun_container_t *container,
+                           pid_t pid,
+                           libcrun_error_t *err)
+{
+  const unsigned char *buf = NULL;
+  yajl_gen gen = NULL;
+  size_t buf_len;
+  int ret;
+  int i;
+
+  gen = yajl_gen_alloc (NULL);
+  if (gen == NULL)
+    return crun_make_error (err, errno, "yajl_gen_alloc");
+  yajl_gen_array_open (gen);
+
+  /* Remember original stdin, stdout, stderr for container restore. */
+  for (i = 0; i < 3; i++)
+    {
+      cleanup_free char *fd_path;
+      char link_path[PATH_MAX];
+      xasprintf (&fd_path, "/proc/%d/fd/%d", pid, i);
+      ret = readlink (fd_path, link_path, PATH_MAX - 1);
+      if (UNLIKELY (ret < 0))
+        return crun_make_error (err, errno, "readlink");
+      link_path[ret] = 0;
+      yajl_gen_string (gen, YAJL_STR (link_path), strlen (link_path));
+    }
+
+  yajl_gen_array_close (gen);
+  yajl_gen_get_buf (gen, &buf, &buf_len);
+  if (buf)
+    get_private_data (container)->external_descriptors = xstrdup((const char *) buf);
+  yajl_gen_free (gen);
+
+  return 0;
+}
+
 int
 libcrun_set_terminal (libcrun_container_t *container, libcrun_error_t *err)
 {
@@ -2486,6 +2539,10 @@ libcrun_run_linux_container (libcrun_container_t *container,
   if (pid)
     {
       pid_t grandchild = 0;
+
+      ret = save_external_descriptors (container, pid, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
 
       ret = close_and_reset (&sync_socket_container);
       if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -71,4 +71,5 @@ int libcrun_container_restore_linux (libcrun_container_status_t *status,
                                      libcrun_error_t *err);
 
 int libcrun_find_namespace (const char *name);
+char *libcrun_get_external_descriptors (libcrun_container_t *container);
 #endif

--- a/src/libcrun/status.h
+++ b/src/libcrun/status.h
@@ -42,6 +42,7 @@ struct libcrun_container_status_s
   int systemd_cgroup;
   char *created;
   int detached;
+  char *external_descriptors;
 };
 typedef struct libcrun_container_status_s libcrun_container_status_t;
 


### PR DESCRIPTION
With this I am able to use Podman with crun to checkpoint and restore containers.

The checkpoint and restore commands are still hidden in crun and prefixed using '_'.

One smaller problem, easy to fix, is that crun (just like runc) creates a few directories implicitly on container creation (like `/run`). I need to create these directories also during restore. This makes it impossible to currently migrate a container where `/run` is not part of the container image as CRIU fails remounting `/run/.containerenv` (for example) because `/run` does not exist.

The bigger problem I am seeing is related to CRIU's incomplete cgroup2 support. I think.

One of my test containers is using Java and after restore the JVM is running on 100% CPU usage all the time, because, I think, the JVM does not correctly detect the available CPUs. Something like this. I still need to understand this better.