### PR TITLE
[master] Use `stdenv.mkDerivation` instead of `crun.overrideAttrs`

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -37,37 +37,33 @@ let
     enableStatic = true;
   });
 
-  self = with pkgs; {
-    crun-static = (crun.overrideAttrs(x: {
-      name = "crun-static";
-      src = ./..;
-      doCheck = false;
-      buildInputs = [
-        criu
-        glibc
-        glibc.static
-        libcap
-        libseccomp
-        systemd
-        yajl
-      ];
-      configureFlags = [ "--enable-static-nss" ];
-      prePatch = ''
-        export LDFLAGS="-static-libgcc -static"
-        export CRUN_LDFLAGS="-all-static"
-        export LIBS="\
-          ${criu}/lib/libcriu.a \
-          ${glibc.static}/lib/libc.a \
-          ${glibc.static}/lib/libpthread.a \
-          ${glibc.static}/lib/librt.a \
-          ${libcap.lib}/lib/libcap.a \
-          ${libseccomp.lib}/lib/libseccomp.a \
-          ${protobufc}/lib/libprotobuf-c.a \
-          ${protobuf}/lib/libprotobuf.a \
-          ${systemd.lib}/lib/libsystemd.a \
-          ${yajl}/lib/libyajl_s.a \
-        "
-      '';
-    }));
+  self = with pkgs; stdenv.mkDerivation rec {
+    name = "crun";
+    src = ./..;
+    doCheck = false;
+    enableParallelBuilding = true;
+    nativeBuildInputs = [ autoreconfHook go-md2man pkg-config python3 ];
+    buildInputs = [ criu glibc glibc.static libcap libseccomp systemd yajl ];
+    configureFlags = [ "--enable-static-nss" ];
+    prePatch = ''
+      export LDFLAGS="-static-libgcc -static -s -w"
+      export CRUN_LDFLAGS="-all-static"
+      export LIBS="\
+        ${criu}/lib/libcriu.a \
+        ${glibc.static}/lib/libc.a \
+        ${glibc.static}/lib/libpthread.a \
+        ${glibc.static}/lib/librt.a \
+        ${libcap.lib}/lib/libcap.a \
+        ${libseccomp.lib}/lib/libseccomp.a \
+        ${protobufc}/lib/libprotobuf-c.a \
+        ${protobuf}/lib/libprotobuf.a \
+        ${systemd.lib}/lib/libsystemd.a \
+        ${yajl}/lib/libyajl_s.a \
+      "
+    '';
+    postPatch = ''
+      cat Makefile | egrep '^VERSION = ' | sed 's/^VERSION = //g' > .tarball-version
+      echo "#define GIT_VERSION \"$(cat .tarball-version)\"" > git-version.h
+    '';
   };
 in self

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "1b5925f2189dc9b4ebf7168252bf89a94b7405ba",
-  "date": "2020-05-27T15:03:28+02:00",
-  "path": "/nix/store/qdsrj7hw9wzzng9l2kfbsyi9ynprrn6p-nixpkgs",
-  "sha256": "0q9plknr294k4bjfqvgvp5vglfby5yn64k6ml0gqwi0dwf0qi6fv",
+  "rev": "0f114432d4a9399e0b225d5be1599c7ebc5e2772",
+  "date": "2020-05-29T19:54:08-05:00",
+  "path": "/nix/store/ds31sjj3ppsk0xclkficx9p3w6qslmdc-nixpkgs",
+  "sha256": "1qd2dlc5dk98y0xdahv9k72ibv5dsy10jg25xqvj38sadxbs3g0j",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
Using `crun.overrideAttrs` may result as broken due to nixpkgs upstream changes; replace with native `stdenv.mkDerivation` with complete definition could simply avoid this happening.

Changes based on https://github.com/NixOS/nixpkgs/blob/e469b77/pkgs/applications/virtualization/crun/default.nix; also fix `postPath` for `crun --version`, e.g.

```
crun version 0.13.147-e3f4-dirty
commit: 0.13.147-e3f4-dirty
spec: 1.0.0
+SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +YAJL
```

Signed-off-by: Wong Hoi Sing Edison <hswong3i@gmail.com>