### PR TITLE
Various packaging and configure fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,7 +135,7 @@ dist-hook:
 	$(AM_V_GEN)echo $(VERSION) > $(distdir)/.tarball-version
 	$(AM__GEN)cp git-version.h $(distdir)/git-version.h
 
-EXTRA_DIST += $(TESTS) tests/tests_utils.py build-aux/git-version-gen .version git-version.h src/libcrun/signals.perf
+EXTRA_DIST += $(TESTS) tests/Makefile.tests tests/run_all_tests.sh tests/tests_utils.py build-aux/git-version-gen .version git-version.h src/libcrun/signals.perf
 BUILT_SOURCES = .version git-version.h
 
 if HAVE_MD2MAN

--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,7 @@ AC_SUBST([RPM_VERSION])
 
 AC_CHECK_TOOL(GPERF, gperf)
 if test -z "$GPERF"; then
-       AC_MSG_NOTICE(gperf not found, cannot rebuild signal parser code)
+       AC_MSG_NOTICE(gperf not found - cannot rebuild signal parser code)
 fi
 
 

--- a/tests/Makefile.tests
+++ b/tests/Makefile.tests
@@ -3,7 +3,7 @@ TESTS := $(shell find . -name "test_*.py")
 INIT ?= init
 OCI_RUNTIME ?= /usr/bin/crun
 
-check: init tap-driver.sh
+check: $(INIT) tap-driver.sh
 	OCI_RUNTIME=${OCI_RUNTIME} INIT=${INIT} ./run_all_tests.sh
 
 tap-driver.sh:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2020 Adrian Reber <areber@redhat.com>

--- a/tests/test_cwd.py
+++ b/tests/test_cwd.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_detach.py
+++ b/tests/test_detach.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_pid_file.py
+++ b/tests/test_pid_file.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_preserve_fds.py
+++ b/tests/test_preserve_fds.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_rlimits.py
+++ b/tests/test_rlimits.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_tty.py
+++ b/tests/test_tty.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_uid_gid.py
+++ b/tests/test_uid_gid.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -1,4 +1,4 @@
-#!/bin/env $PYTHON
+#!/bin/env python3
 # crun - OCI runtime written in C
 #
 # Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>


### PR DESCRIPTION
- Makefile.am : add Makefile.tests and test_runner.sh to
  EXTRA_DIST, so we'll get them in the tarball, so we
  can ship them in the crun-tests rpm.

- configure.ac - fix weird error-message condition. TL;DR
  is that a comma in AC_MSG_NOTICE is interpreted as "the
  first arg is the message, the second is an output file"(?),
  the end result being that if gperf is not found, a file
  named "cannot" is created in $CWD with partial error
  message output. This was a fun one to track down.

- tests/*.py : explicitly specify 'python3' in env line,
  not $PYTHON. The latter leads to rpmbuild creating a
  -tests rpm with 'Requires: /usr/bin/$PYTHON' (yes,
  dollar-python) which leads to an uninstallable rpm.

- tests/Makefile.tests : in 'check' target, depend on $(INIT),
  not explicit 'init'. In packaged crun-tests rpm, 'init' will
  be shipped pre-built as /usr/bin/crun-test-init

Signed-off-by: Ed Santiago <santiago@redhat.com>