### PR TITLE
[nix] Use `stdenv.mkDerivation` instead of `crun.overrideAttrs`

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,6 +3,7 @@ let
   pkgs = (import ./nixpkgs.nix {
     config = {
       packageOverrides = pkg: {
+        criu = (static pkg.criu);
         libseccomp = (static pkg.libseccomp);
         protobufc = (static pkg.protobufc);
         libcap = (static pkg.libcap).overrideAttrs(x: {
@@ -13,16 +14,16 @@ let
             mv "$lib"/lib/security "$pam/lib"
           '';
         });
-        yajl = (static pkg.yajl).overrideAttrs(x: {
-          preConfigure = ''
-            export CMAKE_STATIC_LINKER_FLAGS="-static"
-          '';
-        });
         systemd = pkg.systemd.overrideAttrs(x: {
           mesonFlags = x.mesonFlags ++ [ "-Dstatic-libsystemd=true" ];
           postFixup = ''
             ${x.postFixup}
             sed -ri "s;$out/(.*);$nukedRef/\1;g" $lib/lib/libsystemd.a
+          '';
+        });
+        yajl = (static pkg.yajl).overrideAttrs(x: {
+          preConfigure = ''
+            export CMAKE_STATIC_LINKER_FLAGS="-static"
           '';
         });
       };
@@ -37,37 +38,18 @@ let
     enableStatic = true;
   });
 
-  self = with pkgs; {
-    crun-static = (crun.overrideAttrs(x: {
-      name = "crun-static";
-      src = ./..;
-      doCheck = false;
-      buildInputs = [
-        criu
-        glibc
-        glibc.static
-        libcap
-        libseccomp
-        systemd
-        yajl
-      ];
-      configureFlags = [ "--enable-static-nss" ];
-      prePatch = ''
-        export LDFLAGS="-static-libgcc -static"
-        export CRUN_LDFLAGS="-all-static"
-        export LIBS="\
-          ${criu}/lib/libcriu.a \
-          ${glibc.static}/lib/libc.a \
-          ${glibc.static}/lib/libpthread.a \
-          ${glibc.static}/lib/librt.a \
-          ${libcap.lib}/lib/libcap.a \
-          ${libseccomp.lib}/lib/libseccomp.a \
-          ${protobufc}/lib/libprotobuf-c.a \
-          ${protobuf}/lib/libprotobuf.a \
-          ${systemd.lib}/lib/libsystemd.a \
-          ${yajl}/lib/libyajl_s.a \
-        "
-      '';
-    }));
+  self = with pkgs; stdenv.mkDerivation rec {
+    name = "crun";
+    src = ./..;
+    doCheck = false;
+    enableParallelBuilding = true;
+    nativeBuildInputs = [ autoreconfHook git go-md2man pkg-config python3 ];
+    buildInputs = [ criu glibc glibc.static libcap libseccomp protobufc systemd yajl ];
+    prePatch = ''
+      export LDFLAGS='-static-libgcc -static -s -w'
+      export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
+      export CRUN_LDFLAGS='-all-static'
+      export LIBS='${criu}/lib/libcriu.a ${glibc.static}/lib/libc.a ${glibc.static}/lib/libpthread.a ${glibc.static}/lib/librt.a ${libcap.lib}/lib/libcap.a ${libseccomp.lib}/lib/libseccomp.a ${protobufc}/lib/libprotobuf-c.a ${protobuf}/lib/libprotobuf.a ${systemd.lib}/lib/libsystemd.a ${yajl}/lib/libyajl_s.a'
+    '';
   };
 in self

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "1b5925f2189dc9b4ebf7168252bf89a94b7405ba",
-  "date": "2020-05-27T15:03:28+02:00",
-  "path": "/nix/store/qdsrj7hw9wzzng9l2kfbsyi9ynprrn6p-nixpkgs",
-  "sha256": "0q9plknr294k4bjfqvgvp5vglfby5yn64k6ml0gqwi0dwf0qi6fv",
+  "rev": "0f114432d4a9399e0b225d5be1599c7ebc5e2772",
+  "date": "2020-05-29T19:54:08-05:00",
+  "path": "/nix/store/ds31sjj3ppsk0xclkficx9p3w6qslmdc-nixpkgs",
+  "sha256": "1qd2dlc5dk98y0xdahv9k72ibv5dsy10jg25xqvj38sadxbs3g0j",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
Using `crun.overrideAttrs` may result as broken due to nixpkgs upstream changes; replace with native `stdenv.mkDerivation` with complete definition could simply avoid this happening.

Changes based on https://github.com/NixOS/nixpkgs/blob/e469b77/pkgs/applications/virtualization/crun/default.nix; also fix `crun --version` with correct version and commit, e.g.

```
crun version 0.13.1-5077
commit: 50777c63f2b44f2426b81e20bb9876a9349cdeb6
spec: 1.0.0
+SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +YAJL
```

Fixes #380

Signed-off-by: Wong Hoi Sing Edison <hswong3i@gmail.com>
