### PR TITLE
Add crun.1 file to dist tar ball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -138,8 +138,8 @@ dist-hook:
 EXTRA_DIST += $(TESTS) tests/tests_utils.py build-aux/git-version-gen .version git-version.h src/libcrun/signals.perf
 BUILT_SOURCES = .version git-version.h
 
+man_MANS = crun.1
 if HAVE_MD2MAN
-man1_MANS = crun.1
 crun.1: $(abs_srcdir)/crun.1.md
 	$(MD2MAN) -in $(abs_srcdir)/crun.1.md -out crun.1
 


### PR DESCRIPTION
I think that forcing to have to go based tool only to generate man page
on build stage is kind of overkill. Usually, roff man pages are part of
the dist tar ball. So this really does this.
Another small correction is that automake automatically can choose
right man<num> directory based on the extension so all man pages
can be put in one variable man_MANS.