### PR TITLE
create: code cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,7 @@ AC_ARG_ENABLE([systemd],
 AS_IF([test "x$enable_systemd" != "xno"], [
 	AC_CHECK_HEADERS([systemd/sd-bus.h], [], [AC_MSG_ERROR([*** Missing libsystemd headers])])
 	AS_IF([test "$ac_cv_header_systemd_sd_bus_h" = "yes"], [
-		AC_SEARCH_LIBS(sd_listen_fds, [systemd], [AC_DEFINE([HAVE_SYSTEMD], 1, [Define if libsystemd is available])], [AC_MSG_ERROR([*** Failed to find libsystemd])])
+		AC_SEARCH_LIBS(sd_bus_match_signal_async, [systemd], [AC_DEFINE([HAVE_SYSTEMD], 1, [Define if libsystemd is available])], [AC_MSG_ERROR([*** Failed to find libsystemd])])
 	])
 ])
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1374,11 +1374,9 @@ flush_fd_to_err (libcrun_context_t *context, int terminal_fd)
 }
 
 static int
-cleanup_watch (libcrun_context_t *context, pid_t init_pid, runtime_spec_schema_config_schema *def, const char *id, int sync_socket, int terminal_fd, libcrun_error_t *err)
+cleanup_watch (libcrun_context_t *context, pid_t init_pid, int sync_socket, int terminal_fd, libcrun_error_t *err)
 {
   libcrun_error_t tmp_err = NULL;
-  container_delete_internal (context, def, id, 1, true, &tmp_err);
-  crun_error_release (&tmp_err);
 
   if (init_pid)
     kill (init_pid, SIGKILL);
@@ -1631,7 +1629,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
     ret = libcrun_cgroup_enter (&cg, err);
     if (UNLIKELY (ret < 0))
-      return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+      return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
 
     if (def->linux && def->linux->resources)
       {
@@ -1639,19 +1637,19 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
                                                def->linux->resources,
                                                cgroup_path, err);
         if (UNLIKELY (ret < 0))
-          return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+          return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
       }
   }
 
   /* sync 1.  */
   ret = sync_socket_send_sync (sync_socket, true, err);
   if (UNLIKELY (ret < 0))
-    return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+    return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
 
   /* sync 2.  */
   ret = sync_socket_wait_sync (context, sync_socket, false, err);
   if (UNLIKELY (ret < 0))
-    return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+    return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
 
   /* The container is waiting that we write back.  In this phase we can launch the
      prestart hooks.  */
@@ -1661,7 +1659,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
                       (hook **) def->hooks->prestart,
                       def->hooks->prestart_len, hooks_out_fd, hooks_err_fd, err);
       if (UNLIKELY (ret != 0))
-        return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+        return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
     }
   if (def->hooks && def->hooks->create_runtime_len)
     {
@@ -1669,7 +1667,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
                       (hook **) def->hooks->create_runtime,
                       def->hooks->create_runtime_len, hooks_out_fd, hooks_err_fd, err);
       if (UNLIKELY (ret != 0))
-        return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+        return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
     }
 
   if (seccomp_fd >= 0)
@@ -1683,41 +1681,41 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
       ret = libcrun_generate_seccomp (container, seccomp_fd, seccomp_gen_options, err);
       if (UNLIKELY (ret < 0))
-        return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+        return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
       close_and_reset (&seccomp_fd);
     }
 
   /* sync 3.  */
   ret = sync_socket_send_sync (sync_socket, true, err);
   if (UNLIKELY (ret < 0))
-    return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+    return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
 
   if (def->process && def->process->terminal && !detach && context->console_socket == NULL)
     {
       terminal_fd = receive_fd_from_socket (socket_pair_0, err);
       if (UNLIKELY (terminal_fd < 0))
-        return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+        return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
 
       close_and_reset (&socket_pair_0);
 
       ret = libcrun_setup_terminal_master (terminal_fd, &orig_terminal, err);
       if (UNLIKELY (ret < 0))
-        return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+        return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
     }
 
   /* sync 4.  */
   ret = sync_socket_wait_sync (context, sync_socket, false, err);
   if (UNLIKELY (ret < 0))
-    return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+    return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
 
   ret = close_and_reset (&sync_socket);
   if (UNLIKELY (ret < 0))
-    return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+    return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
 
   get_current_timestamp (created);
   ret = write_container_status (container, context, pid, cgroup_path, scope, created, err);
   if (UNLIKELY (ret < 0))
-    return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+    return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
 
   if (def->hooks && def->hooks->poststart_len)
     {
@@ -1725,13 +1723,13 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
                       (hook **) def->hooks->poststart,
                       def->hooks->poststart_len, hooks_out_fd, hooks_err_fd, err);
       if (UNLIKELY (ret < 0))
-        return cleanup_watch (context, pid, def, context->id, sync_socket, terminal_fd, err);
+        return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
     }
 
   ret = wait_for_process (pid, context, terminal_fd, notify_socket, container_ready_fd, err);
   if (!context->detach)
     {
-      cleanup_watch (context, 0, def, context->id, sync_socket, terminal_fd, err);
+      cleanup_watch (context, 0, sync_socket, terminal_fd, err);
       crun_error_release (err);
     }
 
@@ -1778,6 +1776,14 @@ int libcrun_copy_config_file (const char *id, const char *state_root, const char
   return 0;
 }
 
