### PR TITLE
memset nits

### DIFF
--- a/contrib/terminal-receiver/terminal-receiver.c
+++ b/contrib/terminal-receiver/terminal-receiver.c
@@ -42,13 +42,12 @@
 int
 open_unix_domain_socket (const char *path)
 {
-  struct sockaddr_un addr;
+  struct sockaddr_un addr = {};
   int ret;
   int fd = socket (AF_UNIX, SOCK_STREAM, 0);
   if (fd < 0)
     error (EXIT_FAILURE, errno, "error creating UNIX socket");
 
-  memset (&addr, 0, sizeof (addr));
   strcpy (addr.sun_path, path);
   addr.sun_family = AF_UNIX;
   ret = bind (fd, (struct sockaddr *) &addr, sizeof (addr));
@@ -67,13 +66,11 @@ receive_fd_from_socket (int from)
 {
   int fd = -1;
   struct iovec iov[1];
-  struct msghdr msg;
-  char ctrl_buf[CMSG_SPACE (sizeof (int))];
+  struct msghdr msg = {};
+  char ctrl_buf[CMSG_SPACE (sizeof (int))] = {};
   char data[1];
   int ret;
   struct cmsghdr *cmsg;
-  memset (&msg, 0, sizeof (struct msghdr));
-  memset (ctrl_buf, 0, CMSG_SPACE (sizeof (int)));
 
   data[0] = ' ';
   iov[0].iov_base = data;

--- a/src/exec.c
+++ b/src/exec.c
@@ -175,8 +175,7 @@ make_oci_process_user (const char *userspec)
   if (userspec == NULL)
     return NULL;
 
-  u = xmalloc (sizeof (runtime_spec_schema_config_schema_process_user));
-  memset (u, 0, sizeof (runtime_spec_schema_config_schema_process_user));
+  u = xmalloc0 (sizeof (runtime_spec_schema_config_schema_process_user));
 
   errno = 0;
   u->uid = strtol (userspec, &endptr, 10);
@@ -224,14 +223,11 @@ crun_command_exec (struct crun_global_arguments *global_args, int argc, char **a
     return libcrun_container_exec_process_file (&crun_context, argv[first_arg], exec_options.process, err);
   else
     {
-      runtime_spec_schema_config_schema_process *process = xmalloc (sizeof (*process));
+      runtime_spec_schema_config_schema_process *process = xmalloc0 (sizeof (*process));
       int i;
 
-      memset (process, 0, sizeof (*process));
-
       process->args_len = argc;
-      process->args = xmalloc ((argc + 1) * sizeof (*process->args));
-      memset (process->args, 0, (argc + 1) * sizeof (*process->args));
+      process->args = xmalloc0 ((argc + 1) * sizeof (*process->args));
       for (i = 0; i < argc - first_arg; i++)
         process->args[i] = xstrdup (argv[first_arg + i + 1]);
       process->args[i] = NULL;

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -384,8 +384,7 @@ sync_socket_send_sync (int fd, bool flush_errors, libcrun_error_t *err)
 static libcrun_container_t *
 make_container (runtime_spec_schema_config_schema *container_def)
 {
-  libcrun_container_t *container = xmalloc (sizeof (*container));
-  memset (container, 0, sizeof (*container));
+  libcrun_container_t *container = xmalloc0 (sizeof (*container));
   container->container_def = container_def;
 
   container->host_uid = geteuid ();

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -440,14 +440,13 @@ int unblock_signals (libcrun_error_t *err)
   int i;
   int ret;
   sigset_t mask;
-  struct sigaction act;
+  struct sigaction act = {};
 
   sigfillset (&mask);
   ret = sigprocmask (SIG_UNBLOCK, &mask, NULL);
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "sigprocmask");
 
-  memset (&act, 0, sizeof (act));
   act.sa_handler = SIG_DFL;
   for (i = 0; i < NSIG; i++)
     {
@@ -934,10 +933,9 @@ static int
 container_delete_internal (libcrun_context_t *context, runtime_spec_schema_config_schema *def, const char *id, bool force, bool only_cleanup, libcrun_error_t *err)
 {
   int ret;
-  cleanup_container_status libcrun_container_status_t status;
+  cleanup_container_status libcrun_container_status_t status = {};
   const char *state_root = context->state_root;
 
-  memset (&status, 0, sizeof (status));
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
     {
@@ -1026,9 +1024,7 @@ libcrun_container_kill (libcrun_context_t *context, const char *id, int signal, 
 {
   int ret;
   const char *state_root = context->state_root;
-  cleanup_container_status libcrun_container_status_t status;
-
-  memset (&status, 0, sizeof (status));
+  cleanup_container_status libcrun_container_status_t status = {};
 
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
@@ -1045,9 +1041,7 @@ libcrun_container_kill_all (libcrun_context_t *context, const char *id, int sign
 {
   int ret;
   const char *state_root = context->state_root;
-  cleanup_container_status libcrun_container_status_t status;
-
-  memset (&status, 0, sizeof (status));
+  cleanup_container_status libcrun_container_status_t status = {};
 
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
@@ -1920,9 +1914,8 @@ libcrun_container_start (libcrun_context_t *context, const char *id, libcrun_err
   int ret;
   cleanup_close int fd = -1;
   const char *state_root = context->state_root;
-  libcrun_container_status_t status;
+  libcrun_container_status_t status = {};
 
-  memset (&status, 0, sizeof (status));
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
     return ret;
@@ -2033,7 +2026,7 @@ libcrun_get_container_state_string (const char *id, libcrun_container_status_t *
 int
 libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, libcrun_error_t *err)
 {
-  libcrun_container_status_t status;
+  libcrun_container_status_t status = {};
   const char *state_root = context->state_root;
   const char *container_status = NULL;
   yajl_gen gen = NULL;
@@ -2042,7 +2035,6 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
   int running;
   size_t len;
 
-  memset (&status, 0, sizeof (status));
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
     return ret;
@@ -2133,7 +2125,7 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
 {
   int ret;
   pid_t pid;
-  libcrun_container_status_t status;
+  libcrun_container_status_t status = {};
   const char *state_root = context->state_root;
   cleanup_close int terminal_fd = -1;
   cleanup_close int seccomp_fd = -1;
@@ -2147,7 +2139,6 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
   cleanup_close int pipefd1 = -1;
   char b;
 
-  memset (&status, 0, sizeof (status));
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
     return ret;
@@ -2438,10 +2429,9 @@ int
 libcrun_container_update (libcrun_context_t *context, const char *id, const char *content, size_t len, libcrun_error_t *err)
 {
   int ret;
-  libcrun_container_status_t status;
+  libcrun_container_status_t status = {};
   const char *state_root = context->state_root;
 
-  memset (&status, 0, sizeof (status));
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
     return ret;
@@ -2460,9 +2450,8 @@ libcrun_container_pause (libcrun_context_t *context, const char *id, libcrun_err
 {
   int ret;
   const char *state_root = context->state_root;
-  libcrun_container_status_t status;
+  libcrun_container_status_t status = {};
 
-  memset (&status, 0, sizeof (status));
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
     return ret;
@@ -2481,9 +2470,8 @@ libcrun_container_unpause (libcrun_context_t *context, const char *id, libcrun_e
 {
   int ret;
   const char *state_root = context->state_root;
-  libcrun_container_status_t status;
+  libcrun_container_status_t status = {};
 
-  memset (&status, 0, sizeof (status));
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
     return ret;
@@ -2504,10 +2492,9 @@ libcrun_container_checkpoint (libcrun_context_t *context, const char *id,
 {
   int ret;
   const char *state_root = context->state_root;
-  libcrun_container_status_t status;
+  libcrun_container_status_t status = {};
   cleanup_free libcrun_container_t *container = NULL;
 
-  memset (&status, 0, sizeof (status));
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
     return ret;
@@ -2541,7 +2528,7 @@ libcrun_container_restore (libcrun_context_t *context, const char *id,
   cleanup_free libcrun_container_t *container = NULL;
   runtime_spec_schema_config_schema *def;
   cleanup_free char *cgroup_path = NULL;
-  libcrun_container_status_t status;
+  libcrun_container_status_t status = {};
   int cgroup_mode, cgroup_manager;
   cleanup_free char *scope = NULL;
   uid_t root_uid = -1;
@@ -2571,7 +2558,6 @@ libcrun_container_restore (libcrun_context_t *context, const char *id,
     return ret;
 
   /* The CRIU restore code uses bundle and rootfs of status. */
-  memset (&status, 0, sizeof (status));
   status.bundle = xstrdup(context->bundle);
   status.rootfs = xstrdup (def->root->path);
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -96,8 +96,7 @@ get_private_data (struct libcrun_container_s *container)
 {
   if (container->private_data == NULL)
     {
-      struct private_data_s *p = xmalloc (sizeof (*p));
-      memset (p, 0, sizeof (*p));
+      struct private_data_s *p = xmalloc0 (sizeof (*p));
       container->private_data = p;
       p->rootfsfd = -1;
     }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2122,9 +2122,8 @@ int
 libcrun_set_caps (runtime_spec_schema_config_schema_process_capabilities *capabilities, uid_t uid, gid_t gid, int no_new_privileges, libcrun_error_t *err)
 {
   int ret;
-  struct all_caps_s caps;
+  struct all_caps_s caps = {};
 
-  memset (&caps, 0, sizeof (caps));
   if (capabilities)
     {
       ret = read_caps (caps.effective,

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -253,9 +253,7 @@ libcrun_generate_seccomp (libcrun_container_t *container, int outfd, unsigned in
               size_t k;
               struct scmp_arg_cmp arg_cmp[6];
               bool multiple_args = false;
-              uint32_t count[6];
-
-              memset (count, 0, sizeof (count));
+              uint32_t count[6] = {};
 
               for (k = 0; k < seccomp->syscalls[i]->args_len && k < 6; k++)
                 {

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -857,13 +857,12 @@ read_all_file (const char *path, char **out, size_t *len, libcrun_error_t *err)
 int
 open_unix_domain_client_socket (const char *path, int dgram, libcrun_error_t *err)
 {
-  struct sockaddr_un addr;
+  struct sockaddr_un addr = {};
   int ret;
   cleanup_close int fd = socket (AF_UNIX, dgram ? SOCK_DGRAM : SOCK_STREAM, 0);
   if (UNLIKELY (fd < 0))
     return crun_make_error (err, errno, "error creating UNIX socket");
 
-  memset (&addr, 0, sizeof (addr));
   if (strlen (path) >= sizeof (addr.sun_path))
     return crun_make_error (err, 0, "invalid path %s specified", path);
   strcpy (addr.sun_path, path);
@@ -881,13 +880,12 @@ open_unix_domain_client_socket (const char *path, int dgram, libcrun_error_t *er
 int
 open_unix_domain_socket (const char *path, int dgram, libcrun_error_t *err)
 {
-  struct sockaddr_un addr;
+  struct sockaddr_un addr = {};
   int ret;
   cleanup_close int fd = socket (AF_UNIX, dgram ? SOCK_DGRAM : SOCK_STREAM, 0);
   if (UNLIKELY (fd < 0))
     return crun_make_error (err, errno, "error creating UNIX socket");
 
-  memset (&addr, 0, sizeof (addr));
   if (strlen (path) >= sizeof (addr.sun_path))
     return crun_make_error (err, 0, "invalid path %s specified", path);
   strcpy (addr.sun_path, path);
@@ -915,12 +913,9 @@ send_fd_to_socket (int server, int fd, libcrun_error_t *err)
   int ret;
   struct cmsghdr *cmsg = NULL;
   struct iovec iov[1];
-  struct msghdr msg;
-  char ctrl_buf[CMSG_SPACE (sizeof (int))];
+  struct msghdr msg = {};
+  char ctrl_buf[CMSG_SPACE (sizeof (int))] = {};
   char data[1];
-
-  memset (&msg, 0, sizeof (struct msghdr));
-  memset (ctrl_buf, 0, CMSG_SPACE (sizeof (int)));
 
   data[0] = ' ';
   iov[0].iov_base = data;
@@ -952,13 +947,10 @@ receive_fd_from_socket (int from, libcrun_error_t *err)
   cleanup_close int fd = -1;
   int ret;
   struct iovec iov[1];
-  struct msghdr msg;
-  char ctrl_buf[CMSG_SPACE (sizeof (int))];
+  struct msghdr msg = {};
+  char ctrl_buf[CMSG_SPACE (sizeof (int))] = {};
   char data[1];
   struct cmsghdr *cmsg;
-
-  memset (&msg, 0, sizeof (struct msghdr));
-  memset (ctrl_buf, 0, CMSG_SPACE (sizeof (int)));
 
   data[0] = ' ';
   iov[0].iov_base = data;

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -131,6 +131,14 @@ xmalloc (size_t size)
 }
 
 void *
+xmalloc0 (size_t size)
+{
+  void *res = xmalloc (size);
+  memset (res, 0, size);
+  return res;
+}
+
+void *
 xrealloc (void *ptr, size_t size)
 {
   void *res = realloc (ptr, size);

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -56,6 +56,8 @@ int close_and_reset (int *fd);
 
 void *xmalloc (size_t size);
 
+void *xmalloc0 (size_t size);
+
 void *xrealloc (void *ptr, size_t size);
 
 char *xstrdup (const char *str);

--- a/tests/init.c
+++ b/tests/init.c
@@ -172,10 +172,9 @@ int main (int argc, char **argv)
 
   if (strcmp (argv[1], "gethostname") == 0)
     {
-      char buffer[64];
+      char buffer[64] = {};
       int ret;
 
-      memset (buffer, 0, sizeof (buffer));
       ret = gethostname (buffer, sizeof (buffer) - 1);
       if (ret < 0)
         error (EXIT_FAILURE, errno, "gethostname");


### PR DESCRIPTION
1. Use C99-style zero init (` = {};`) instead of memset where appropriate.
2. Introduce and use `xmalloc0` which is xmalloc + bzero