### PR TITLE
utils: use calloc instead of malloc+memset

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -133,8 +133,9 @@ xmalloc (size_t size)
 void *
 xmalloc0 (size_t size)
 {
-  void *res = xmalloc (size);
-  memset (res, 0, size);
+  void *res = calloc (1, size);
+  if (UNLIKELY (res == NULL))
+    OOM ();
   return res;
 }
 


### PR DESCRIPTION
it is usually faster.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>