### PR TITLE
container: add support for libkrun

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,9 @@ AS_IF([test "x$enable_caps" != "xno"], [
 	])
 ])
 
+dnl include support for libkrun (EXPERIMENTAL)
+AC_ARG_WITH([libkrun], AS_HELP_STRING([--with-libkrun], [build with libkrun support]))
+AS_IF([test "x$with_libkrun" = "xyes"], AC_CHECK_HEADERS([libkrun.h], AC_DEFINE([HAVE_LIBKRUN], 1, [Define if libkrun is available]), [AC_MSG_ERROR([*** Missing libkrun headers])]))
 dnl libseccomp
 AC_ARG_ENABLE([seccomp],
 	AS_HELP_STRING([--disable-seccomp], [Ignore libseccomp and disable support]))

--- a/crun.1
+++ b/crun.1
@@ -386,7 +386,9 @@ it is supported in the OCI runtime specs.  It must be an absolute path.
 .PP
 If the annotation \fB\fCrun.oci.seccomp.plugins=PLUGIN1[:PLUGIN2]...\fR is specified, the
 seccomp listener fd is handled through the specified plugins.  The
-plugin must either be an absolute path or a filename.
+plugin must either be an absolute path or a file name that is looked
+up by \fB\fCldopen(3)\fR\&.  More information on how the lookup is performed
+are available on the \fB\fCld.so(8)\fR man page.
 
 .SH \fB\fCrun.oci.seccomp\_fail\_unknown\_syscall=1\fR
 .PP
@@ -459,6 +461,16 @@ If the annotation \fB\fCrun.oci.hooks.stderr\fR is present, then crun
 will open the specified file and use it as the stderr for the hook
 processes.  The file is opened in append mode and it is created if it
 doesn't already exist.
+
+.SH \fB\fCrun.oci.handler=HANDLER\fR
+.PP
+It is an experimental feature.
+
+.PP
+If specified, run the specified handler for execing the container.
+The only supported value is \fB\fCkrun\fR\&.  When \fB\fCkrun\fR is specified, the
+\fB\fClibkrun.so\fR shared object is loaded and it is used to launch the
+container using libkrun.
 
 .SH tmpcopyup mount options
 .PP

--- a/crun.1.md
+++ b/crun.1.md
@@ -369,6 +369,14 @@ will open the specified file and use it as the stderr for the hook
 processes.  The file is opened in append mode and it is created if it
 doesn't already exist.
 
+## `run.oci.handler=HANDLER`
+
+It is an experimental feature.
+
+If specified, run the specified handler for execing the container.
+The only supported value is `krun`.  When `krun` is specified, the
+`libkrun.so` shared object is loaded and it is used to launch the
+container using libkrun.
 
 ## tmpcopyup mount options
 

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -45,6 +45,9 @@ struct libcrun_context_s
   bool no_new_keyring;
   bool force_no_cgroup;
   bool no_pivot;
+
+  int (*exec_func) (void *container, void *arg, const char *pathname, char *const argv[]);
+  void *exec_func_arg;
 };
 
 enum

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1788,6 +1788,9 @@ libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_
   __attribute__ ((cleanup (cleanup_rmdir))) char *tmpdirparent = NULL;
   int rootfsfd = -1;
 
+  if (rootfs == NULL || def->mounts == NULL)
+    return 0;
+
   if (def->linux->rootfs_propagation)
     rootfs_propagation = get_mount_flags (def->linux->rootfs_propagation, 0, NULL, NULL);
 
@@ -3138,9 +3141,12 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
   sync_socket_container = sync_socket[1];
 
 #ifdef HAVE_SYSTEMD
-  ret = do_notify_socket (container, def->root->path, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
+  if (def->root)
+    {
+      ret = do_notify_socket (container, def->root->path, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+    }
 #endif
 
   get_uid_gid_from_def (container->container_def, &container->container_uid, &container->container_gid);


### PR DESCRIPTION
add a custom annotation to specify whether the container must be
executed using libkrun.

crun must be configured and compiled with `--with-libkrun`.
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

example usage:
```
$ podman run -v /dev/kvm:/dev/kvm  --annotation run.oci.handler=krun --rm fedora echo hello
hello
```
