### PR TITLE
cgroup: use systemd scope if it already exists

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -1088,9 +1088,13 @@ int enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *reso
     }
 
   sd_err = sd_bus_call (bus, m, 0, &error, &reply);
-  if (UNLIKELY (sd_err < 0))
+  if (UNLIKELY (sd_err < 0  && sd_err != EEXIST))
     {
-      ret = crun_make_error (err, sd_bus_error_get_errno (&error), "sd-bus call");
+      errno = sd_bus_error_get_errno (&error);
+      if (errno == EEXIST)
+        return 0;
+
+      ret = crun_make_error (err, errno, "sd-bus call");
       goto exit;
     }
 


### PR DESCRIPTION
if the scope already exists, do not fail with an error.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>