### PR TITLE
Revert " [openSUSE 15.1] Missing libseccomp headers"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,9 +35,8 @@ libcrun_la_SOURCES = src/libcrun/utils.c \
 			src/libcrun/chroot_realpath.c \
 			src/libcrun/signals.c
 
-libcrun_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(SECCOMP_CFLAGS)
-
-libcrun_la_LIBADD = libocispec/libocispec.la $(SECCOMP_LIBS)
+libcrun_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src
+libcrun_la_LIBADD = libocispec/libocispec.la
 
 if PYTHON_BINDINGS
 pyexec_LTLIBRARIES = python_crun.la

--- a/configure.ac
+++ b/configure.ac
@@ -43,13 +43,10 @@ dnl libseccomp
 AC_ARG_ENABLE([seccomp],
 	AS_HELP_STRING([--disable-seccomp], [Ignore libseccomp and disable support]))
 AS_IF([test "x$enable_seccomp" != "xno"], [
-	PKG_CHECK_MODULES([SECCOMP], [libseccomp], [], [
-		AC_CHECK_HEADERS([seccomp.h], [], [AC_MSG_ERROR([*** Missing libseccomp headers])])
-		AS_IF([test "$ac_cv_header_seccomp_h" = "yes"], [
-			AC_SEARCH_LIBS(seccomp_rule_add, [seccomp], [AC_DEFINE([HAVE_SECCOMP], 1, [Define if seccomp is available])], [AC_MSG_ERROR([*** libseccomp headers not found])])
-			AC_SEARCH_LIBS(seccomp_arch_resolve_name, [seccomp], [AC_DEFINE([SECCOMP_ARCH_RESOLVE_NAME], 1, [Define if seccomp_arch_resolve_name is available])], [ ])
-		])
-		AC_SUBST([SECCOMP_LIBS], [-lseccomp])
+	AC_CHECK_HEADERS([seccomp.h], [], [AC_MSG_ERROR([*** Missing libseccomp headers])])
+	AS_IF([test "$ac_cv_header_seccomp_h" = "yes"], [
+		AC_SEARCH_LIBS(seccomp_rule_add, [seccomp], [AC_DEFINE([HAVE_SECCOMP], 1, [Define if seccomp is available])], [AC_MSG_ERROR([*** libseccomp headers not found])])
+		AC_SEARCH_LIBS(seccomp_arch_resolve_name, [seccomp], [AC_DEFINE([SECCOMP_ARCH_RESOLVE_NAME], 1, [Define if seccomp_arch_resolve_name is available])], [ ])
 	])
 ])
 


### PR DESCRIPTION
We do not use pkg-config any more for libseccomp to ensure less complex
build scenarios.

This reverts commit 3310cd26e3c40ad3c759d953d31de19468ca0d5e.

Ref https://github.com/containers/crun/pull/366