### PR TITLE
status: use yajl to write the status file

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1874,3 +1874,26 @@ find_annotation (libcrun_container_t *container, const char *name)
 
   return NULL;
 }
+
+ssize_t
+safe_write (int fd, const void *buf, ssize_t count)
+{
+  ssize_t written = 0;
+  if (count < 0)
+    {
+      errno = EINVAL;
+      return -1;
+    }
+  while (written < count)
+    {
+      ssize_t w = write (fd, buf + written, count - written);
+      if (UNLIKELY (w < 0))
+        {
+          if (errno == EINTR || errno == EAGAIN)
+            continue;
+          return w;
+        }
+      written += w;
+    }
+  return written;
+}

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -158,4 +158,6 @@ int str2sig (const char *name);
 
 int safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *path, int flags, int mode, libcrun_error_t *err);
 
+ssize_t safe_write (int fd, const void *buf, ssize_t count);
+
 #endif


### PR DESCRIPTION
use the libyajl library to write the JSON status file instead of
directly writing it.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>