### PR TITLE
Update README With Shared Library Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ To install into default PREFIX (`/usr/local`):
 sudo make install
 ```
 
+### Shared Libraries
+
+The previous build instructions do not enable shared libraries, therefore you will be unable to use libcrun. If you wish to build the shared libraries you can change the previous `./configure.sh` statement to `./configure --enable-shared`.
+
 ## Static build
 
 It is possible to build a statically linked binary of crun by using the


### PR DESCRIPTION
Hello I have made a small change to the README so those less familiar with autotools can more easily install libcrun without needing to opening issues like https://github.com/containers/crun/issues/477