### PR TITLE
exec: drop additional groups if not specified

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2343,14 +2343,9 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
           close_and_reset (&seccomp_fd);
         }
 
-      if (process->user && process->user->additional_gids_len)
-        {
-          gid_t *additional_gids = process->user->additional_gids;
-          size_t additional_gids_len = process->user->additional_gids_len;
-          ret = setgroups (additional_gids_len, additional_gids);
-          if (UNLIKELY (ret < 0))
-            libcrun_fail_with_error (errno, "%s", "setgroups %d groups", process->user->additional_gids_len);
-        }
+      ret = libcrun_container_setgroups (container, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
 
       if (process->capabilities)
         capabilities = process->capabilities;

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -72,4 +72,5 @@ int libcrun_container_restore_linux (libcrun_container_status_t *status,
 
 int libcrun_find_namespace (const char *name);
 char *libcrun_get_external_descriptors (libcrun_container_t *container);
+int libcrun_container_setgroups (libcrun_container_t *container, libcrun_error_t *err);
 #endif


### PR DESCRIPTION
if the config file does't specify any, make sure to drop any
additional group.

Closes: https://github.com/containers/crun/issues/394

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>