### PR TITLE
Partly rollback #448

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,11 +19,11 @@ jobs:
 
       - run: |
           set -ex
-          sudo mkdir -p /nix
           sudo mkdir -p .cache
-          sudo mount --bind .cache /nix
+          sudo mv .cache /nix
           if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
           sudo RUNTIME=docker SKIP_CHECKS=1 SKIP_GPG=1 build-aux/release.sh
+          sudo mv /nix .cache
           sudo chown -Rf $(whoami) .cache
 
       - run: |

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,8 +4,20 @@ let
     config = {
       packageOverrides = pkg: {
         criu = (static pkg.criu);
+        gpgme = (static pkg.gpgme);
+        libassuan = (static pkg.libassuan);
+        libgpgerror = (static pkg.libgpgerror);
         libseccomp = (static pkg.libseccomp);
         protobufc = (static pkg.protobufc);
+        glib = (static pkg.glib).overrideAttrs(x: {
+          outputs = [ "bin" "out" "dev" ];
+          mesonFlags = [
+            "-Ddefault_library=static"
+            "-Ddevbindir=${placeholder ''dev''}/bin"
+            "-Dgtk_doc=false"
+            "-Dnls=disabled"
+          ];
+        });
         libcap = (static pkg.libcap).overrideAttrs(x: {
           postInstall = ''
             mkdir -p "$doc/share/doc/${x.pname}-${x.version}"
@@ -45,7 +57,7 @@ let
 
   self = with pkgs; stdenv.mkDerivation rec {
     name = "crun";
-    src = builtins.filterSource (p: t: lib.cleanSourceFilter p t && baseNameOf p != ".cache") ./..;
+    src = ./..;
     vendorSha256 = null;
     doCheck = false;
     enableParallelBuilding = true;

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "b49e7987632e4c7ab3a093fdfc433e1826c4b9d7",
-  "date": "2020-07-26T09:18:52+02:00",
-  "sha256": "1mj6fy0p24izmasl653s5z4f2ka9v3b6mys45kjrqmkv889yk2r6",
+  "rev": "d6a445fe821052861b379d9b6c02d21623c25464",
+  "date": "2020-08-11T04:28:16+01:00",
+  "sha256": "064scwaxg8qg4xbmq07hag57saa4bhsb4pgg5h5vfs4nhhwvchg9",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
 Partly rollback #448

The changes of `src = ./..;` make local build with `nix build -f nix/` failed. This PR partly rollback from #448.

Also update nix pin with `make nixpkgs`, see
- https://github.com/containers/crun/pull/450
- https://github.com/containers/conmon/pull/189
- https://github.com/containers/skopeo/pull/973
- https://github.com/containers/buildah/pull/2533
- https://github.com/containers/podman/pull/7286
- https://github.com/cri-o/cri-o/pull/4065

```release-note
Update nix pin with `make `nixpkgs`
```