### PR TITLE
Makefile.am: remove deprecated target oci-runtime-validation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,9 +14,6 @@ srpm: dist-gzip rpm/crun.spec
 	$(MAKE) -C $(WD) dist-gzip
 	rpmbuild -bs --define "_sourcedir $(WD)" --define "_specdir $(WD)" --define "_builddir $(WD)" --define "_srcrpmdir $(WD)" --define "_rpmdir $(WD)" --define "_buildrootdir $(WD)/.build" rpm/crun.spec
 
-oci-runtime-validation:
-	RUNTIME=$(CURDIR)/crun tests/oci-runtime-validation
-
 CLEANFILES = crun.spec crun.1
 
 lib_LTLIBRARIES = libcrun.la


### PR DESCRIPTION
this target doesn't work any more
$ make oci-runtime-validation
RUNTIME=/home/lizj/workspace/NARI/crun/crun tests/oci-runtime-validation
/bin/bash: tests/oci-runtime-validation: No such file or directory
Makefile:2429: recipe for target 'oci-runtime-validation' failed
make: *** [oci-runtime-validation] Error 127

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>