+static void
+force_delete_container_status (libcrun_context_t *context, runtime_spec_schema_config_schema *def)
+{
+  libcrun_error_t tmp_err = NULL;
+  container_delete_internal (context, def, context->id, 1, true, &tmp_err);
+  crun_error_release (&tmp_err);
+}
+
 int
 libcrun_container_run (libcrun_context_t *context, libcrun_container_t *container, unsigned int options, libcrun_error_t *err)
 {
@@ -1809,7 +1815,11 @@ libcrun_container_run (libcrun_context_t *context, libcrun_container_t *containe
       ret = libcrun_copy_config_file (context->id, context->state_root, context->bundle, err);
       if (UNLIKELY (ret < 0))
         return ret;
-      return libcrun_container_run_internal (container, context, -1, err);
+
+      ret = libcrun_container_run_internal (container, context, -1, err);
+      if (UNLIKELY (ret < 0))
+        force_delete_container_status (context, def);
+      return ret;
     }
 
   ret = pipe (container_ret_status);
@@ -1865,6 +1875,7 @@ libcrun_container_run (libcrun_context_t *context, libcrun_container_t *containe
   TEMP_FAILURE_RETRY (write (pipefd1, &ret, sizeof (ret)));
   if (UNLIKELY (ret < 0))
     {
+      force_delete_container_status (context, def);
       TEMP_FAILURE_RETRY (write (pipefd1, &((*err)->status), sizeof ((*err)->status)));
       TEMP_FAILURE_RETRY (write (pipefd1, (*err)->msg, strlen ((*err)->msg) + 1));
     }
@@ -1910,7 +1921,10 @@ libcrun_container_create (libcrun_context_t *context, libcrun_container_t *conta
       ret = libcrun_copy_config_file (context->id, context->state_root, context->bundle, err);
       if (UNLIKELY (ret < 0))
         return ret;
-      return libcrun_container_run_internal (container, context, -1, err);
+      ret = libcrun_container_run_internal (container, context, -1, err);
+      if (UNLIKELY (ret < 0))
+        force_delete_container_status (context, def);
+      return ret;
     }
 
   ret = pipe (container_ready_pipe);
@@ -1957,6 +1971,7 @@ libcrun_container_create (libcrun_context_t *context, libcrun_container_t *conta
   ret = libcrun_container_run_internal (container, context, pipefd1, err);
   if (UNLIKELY (ret < 0))
     {
+      force_delete_container_status (context, def);
       libcrun_error ((*err)->status, "%s", (*err)->msg);
       crun_set_output_handler (log_write_to_stderr, NULL, false);
     }

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1587,8 +1587,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   if (cgroup_mode < 0)
     return cgroup_mode;
 
-  pid = libcrun_run_linux_container (container, context->detach,
-                                     container_init, &container_args,
+  pid = libcrun_run_linux_container (container, container_init, &container_args,
                                      &sync_socket, err);
   if (UNLIKELY (pid < 0))
     return pid;

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3050,22 +3050,12 @@ init_container (libcrun_container_t *container,
 #ifdef CLONE_NEWTIME
   if (init_status->all_namespaces & CLONE_NEWTIME)
     {
-      cleanup_close int fd = open ("/proc/self/timens_offsets", O_WRONLY | O_CLOEXEC);
-      if (container->container_def->annotations)
+      const char *v = find_annotation (container, "run.oci.timens_offset");
+      if (v)
         {
-          for (i = 0; i < container->container_def->annotations->len; i++)
-            {
-              if (strcmp (container->container_def->annotations->keys[i], "run.oci.timens_offset") == 0)
-                {
-                  const char *v;
-
-                  v = container->container_def->annotations->values[i];
-
-                  ret = write (fd, v, strlen (v));
-                  if (UNLIKELY (ret < 0))
-                    return crun_make_error (err, errno, "write");
-                }
-            }
+          ret = write_file ("/proc/self/timens_offsets", v, strlen (v), err);
+          if (UNLIKELY (ret < 0))
+            return ret;
         }
     }
 #endif

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3095,7 +3095,6 @@ init_container (libcrun_container_t *container,
 
 pid_t
 libcrun_run_linux_container (libcrun_container_t *container,
-                             int detach,
                              container_entrypoint_t entrypoint,
                              void *args,
                              int *sync_socket_out,
@@ -3196,7 +3195,7 @@ libcrun_run_linux_container (libcrun_container_t *container,
     init_status.must_wait_for_userns_creation = !clone_can_create_userns || ((init_status.fd_len > 0) && (init_status.userns_index < 0));
 
   /* If we create a new user namespace, create it as part of the clone.  */
-  pid = syscall_clone ((init_status.namespaces_to_unshare & (clone_can_create_userns ? CLONE_NEWUSER : 0)) | (detach ? 0 : SIGCHLD), NULL);
+  pid = syscall_clone ((init_status.namespaces_to_unshare & (clone_can_create_userns ? CLONE_NEWUSER : 0)) | SIGCHLD, NULL);
   if (UNLIKELY (pid < 0))
     return crun_make_error (err, errno, "clone");
 
@@ -3247,8 +3246,7 @@ libcrun_run_linux_container (libcrun_container_t *container,
             return crun_make_error (err, errno, "read pid from sync socket");
 
           /* Cleanup the first process.  */
-          if (! detach)
-            waitpid (pid, NULL, 0);
+          waitpid (pid, NULL, 0);
 
           pid = grandchild;
         }

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -32,7 +32,6 @@ typedef int (*container_entrypoint_t) (void *args, const char *notify_socket,
                                        libcrun_error_t *err);
 
 pid_t libcrun_run_linux_container (libcrun_container_t *container,
-                                   int detach,
                                    container_entrypoint_t entrypoint,
                                    void *args,
                                    int *sync_socket_out,


### PR DESCRIPTION
follow up for #400 

noteworthy: all the errors happening in the init phase are sent through the sync pipe so they can be properly handled by the caller in the initial process.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>