### PR TITLE
list: add json format option

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -23,11 +23,15 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <yajl/yajl_tree.h>
+#include <yajl/yajl_gen.h>
 
 #include "crun.h"
 #include "libcrun/container.h"
 #include "libcrun/utils.h"
 #include "libcrun/status.h"
+
+#define YAJL_STR(x) ((const unsigned char *) (x))
 
 static char doc[] = "OCI runtime";
 
@@ -42,15 +46,22 @@ enum
 
 struct list_options_s
 {
+  bool quiet;
+  int format;
 };
 
-static struct list_options_s list_options;
+enum
+  {
+   LIST_TABLE = 100,
+   LIST_JSON,
+  };
 
-static bool quiet;
+static struct list_options_s list_options;
 
 static struct argp_option options[] =
   {
    {"quiet", 'q', 0, 0, "show only IDs", 0},
+   {"format", 'f', "FORMAT", 0, "select one of: table or json (default: \"table\")", 0},
    { 0, }
   };
 
@@ -62,7 +73,15 @@ parse_opt (int key, char *arg arg_unused, struct argp_state *state arg_unused)
   switch (key)
     {
     case 'q':
-      quiet = true;
+      list_options.quiet = true;
+      break;
+    case 'f':
+      if (strcmp (arg, "table") == 0)
+        list_options.format = LIST_TABLE;
+      else if (strcmp (arg, "json") == 0)
+        list_options.format = LIST_JSON;
+      else
+        error (EXIT_FAILURE, 0, "invalid format `%s`", arg);
       break;
 
     default:
@@ -81,6 +100,11 @@ crun_command_list (struct crun_global_arguments *global_args, int argc, char **a
   int ret, max_length = 4;
   libcrun_context_t crun_context = {0, };
   libcrun_container_list_t *list, *it;
+  yajl_gen gen = NULL;
+  size_t len;
+  const unsigned char *buf = NULL;
+
+  list_options.format = LIST_TABLE;
 
   argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &list_options);
   crun_assert_n_args (argc - first_arg, 0, 0);
@@ -102,8 +126,18 @@ crun_command_list (struct crun_global_arguments *global_args, int argc, char **a
 
   max_length++;
 
-  if (!quiet)
+  gen = yajl_gen_alloc (NULL);
+  if (gen == NULL)
+    error (EXIT_FAILURE, 0, "yajl_gen_alloc failed");
+
+  if (!list_options.quiet && list_options.format == LIST_TABLE)
     printf ("%-*s%-10s%-8s %-39s\n", max_length, "NAME", "PID", "STATUS", "BUNDLE PATH");
+  else if (list_options.format == LIST_JSON)
+    {
+      yajl_gen_config (gen, yajl_gen_beautify, 1);
+      yajl_gen_config (gen, yajl_gen_validate_utf8, 1);
+      yajl_gen_array_open (gen);
+    }
   for (it = list; it; it = it->next)
     {
       libcrun_container_status_t status;
@@ -114,7 +148,7 @@ crun_command_list (struct crun_global_arguments *global_args, int argc, char **a
           libcrun_error_write_warning_and_release (stderr, &err);
           continue;
         }
-      if (quiet)
+      if (list_options.quiet && list_options.format == LIST_TABLE)
         printf ("%s\n", it->name);
       else
         {
@@ -132,11 +166,45 @@ crun_command_list (struct crun_global_arguments *global_args, int argc, char **a
           if (! running)
             pid = 0;
 
-          printf ("%-*s%-10d%-8s %-39s\n", max_length, it->name, pid, container_status, status.bundle);
+          switch (list_options.format)
+            {
+            case LIST_JSON:
+              yajl_gen_map_open (gen);
+              yajl_gen_string (gen, YAJL_STR ("id"), strlen ("id"));
+              yajl_gen_string (gen, YAJL_STR (it->name), strlen (it->name));
+              yajl_gen_string (gen, YAJL_STR ("pid"), strlen ("pid"));
+              yajl_gen_integer (gen, pid);
+              yajl_gen_string (gen, YAJL_STR ("status"), strlen ("status"));
+              yajl_gen_string (gen, YAJL_STR (container_status), strlen (container_status));
+              yajl_gen_string (gen, YAJL_STR ("bundle"), strlen ("bundle"));
+              yajl_gen_string (gen, YAJL_STR (status.bundle), strlen (status.bundle));
+              yajl_gen_map_close (gen);
+              break;
+
+            case LIST_TABLE:
+              printf ("%-*s%-10d%-8s %-39s\n", max_length, it->name, pid, container_status, status.bundle);
+              break;
+            }
         }
+
 
       libcrun_free_container_status (&status);
     }
+  if (list_options.format == LIST_JSON)
+    {
+      yajl_gen_array_close (gen);
+      if (yajl_gen_get_buf (gen, &buf, &len) != yajl_gen_status_ok)
+        {
+          ret = libcrun_make_error (err, 0, "cannot generate json list");
+          goto exit;
+        }
+      printf("%s",buf);
+    }
+
+ exit:
+  if (gen)
+    yajl_gen_free (gen);
+
   libcrun_free_containers_list (list);
-  return 0;
+  return ret >= 0 ? 0 : ret;
 }


### PR DESCRIPTION
Add format option to `crun list` to have an option of printing list of containers out as a json array.