### PR TITLE
crun: allow to declare path to config file

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -71,7 +71,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
       break;
 
     case 'f':
-      config_file = argp_mandatory_argument (arg, state);
+      config_file = crun_context.config_file = argp_mandatory_argument (arg, state);
       break;
 
     case OPTION_CONSOLE_SOCKET:
@@ -116,11 +116,26 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
   int first_arg, ret;
   libcrun_container_t *container;
   cleanup_free char *bundle_cleanup = NULL;
+  cleanup_free char *config_file_cleanup = NULL;
 
   crun_context.preserve_fds = 0;
   argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &crun_context);
 
   crun_assert_n_args (argc - first_arg, 1, 1);
+
+
+  /* Make sure the config is an absolute path before changing the directory.  */
+  if ((strcmp("config.json", config_file) != 0))
+    {
+      if (config_file[0] != '/')
+        {
+          config_file_cleanup = realpath (config_file, NULL);
+          if (config_file_cleanup == NULL)
+            libcrun_fail_with_error (errno, "realpath `%s` failed", config_file);
+          config_file = config_file_cleanup;
+          crun_context.config_file = config_file;
+        }
+    }
 
   /* Make sure the bundle is an absolute path.  */
   if (bundle)

--- a/src/crun.c
+++ b/src/crun.c
@@ -77,6 +77,9 @@ init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global
   if (con->bundle == NULL)
     con->bundle = ".";
 
+  if (con->config_file == NULL)
+    con->config_file = "./config.json";
+
   return 0;
 }
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1755,10 +1755,9 @@ int check_config_file (runtime_spec_schema_config_schema *def, libcrun_error_t *
 }
 
 static
