### PR TITLE
Add support for SCMP_ACT_KILL_THREAD

### DIFF
--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -122,6 +122,10 @@ get_seccomp_action (const char *name, int errno_ret, libcrun_error_t *err)
   else if (strcmp (p, "KILL_PROCESS") == 0)
     return SCMP_ACT_KILL_PROCESS;
 #endif
+#ifdef SCMP_ACT_KILL_THREAD
+  else if (strcmp (p, "KILL_THREAD") == 0)
+    return SCMP_ACT_KILL_THREAD;
+#endif
 #ifdef SCMP_ACT_NOTIFY
   else if (strcmp (p, "NOTIFY") == 0)
     return SCMP_ACT_NOTIFY;


### PR DESCRIPTION
This seccomp action has been added to libseccomp a while ago, so I guess we can support it in crun as well:
https://github.com/seccomp/libseccomp/commit/b2f15f3d02f302b12b9d1a37d83521e6f9e08841