### PR TITLE
linux: handle join of a different pid/ipc namespace

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,17 @@ AS_IF([test "x$enable_criu" != "xno"], [
 FOUND_LIBS=$LIBS
 LIBS=""
 
+dnl mount API
+AC_COMPILE_IFELSE(
+	[AC_LANG_SOURCE([[
+			#include <linux/mount.h>
+			int cmd = FSCONFIG_CMD_CREATE;
+		]])],
+		[AC_MSG_RESULT(yes)
+		 AC_DEFINE([HAVE_FSCONFIG_CMD_CREATE], 1, [Define if FSCONFIG_CMD_CREATE is available])],
+		[AC_MSG_RESULT(no)])
+
+
 AC_SUBST([FOUND_LIBS])
 AC_SUBST([CRUN_LDFLAGS])
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2934,6 +2934,10 @@ libcrun_run_linux_container (libcrun_container_t *container,
           ret = TEMP_FAILURE_RETRY (read (sync_socket_host, &grandchild, sizeof (grandchild)));
           if (UNLIKELY (ret < 0))
             return crun_make_error (err, errno, "read pid from sync socket");
+
+          /* Cleanup the first process.  */
+          if (! detach)
+            waitpid (pid, NULL, 0);
         }
 
       *sync_socket_out = get_and_reset (&sync_socket_host);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -465,12 +465,15 @@ do_mount (libcrun_container_t *container,
               if (UNLIKELY (ret < 0))
                 return ret;
 
-              ret = mount ("/sys", to, "/sys", MS_BIND | MS_REC | MS_SLAVE, data);
-              if (LIKELY (ret == 0))
-                return 0;
+              if (ret > 0)
+                {
+                  ret = mount ("/sys", to, "/sys", MS_BIND | MS_REC | MS_SLAVE, data);
+                  if (LIKELY (ret == 0))
+                    return 0;
+                }
             }
 
-          return crun_make_error (err, saved_errno, "mount `%s` to '%s'", source, target);
+          return crun_make_error (err, saved_errno, "mount `%s` to '/%s'", source, target);
         }
 
       if ((flags & MS_BIND) && (flags & ~(MS_BIND | MS_RDONLY | ALL_PROPAGATIONS)))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -121,7 +121,7 @@ static struct linux_namespace_s namespaces[] =
    {"uts", "uts", CLONE_NEWUTS},
    {"user", "user", CLONE_NEWUSER},
 #ifdef CLONE_NEWCGROUP
-   {"cgroup", "cgroup",CLONE_NEWCGROUP},
+   {"cgroup", "cgroup", CLONE_NEWCGROUP},
 #endif
 #ifdef CLONE_NEWTIME
    {"time", "time", CLONE_NEWTIME},
@@ -2589,6 +2589,7 @@ libcrun_run_linux_container (libcrun_container_t *container,
 #define MAX_NAMESPACES 10
   cleanup_close_vec int *namespaces_to_join = (int[MAX_NAMESPACES+1]){-1};
   int namespaces_to_join_index[MAX_NAMESPACES];
+  int namespaces_to_join_value[MAX_NAMESPACES];
   size_t n_namespaces_to_join = 0;
   int userns_join_index = -1;
   int userns_join_index_origin = -1;
@@ -2625,6 +2626,7 @@ libcrun_run_linux_container (libcrun_container_t *container,
 
           namespaces_to_join[n_namespaces_to_join] = fd;
           namespaces_to_join_index[n_namespaces_to_join] = i;
+          namespaces_to_join_value[n_namespaces_to_join] = value;
           n_namespaces_to_join++;
           namespaces_to_join[n_namespaces_to_join] = -1;
         }
@@ -2674,7 +2676,30 @@ libcrun_run_linux_container (libcrun_container_t *container,
       goto out;
 
   if (flags & CLONE_NEWPID)
-    must_fork = true;
+    {
+      must_fork = true;
+      for (i = 0; i < n_namespaces_to_join; i++)
+        {
+          if (namespaces_to_join_value[i] == CLONE_NEWPID)
+            {
+              if (setns (namespaces_to_join[i], CLONE_NEWPID) == 0)
+                {
+                  flags_unshare &= ~CLONE_NEWPID;
+                  must_fork = false;
+                  close_and_reset (&namespaces_to_join[i]);
+                }
+              break;
+            }
+        }
+      if (i == n_namespaces_to_join && (flags & CLONE_NEWUSER) == 0)
+        {
+          if (unshare (CLONE_NEWPID) == 0)
+            {
+              flags_unshare &= ~CLONE_NEWPID;
+              must_fork = false;
+            }
+        }
+    }
 #ifdef CLONE_NEWTIME
   if (flags & CLONE_NEWTIME)
     must_fork = true;


### PR DESCRIPTION
To do so, we need first to attempt joining the namespace, once that is done, the mque and proc file system are mounted using fsmount and then the user namespace is created.  The reference to the  namespaces is injected into the container.

Requires Linux 5.3+.

Closes: https://github.com/containers/crun/issues/396

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
