### PR TITLE
cgroup: ignore cpu resources if set to 0

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -2326,7 +2326,7 @@ write_cpu_resources (int dirfd_cpu, bool cgroup2, runtime_spec_schema_config_lin
       /* convert linearly from 2-262144 to 1-10000.  */
 #define CONVERT_SHARES_TO_CGROUPS_V2(x) (1 + (((x) - 2) * 9999) / 262142)
 
-  if (cpu->shares_present)
+  if (cpu->shares)
     {
       uint32_t val = cpu->shares;
 
@@ -2339,7 +2339,7 @@ write_cpu_resources (int dirfd_cpu, bool cgroup2, runtime_spec_schema_config_lin
       if (UNLIKELY (ret < 0))
         return ret;
     }
-  if (cpu->period_present)
+  if (cpu->period)
     {
       if (cgroup2)
         period = cpu->period;
@@ -2363,7 +2363,7 @@ write_cpu_resources (int dirfd_cpu, bool cgroup2, runtime_spec_schema_config_lin
             return ret;
         }
     }
-  if (cpu->realtime_period_present)
+  if (cpu->realtime_period)
     {
       if (cgroup2)
         return crun_make_error (err, 0, "realtime period not supported on cgroupv2");
@@ -2372,7 +2372,7 @@ write_cpu_resources (int dirfd_cpu, bool cgroup2, runtime_spec_schema_config_lin
       if (UNLIKELY (ret < 0))
         return ret;
     }
-  if (cpu->realtime_runtime_present)
+  if (cpu->realtime_runtime)
     {
       if (cgroup2)
         return crun_make_error (err, 0, "realtime runtime not supported on cgroupv2");


### PR DESCRIPTION
Docker sets the value to 0 when the setting is not specified.

partially revert 65f93d4203442b4707981c8c4f0a82ad9032704f

Closes: https://github.com/containers/crun/issues/383

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>