### PR TITLE
criu: fix different signedness comparison

### DIFF
--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -280,8 +280,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status,
 
     if (tree && YAJL_IS_ARRAY (tree))
       {
-        size_t len = tree->u.array.len;
-        int i;
+        size_t i, len = tree->u.array.len;
 
         /* len will probably always be 3 as crun is currently only
          * recording the destination of FD 0, 1 and 2. */


### PR DESCRIPTION
reported by gcc:

src/libcrun/criu.c:288:23: warning: comparison of integer expressions
  of different signedness: 'int' and 'size_t' {aka 'long unsigned
  int'} [-Wsign-compare]
  288 |         for (i = 0; i < len; ++i)

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>