### PR TITLE
kill: use pidfd_send_signal if supported

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1056,11 +1056,13 @@ container_delete_internal (libcrun_context_t *context, runtime_spec_schema_confi
           */
           if (has_new_pid_namespace (def))
             {
-              ret = kill (status.pid, SIGKILL);
-              if (UNLIKELY (ret < 0) && errno != ESRCH)
+              ret = libcrun_kill_linux (&status, SIGKILL, err);
+              if (UNLIKELY (ret < 0))
                 {
-                  crun_make_error (err, errno, "kill cannot find process");
-                  return ret;
+                  if (crun_error_get_errno (err) != ESRCH)
+                    return ret;
+
+                  crun_error_release (err);
                 }
             }
           else if (status.cgroup_path)

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1109,10 +1109,7 @@ libcrun_container_kill (libcrun_context_t *context, const char *id, int signal, 
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = kill (status.pid, signal);
-  if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "kill container");
-  return 0;
+  return libcrun_kill_linux (&status, signal, err);
 }
 
 int

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3754,3 +3754,14 @@ libcrun_container_restore_linux (libcrun_container_status_t *status,
 
   return 0;
 }
+
+int
+libcrun_kill_linux (libcrun_container_status_t *status, int signal, libcrun_error_t *err)
+{
+  int ret;
+
+  ret = kill (status->pid, signal);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "kill container");
+  return 0;
+}

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -164,6 +164,7 @@ syscall_clone (unsigned long flags, void *child_stack)
   return (int) syscall (__NR_clone, flags, child_stack);
 #endif
 }
+
 static int
 syscall_fsopen (const char *fs_name, unsigned int flags)
 {
@@ -215,6 +216,34 @@ syscall_keyctl_join (const char *name)
 {
 #define KEYCTL_JOIN_SESSION_KEYRING 0x1
   return (int) syscall (__NR_keyctl, KEYCTL_JOIN_SESSION_KEYRING, name, 0);
+}
+
+static int
+syscall_pidfd_open (pid_t pid, unsigned int flags)
+{
+#if defined __NR_pidfd_open
+  return (int) syscall (__NR_pidfd_open, pid, flags);
+#else
+  (void) pid;
+  (void) flags;
+  errno = ENOTSUP;
+  return -1;
+#endif
+}
+
+static int
+syscall_pidfd_send_signal (int pidfd, int sig, siginfo_t *info, unsigned int flags)
+{
+#if defined __NR_pidfd_send_signal
+  return (int) syscall (__NR_pidfd_send_signal, pidfd, sig, info, flags);
+#else
+  (void) pidfd;
+  (void) sig;
+  (void) info;
+  (void) flags;
+  errno = ENOTSUP;
+  return -1;
+#endif
 }
 
 int
@@ -3759,9 +3788,36 @@ int
 libcrun_kill_linux (libcrun_container_status_t *status, int signal, libcrun_error_t *err)
 {
   int ret;
+  cleanup_close int pidfd = -1;
 
-  ret = kill (status->pid, signal);
+  pidfd = syscall_pidfd_open (status->pid, 0);
+  if (UNLIKELY (pidfd < 0))
+    {
+      /* If pidfd_open is not supported, fallback to kill.  */
+      if (errno == ENOTSUP)
+        {
+          ret = kill (status->pid, signal);
+          if (UNLIKELY (ret < 0))
+            return crun_make_error (err, errno, "kill container");
+          return 0;
+        }
+      return crun_make_error (err, errno, "open pidfd");
+    }
+
+  ret = libcrun_check_pid_valid (status, err);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "kill container");
+    return ret;
+
+  /* The pid is not valid anymore, return an error.  */
+  if (ret == 0)
+    {
+      errno = ESRCH;
+      return crun_make_error (err, errno, "kill container");
+    }
+
+  ret = syscall_pidfd_send_signal (pidfd, signal, NULL, 0);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "send signal to pidfd");
+
   return 0;
 }

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -72,4 +72,5 @@ int libcrun_container_restore_linux (libcrun_container_status_t *status,
 int libcrun_find_namespace (const char *name);
 char *libcrun_get_external_descriptors (libcrun_container_t *container);
 int libcrun_container_setgroups (libcrun_container_t *container, libcrun_error_t *err);
+int libcrun_kill_linux (libcrun_container_status_t *status, int signal, libcrun_error_t *err);
 #endif

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -529,7 +529,7 @@ libcrun_is_container_running (libcrun_container_status_t *status, libcrun_error_
 
   if (ret == 0)
     {
-      /* For backwards compatability, check start time only if available. */
+      /* For backwards compatibility, check start time only if available. */
       if (status->process_start_time)
         {
           struct pid_stat st;

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -155,7 +155,7 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   yajl_gen gen = NULL;
 
   ret = read_pid_stat (status->pid, &st, err);
-  if (UNLIKELY (ret))
+  if (UNLIKELY (ret < 0))
     return ret;
 
   status->process_start_time = st.starttime;
@@ -518,6 +518,32 @@ libcrun_free_containers_list (libcrun_container_list_t *list)
     }
 }
 
+/* check if the container pid is still valid.
+   Returns:
+   -1: on errors
+    0: pid not valid
+    1: pid valid and container in the running/created/paused state
+*/
+int
+libcrun_check_pid_valid (libcrun_container_status_t *status, libcrun_error_t *err)
+{
+  struct pid_stat st;
+  int ret;
+
+  /* For backwards compatibility, check start time only if available. */
+  if (! status->process_start_time)
+    return 1;
+
+  ret = read_pid_stat (status->pid, &st, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  if (status->process_start_time != st.starttime || st.state == 'Z' || st.state == 'X')
+    return 0; /* stopped */
+
+  return 1; /* running, created, or paused */
+}
+
 int
 libcrun_is_container_running (libcrun_container_status_t *status, libcrun_error_t *err)
 {
@@ -528,20 +554,8 @@ libcrun_is_container_running (libcrun_container_status_t *status, libcrun_error_
     return crun_make_error (err, errno, "kill");
 
   if (ret == 0)
-    {
-      /* For backwards compatibility, check start time only if available. */
-      if (status->process_start_time)
-        {
-          struct pid_stat st;
-          ret = read_pid_stat (status->pid, &st, err);
-          if (UNLIKELY (ret))
-            return ret;
+    return libcrun_check_pid_valid (status, err);
 
-          if (status->process_start_time != st.starttime || st.state == 'Z' || st.state == 'X')
-            return 0; /* stopped */
-        }
-      return 1; /* running, created, or paused */
-    }
   return 0; /* stopped */
 }
 

--- a/src/libcrun/status.h
+++ b/src/libcrun/status.h
@@ -61,4 +61,5 @@ int libcrun_status_check_directories (const char *state_root, const char *id, li
 int libcrun_status_create_exec_fifo (const char *state_root, const char *id, libcrun_error_t *err);
 int libcrun_status_write_exec_fifo (const char *state_root, const char *id, libcrun_error_t *err);
 int libcrun_status_has_read_exec_fifo (const char *state_root, const char *id, libcrun_error_t *err);
+int libcrun_check_pid_valid (libcrun_container_status_t *status, libcrun_error_t *err);
 #endif


### PR DESCRIPTION
if pidfd_send_signal is available, use it instead of kill for terminating the container.

It gives the benefit we can check whether the PID is still the container pid and not being vulnerable to TOCTOU checks for sending the signal.

Requires linux 5.3.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
