### PR TITLE
seccomp.c: define seccomp macros when not already defined

### DIFF
--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -41,6 +41,22 @@
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 
+#ifndef __NR_seccomp
+# define __NR_seccomp 0xffff //seccomp syscall number unknown for this architecture
+#endif
+
+#ifndef SECCOMP_SET_MODE_STRICT
+# define SECCOMP_SET_MODE_STRICT 0
+#endif
+
+#ifndef SECCOMP_SET_MODE_FILTER
+# define SECCOMP_SET_MODE_FILTER 1
+#endif
+
+#ifndef SECCOMP_FILTER_FLAG_TSYNC
+# define SECCOMP_FILTER_FLAG_TSYNC (1UL << 0)
+#endif
+
 #ifndef SECCOMP_FILTER_FLAG_LOG
 # define SECCOMP_FILTER_FLAG_LOG (1UL << 1)
 #endif


### PR DESCRIPTION
Fixes the following errors:

> src/libcrun/seccomp.c: In function 'syscall_seccomp':
> src/libcrun/seccomp.c:55:25: error: '__NR_seccomp' undeclared (first use in this function)
>    return (int) syscall (__NR_seccomp, operation, flags, args);
>                          ^
> src/libcrun/seccomp.c:55:25: note: each undeclared identifier is reported only once for each function it appears in
> src/libcrun/seccomp.c: In function 'libcrun_apply_seccomp':
> src/libcrun/seccomp.c:142:24: error: 'SECCOMP_FILTER_FLAG_TSYNC' undeclared (first use in this function)
>                flags |= SECCOMP_FILTER_FLAG_TSYNC;
>                         ^
> src/libcrun/seccomp.c:159:26: error: 'SECCOMP_SET_MODE_FILTER' undeclared (first use in this function)
>    ret = syscall_seccomp (SECCOMP_SET_MODE_FILTER, flags, &seccomp_filter);
>                           ^
