### PR TITLE
Define fgetpwent_r if it does not exist

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -676,7 +676,10 @@ container_init_setup (void *args, const char *notify_socket,
     {
       ret = set_home_env (container->container_uid);
       if (UNLIKELY (ret < 0 && errno != ENOTSUP))
-        libcrun_warning ("cannot set HOME environment variable");
+        {
+          setenv("HOME", "/", 1);
+          libcrun_warning ("cannot detect HOME environment variable, setting default");
+        }
     }
 
   if (def->process && def->process->cwd)
@@ -2323,7 +2326,10 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
         {
           ret = set_home_env (container->container_uid);
           if (UNLIKELY (ret < 0 && errno != ENOTSUP))
-            libcrun_warning ("cannot set HOME environment variable");
+            {
+              setenv("HOME", "/", 1);
+              libcrun_warning ("cannot detect HOME environment variable, setting default");
+            }
         }
 
       /* If the new process block doesn't specify a SELinux label or AppArmor profile, then

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1107,52 +1107,63 @@ run_process (char **args, libcrun_error_t *err)
 }
 
 #ifndef HAVE_FGETPWENT_R
-static unsigned atou(char **s)
+static unsigned
+atou(char **s)
 {
-	unsigned x;
-	for (x=0; **s-'0'<10U; ++*s) x=10*x+(**s-'0');
-	return x;
+  unsigned x;
+  for (x = 0; **s - '0' < 10; ++*s)
+    x = 10 * x + (**s-'0');
+  return x;
 }
 
-int fgetpwent_r(FILE *f, struct passwd *pw, char *line, size_t size, struct passwd **res)
+int
+fgetpwent_r(FILE *f, struct passwd *pw, char *line, size_t size, struct passwd **res)
 {
-	char *s;
-	int rv = 0;
-	for (;;) {
-		line[size-1] = '\xff';
-		if ( (fgets(line, size, f) == NULL) || ferror(f) || line[size-1] != '\xff' ) {
-			rv = (line[size-1] != '\xff') ? ERANGE : ENOENT;
-			line = 0;
-			pw = 0;
-			break;
-		}
-		line[strcspn(line, "\n")] = 0;
+  char *s;
+  int rv = 0;
+  for (;;)
+    {
+      line[size-1] = '\xff';
+      if ( (fgets(line, size, f) == NULL) || ferror(f) || line[size-1] != '\xff' ) {
+        rv = (line[size-1] != '\xff') ? ERANGE : ENOENT;
+        line = 0;
+        pw = 0;
+        break;
+      }
+    line[strcspn(line, "\n")] = 0;
 
-		s = line;
-		pw->pw_name = s++;
-		if (!(s = strchr(s, ':'))) continue;
+    s = line;
+    pw->pw_name = s++;
+    if (!(s = strchr(s, ':')))
+      continue;
 
-		*s++ = 0; pw->pw_passwd = s;
-		if (!(s = strchr(s, ':'))) continue;
+    *s++ = 0; pw->pw_passwd = s;
+    if (!(s = strchr(s, ':')))
+      continue;
 
-		*s++ = 0; pw->pw_uid = atou(&s);
-		if (*s != ':') continue;
+    *s++ = 0; pw->pw_uid = atou(&s);
+    if (*s != ':')
+      continue;
 
-		*s++ = 0; pw->pw_gid = atou(&s);
-		if (*s != ':') continue;
+    *s++ = 0; pw->pw_gid = atou(&s);
+    if (*s != ':')
+      continue;
 
-		*s++ = 0; pw->pw_gecos = s;
-		if (!(s = strchr(s, ':'))) continue;
+    *s++ = 0; pw->pw_gecos = s;
+    if (!(s = strchr(s, ':')))
+      continue;
 
-		*s++ = 0; pw->pw_dir = s;
-		if (!(s = strchr(s, ':'))) continue;
+    *s++ = 0; pw->pw_dir = s;
+    if (!(s = strchr(s, ':')))
+      continue;
 
-		*s++ = 0; pw->pw_shell = s;
-		break;
-	}
-	*res = pw;
-	if (rv) errno = rv;
-	return rv;
+    *s++ = 0; pw->pw_shell = s;
+    break;
+  }
+  *res = pw;
+  if (rv)
+    errno = rv;
+  return rv;
 }
 #endif
 


### PR DESCRIPTION
On non-glibc systems crun struggles to set the HOME environment
variable, which can lead to application failures, specifcally Git inside
of CI systems. This change defines fgetpwnent_r on systems that need it,
and will set HOME to / in the event that all other options failed.