### PR TITLE
cgroup2: try joining initial process cgroup

### DIFF
--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -56,7 +56,7 @@ int libcrun_cgroup_enter (struct libcrun_cgroup_args *args, libcrun_error_t *err
 int libcrun_cgroup_killall_signal (char *path, int signal, libcrun_error_t *err);
 int libcrun_cgroup_killall (char *path, libcrun_error_t *err);
 int libcrun_cgroup_destroy (const char *id, char *path, int manager, libcrun_error_t *err);
-int libcrun_move_process_to_cgroup (pid_t pid, char *path, libcrun_error_t *err);
+int libcrun_move_process_to_cgroup (pid_t pid, pid_t init_pid, char *path, libcrun_error_t *err);
 int libcrun_update_cgroup_resources (int cgroup_mode, runtime_spec_schema_config_linux_resources *resources,
                                      char *path, libcrun_error_t *err);
 int libcrun_cgroups_create_symlinks (int dirfd, libcrun_error_t *err);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2782,7 +2782,7 @@ join_process_parent_helper (pid_t child_pid,
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "waitpid for exec child pid");
 
-  ret = libcrun_move_process_to_cgroup (pid, status->cgroup_path, err);
+  ret = libcrun_move_process_to_cgroup (pid, status->pid, status->cgroup_path, err);
   if (UNLIKELY (ret < 0))
     return ret;
 


### PR DESCRIPTION
if we cannot join the initial container cgroup, then attempt to join
the initial container process cgroup.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>