### PR TITLE
tests: use podman v1.9 instead of master

### DIFF
--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y golang python git gcc automake autoconf libcap-devel \
     go get github.com/onsi/gomega/... && \
     mkdir -p /root/go/src/github.com/containers && \
     chmod 755 /root && \
-    (cd /root/go/src/github.com/containers && git clone https://github.com/containers/libpod && \
+    (cd /root/go/src/github.com/containers && git clone -b v1.9 https://github.com/containers/libpod && \
      cd libpod && \
      make install.catatonit && \
      make)


### PR DESCRIPTION
tests on master are broken at the moment, so let's use v1.9 for now.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>