### PR TITLE
status: simplify /proc/PID/stat parsing

### DIFF
--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -126,7 +126,9 @@ crun_command_checkpoint (struct crun_global_arguments *global_args, int argc, ch
       if (UNLIKELY (path == NULL))
         libcrun_fail_with_error (0, "realloc failed");
 
-      xasprintf (&cr_path, "%s/checkpoint", path);
+      ret = asprintf (&cr_path, "%s/checkpoint", path);
+      if (UNLIKELY (ret < 0))
+        OOM ();
       cr_options.image_path = cr_path;
     }
 

--- a/src/restore.c
+++ b/src/restore.c
@@ -157,7 +157,9 @@ crun_command_restore (struct crun_global_arguments *global_args, int argc, char 
       if (UNLIKELY (path == NULL))
         libcrun_fail_with_error (0, "realloc failed");
 
-      xasprintf (&cr_path, "%s/checkpoint", path);
+      ret = asprintf (&cr_path, "%s/checkpoint", path);
+      if (UNLIKELY (ret < 0))
+        OOM ();
       cr_options.image_path = cr_path;
     }
 


### PR DESCRIPTION
simplify parsing of /proc/PID/stat to read only the information used
by libcrun.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>