-int libcrun_copy_config_file (const char *id, const char *state_root, const char *bundle, libcrun_error_t *err)
+int libcrun_copy_config_file (const char *id, const char *state_root, const char *config_file, libcrun_error_t *err)
 {
   int ret;
-  cleanup_free char *src_path = NULL;
   cleanup_free char *dest_path = NULL;
   cleanup_free char *dir = NULL;
   cleanup_free char *buffer = NULL;
@@ -1768,10 +1767,9 @@ int libcrun_copy_config_file (const char *id, const char *state_root, const char
   if (UNLIKELY (dir == NULL))
         return crun_make_error (err, 0, "cannot get state directory");
 
-  xasprintf (&src_path, "%s/config.json", bundle);
   xasprintf (&dest_path, "%s/config.json", dir);
 
-  ret = read_all_file (src_path, &buffer, &len, err);
+  ret = read_all_file (config_file, &buffer, &len, err);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -1818,7 +1816,7 @@ libcrun_container_run (libcrun_context_t *context, libcrun_container_t *containe
 
   if (!detach && (options & LIBCRUN_RUN_OPTIONS_PREFORK) == 0)
     {
-      ret = libcrun_copy_config_file (context->id, context->state_root, context->bundle, err);
+      ret = libcrun_copy_config_file (context->id, context->state_root, context->config_file, err);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -1872,7 +1870,7 @@ libcrun_container_run (libcrun_context_t *context, libcrun_container_t *containe
   if (UNLIKELY (ret < 0))
     libcrun_fail_with_error (errno, "detach process");
 
-  ret = libcrun_copy_config_file (context->id, context->state_root, context->bundle, err);
+  ret = libcrun_copy_config_file (context->id, context->state_root, context->config_file, err);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -1923,7 +1921,7 @@ libcrun_container_create (libcrun_context_t *context, libcrun_container_t *conta
 
   if ((options & LIBCRUN_RUN_OPTIONS_PREFORK) == 0)
     {
-      ret = libcrun_copy_config_file (context->id, context->state_root, context->bundle, err);
+      ret = libcrun_copy_config_file (context->id, context->state_root, context->config_file, err);
       if (UNLIKELY (ret < 0))
         return ret;
       ret = libcrun_container_run_internal (container, context, -1, err);
@@ -2671,7 +2669,7 @@ libcrun_container_restore (libcrun_context_t *context, const char *id,
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = libcrun_copy_config_file (context->id, context->state_root, context->bundle, err);
+  ret = libcrun_copy_config_file (context->id, context->state_root, context->config_file, err);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -28,6 +28,7 @@ struct libcrun_context_s
   const char *state_root;
   const char *id;
   const char *bundle;
+  const char *config_file;
   const char *console_socket;
   const char *pid_file;
   const char *notify_socket;

--- a/src/run.c
+++ b/src/run.c
@@ -72,7 +72,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
       break;
 
     case 'f':
-      config_file = argp_mandatory_argument (arg, state);
+      config_file = crun_context.config_file = argp_mandatory_argument (arg, state);
       break;
 
     case 'b':
@@ -121,11 +121,25 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
   int first_arg, ret;
   cleanup_free libcrun_container_t *container = NULL;
   cleanup_free char *bundle_cleanup = NULL;
+  cleanup_free char *config_file_cleanup = NULL;
 
   crun_context.preserve_fds = 0;
 
   argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &crun_context);
   crun_assert_n_args (argc - first_arg, 1, 1);
+
+  /* Make sure the config is an absolute path before changing the directory.  */
+  if ((strcmp("config.json", config_file) != 0))
+    {
+      if (config_file[0] != '/')
+        {
+          config_file_cleanup = realpath (config_file, NULL);
+          if (config_file_cleanup == NULL)
+            libcrun_fail_with_error (errno, "realpath `%s` failed", config_file);
+          config_file = config_file_cleanup;
+          crun_context.config_file = config_file;
+        }
+    }
 
   /* Make sure the bundle is an absolute path.  */
   if (bundle)

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -85,6 +85,30 @@ def test_start():
             run_crun_command(["delete", "-f", cid])
     return 0
 
+def test_start_override_config():
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'echo', 'hello']
+    add_all_namespaces(conf)
+    cid = None
+    try:
+        proc, cid = run_and_get_output(conf, command='create', use_popen=True, relative_config_path="config/config.json")
+        for i in range(50):
+            try:
+                s = run_crun_command(["state", cid])
+                break
+            except Exception as e:
+                time.sleep(0.1)
+
+        run_crun_command(["start", cid])
+        out, _ = proc.communicate()
+        if "hello" not in str(out):
+            return -1
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+    return 0
+
+
 def test_run_twice():
     conf = base_config()
     conf['process']['args'] = ['/init', 'echo', 'hi']
@@ -143,6 +167,7 @@ def test_sd_notify_env():
 
 all_tests = {
     "start" : test_start,
+    "start-override-config" : test_start_override_config,
     "run-twice" : test_run_twice,
     "sd-notify" : test_sd_notify,
     "sd-notify-file" : test_sd_notify_file,

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -187,7 +187,7 @@ def get_crun_path():
 
 def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
                        command='run', env=None, use_popen=False, hide_stderr=False,
-                       all_dev_null=False, id_container=None):
+                       all_dev_null=False, id_container=None, relative_config_path="config.json"):
     temp_dir = tempfile.mkdtemp(dir=get_tests_root())
     rootfs = os.path.join(temp_dir, "rootfs")
     os.makedirs(rootfs)
@@ -199,7 +199,12 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
     if id_container is None:
         id_container = 'test-%s' % os.path.basename(temp_dir)
 
-    with open(os.path.join(temp_dir, "config.json"), "w") as config_file:
+    config_path = os.path.join(temp_dir, relative_config_path)
+    config_dir = os.path.dirname(config_path)
+    if not os.path.exists(config_dir):
+        os.makedirs(config_dir)
+
+    with open(config_path, "w") as config_file:
         conf = json.dumps(config)
         config_file.write(conf)
 
@@ -216,8 +221,9 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
     detach_arg = ['--detach'] if detach else []
     preserve_fds_arg = ['--preserve-fds', str(preserve_fds)] if preserve_fds else []
     pid_file_arg = ['--pid-file', pid_file] if pid_file else []
+    relative_config_path = ['--config', relative_config_path] if relative_config_path else []
 
-    args = [crun, command] + preserve_fds_arg + detach_arg + pid_file_arg + [id_container]
+    args = [crun, command] + relative_config_path + preserve_fds_arg + detach_arg + pid_file_arg + [id_container]
 
     stderr = subprocess.STDOUT
     if hide_stderr:


### PR DESCRIPTION
allow to declare the path to the config.json, instead of using
the config.json in the bundle directory.