### PR TITLE
 [openSUSE 15.1] Missing libseccomp headers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,8 +35,9 @@ libcrun_la_SOURCES = src/libcrun/utils.c \
 			src/libcrun/chroot_realpath.c \
 			src/libcrun/signals.c
 
-libcrun_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src
-libcrun_la_LIBADD = libocispec/libocispec.la
+libcrun_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(SECCOMP_CFLAGS)
+
+libcrun_la_LIBADD = libocispec/libocispec.la $(SECCOMP_LIBS)
 
 if PYTHON_BINDINGS
 pyexec_LTLIBRARIES = python_crun.la

--- a/configure.ac
+++ b/configure.ac
@@ -43,10 +43,13 @@ dnl libseccomp
 AC_ARG_ENABLE([seccomp],
 	AS_HELP_STRING([--disable-seccomp], [Ignore libseccomp and disable support]))
 AS_IF([test "x$enable_seccomp" != "xno"], [
-	AC_CHECK_HEADERS([seccomp.h], [], [AC_MSG_ERROR([*** Missing libseccomp headers])])
-	AS_IF([test "$ac_cv_header_seccomp_h" = "yes"], [
-		AC_SEARCH_LIBS(seccomp_rule_add, [seccomp], [AC_DEFINE([HAVE_SECCOMP], 1, [Define if seccomp is available])], [AC_MSG_ERROR([*** libseccomp headers not found])])
-		AC_SEARCH_LIBS(seccomp_arch_resolve_name, [seccomp], [AC_DEFINE([SECCOMP_ARCH_RESOLVE_NAME], 1, [Define if seccomp_arch_resolve_name is available])], [ ])
+	PKG_CHECK_MODULES([SECCOMP], [libseccomp], [], [
+		AC_CHECK_HEADERS([seccomp.h], [], [AC_MSG_ERROR([*** Missing libseccomp headers])])
+		AS_IF([test "$ac_cv_header_seccomp_h" = "yes"], [
+			AC_SEARCH_LIBS(seccomp_rule_add, [seccomp], [AC_DEFINE([HAVE_SECCOMP], 1, [Define if seccomp is available])], [AC_MSG_ERROR([*** libseccomp headers not found])])
+			AC_SEARCH_LIBS(seccomp_arch_resolve_name, [seccomp], [AC_DEFINE([SECCOMP_ARCH_RESOLVE_NAME], 1, [Define if seccomp_arch_resolve_name is available])], [ ])
+		])
+		AC_SUBST([SECCOMP_LIBS], [-lseccomp])
 	])
 ])
 


### PR DESCRIPTION
For openSUSE 15.1, `seccomp.h` is located as `/usr/include/libseccomp/seccomp.h` which could be fetched by `pkg-config --libs libseccomp` and `pkg-config --cflags libseccomp`.

This patch reference from https://build.opensuse.org/package/view_file/openSUSE:Factory/lxc/configure-find-seccomp-using-pkg-config.patch?rev=45, so inject the `pkg-config` result on-the-fly.

Fixes #358