### PR TITLE
linux: drop usage of openat2 for creating directory

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -410,15 +410,13 @@ crun_safe_ensure_at (bool dir, int dirfd, const char *dirpath, size_t dirpath_le
         ret = mkdirat (cwd, cur, mode);
       else
         {
-          ret = safe_openat (cwd, dirpath, dirpath_len, cur, O_CLOEXEC | O_CREAT | O_WRONLY, 0700, err);
+          ret = openat (cwd, cur, O_CLOEXEC | O_CREAT | O_WRONLY | O_NOFOLLOW, 0700);
           if (UNLIKELY (ret < 0))
             {
-              crun_error_release (err);
-
               /* If the previous openat fails, attempt to open the file in O_PATH mode.  */
-              ret = safe_openat (cwd, dirpath, dirpath_len, cur, O_CLOEXEC | O_PATH, 0, err);
+              ret = openat (cwd, cur, O_CLOEXEC | O_PATH, 0);
               if (ret < 0)
-                return ret;
+                return crun_make_error (err, errno, "open `%s/%s`", dirpath, cur);
             }
 
           close_and_replace (&wd_cleanup, ret);

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -45,6 +45,17 @@ def helper_mount(options):
         return [m.vfs_options, m.fs_options]
     return -1
 
+def test_mount_symlink():
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'cat', '/proc/self/mountinfo']
+    add_all_namespaces(conf)
+    mount_opt = {"destination": "/etc/localtime", "type": "bind", "source": "/etc/localtime", "options": ["bind", "ro"]}
+    conf['mounts'].append(mount_opt)
+    out, _ = run_and_get_output(conf, hide_stderr=True)
+    if "Rome" in out:
+        return 0
+    return -1
+
 def test_mount_ro():
     a = helper_mount("ro")[0]
     if "ro" in a:
@@ -116,6 +127,7 @@ all_tests = {
     "test-mount-nosuid" : test_mount_nosuid,
     "test-mount-sync" : test_mount_sync,
     "test-mount-dirsync" : test_mount_dirsync,
+    "test-mount-symlink" : test_mount_symlink,
 }
 
 if __name__ == "__main__":

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -191,7 +191,7 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
     temp_dir = tempfile.mkdtemp(dir=get_tests_root())
     rootfs = os.path.join(temp_dir, "rootfs")
     os.makedirs(rootfs)
-    for i in ["usr/bin", "etc", "var", "lib", "lib64"]:
+    for i in ["usr/bin", "etc", "var", "lib", "lib64", "usr/share/zoneinfo/Europe"]:
         os.makedirs(os.path.join(rootfs, i))
     with open(os.path.join(rootfs, "var", "file"), "w+") as f:
         f.write("file")
@@ -209,6 +209,9 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
     os.makedirs(os.path.join(rootfs, "sbin"))
     shutil.copy2(init, os.path.join(rootfs, "init"))
     shutil.copy2(init, os.path.join(rootfs, "sbin", "init"))
+
+    open(os.path.join(rootfs, "usr/share/zoneinfo/Europe/Rome"), "w").close()
+    os.symlink("../usr/share/zoneinfo/Europe/Rome", os.path.join(rootfs, "etc/localtime"))
 
     detach_arg = ['--detach'] if detach else []
     preserve_fds_arg = ['--preserve-fds', str(preserve_fds)] if preserve_fds else []


### PR DESCRIPTION
while iterating a path to create the missing parent directories, there
is no need to use openat2 as it is possible to use directly O_NOFOLLOW.

The path is anyway opened with openat2 where possible later on in the
same function.

Closes: https://github.com/containers/crun/issues/426

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>