### PR TITLE
container: allow hooks output to file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - run: sudo apt-get update
     - run: sudo apt-get install -y make git gcc build-essential pkgconf libtool libsystemd-dev libcap-dev libseccomp-dev libyajl-dev  go-md2man libtool autoconf python3 automake
     - run: sudo RUNTIME=docker SKIP_CHECKS=1 SKIP_GPG=1 build-aux/release.sh
     - run: |

--- a/crun.1.md
+++ b/crun.1.md
@@ -331,6 +331,21 @@ e.g.
 /sys/fs/cgroup//system.slice/foo-352700.scope/container
 ```
 
+## `run.oci.hooks.stdout=FILE`
+
+If the annotation `run.oci.hooks.stdout` is present, then crun
+will open the specified file and use it as the stdout for the hook
+processes.  The file is opened in append mode and it is created if it
+doesn't already exist.
+
+## `run.oci.hooks.stderr=FILE`
+
+If the annotation `run.oci.hooks.stderr` is present, then crun
+will open the specified file and use it as the stderr for the hook
+processes.  The file is opened in append mode and it is created if it
+doesn't already exist.
+
+
 ## tmpcopyup mount options
 
 If the `tmpcopyup` option is specified for a tmpfs, then the path that

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -481,8 +481,14 @@ initialize_security (runtime_spec_schema_config_schema_process *proc, libcrun_er
 }
 
 static int
-do_hooks (runtime_spec_schema_config_schema *def, pid_t pid, const char *id, bool keep_going, const char *rootfs,
-          const char *cwd, const char *status, hook **hooks, size_t hooks_len,
+do_hooks (runtime_spec_schema_config_schema *def,
+          pid_t pid,
+          const char *id,
+          bool keep_going,
+          const char *cwd,
+          const char *status,
+          hook **hooks,
+          size_t hooks_len,
           libcrun_error_t *err)
 {
   size_t i, stdin_len;
@@ -490,6 +496,7 @@ do_hooks (runtime_spec_schema_config_schema *def, pid_t pid, const char *id, boo
   cleanup_free char *stdin = NULL;
   const unsigned char *annotations = (const unsigned char *) "{}";
   cleanup_free char *cwd_allocated = NULL;
+  const char *rootfs = def->root ? def->root->path : "";
   yajl_gen gen = NULL;
 
   if (cwd == NULL)
@@ -612,7 +619,7 @@ container_init_setup (void *args, const char *notify_socket,
 
   if (def->hooks && def->hooks->create_container_len)
     {
-      ret = do_hooks (def, 0, container->context->id, false, def->root->path, NULL, "created",
+      ret = do_hooks (def, 0, container->context->id, false, NULL, "created",
                       (hook **) def->hooks->create_container,
                       def->hooks->create_container_len, err);
       if (UNLIKELY (ret != 0))
@@ -847,7 +854,7 @@ container_init (void *args, const char *notify_socket, int sync_socket,
     {
       libcrun_container_t *container = entrypoint_args->container;
 
-      ret = do_hooks (def, 0, container->context->id, false, def->root->path, NULL, "starting",
+      ret = do_hooks (def, 0, container->context->id, false, NULL, "starting",
                       (hook **) def->hooks->start_container,
                       def->hooks->start_container_len, err);
       if (UNLIKELY (ret != 0))
@@ -901,7 +908,7 @@ run_poststop_hooks (libcrun_context_t *context, runtime_spec_schema_config_schem
 
   if (def->hooks && def->hooks->poststop_len)
     {
-      ret = do_hooks (def, 0, id, true, def->root->path, status->bundle,
+      ret = do_hooks (def, 0, id, true, status->bundle,
                       "stopped", (hook **) def->hooks->poststop,
                       def->hooks->poststop_len, err);
       if (UNLIKELY (ret < 0))
@@ -1591,7 +1598,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
      prestart hooks.  */
   if (def->hooks && def->hooks->prestart_len)
     {
-      ret = do_hooks (def, pid, context->id, false, def->root->path, NULL, "created",
+      ret = do_hooks (def, pid, context->id, false, NULL, "created",
                       (hook **) def->hooks->prestart,
                       def->hooks->prestart_len, err);
       if (UNLIKELY (ret != 0))
@@ -1602,7 +1609,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
     }
   if (def->hooks && def->hooks->create_runtime_len)
     {
-      ret = do_hooks (def, pid, context->id, false, def->root->path, NULL, "created",
+      ret = do_hooks (def, pid, context->id, false, NULL, "created",
                       (hook **) def->hooks->create_runtime,
                       def->hooks->create_runtime_len, err);
       if (UNLIKELY (ret != 0))
@@ -1662,7 +1669,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
   if (def->hooks && def->hooks->poststart_len)
     {
-      ret = do_hooks (def, pid, context->id, true, def->root->path, NULL, "running",
+      ret = do_hooks (def, pid, context->id, true, NULL, "running",
                       (hook **) def->hooks->poststart,
                       def->hooks->poststart_len, err);
       if (UNLIKELY (ret < 0))

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -124,7 +124,7 @@ int run_process (char **args, libcrun_error_t *err);
 
 size_t format_default_id_mapping (char **ret, uid_t container_id, uid_t host_id, int is_uid);
 
-int run_process_with_stdin_timeout_envp (char *path, char **args, const char *cwd, int timeout, char **envp, char *stdin, size_t stdin_len, libcrun_error_t *err);
+int run_process_with_stdin_timeout_envp (char *path, char **args, const char *cwd, int timeout, char **envp, char *stdin, size_t stdin_len, int out_fd, int err_fd, libcrun_error_t *err);
 
 int close_fds_ge_than (int n, libcrun_error_t *err);
 


### PR DESCRIPTION
support two custom annotations "run.oci.hooks.stdout" and "run.oci.hooks.stderr" that allow to specify the output for hook processes.

When the annotations are specified, the value is used as destination file for the hooks stdout and stderr.

The file is open in append mode and it is created if it doesn't exist.

Closes: https://github.com/containers/crun/issues/353
