### PR TITLE
Enable checkpoint/restore support (finally)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,7 +94,7 @@ AS_IF([test "x$with_python_bindings" = "xyes"], [
 dnl criu
 AC_ARG_ENABLE([criu], AS_HELP_STRING([--disable-criu], [Disable CRIU based checkpoint/restore support]))
 AS_IF([test "x$enable_criu" != "xno"], [
-            PKG_CHECK_MODULES([CRIU], [criu >= 3.13], [have_criu="yes"], [have_criu="no"
+            PKG_CHECK_MODULES([CRIU], [criu >= 3.15], [have_criu="yes"], [have_criu="no"
 			       AC_MSG_RESULT([CRIU headers not found, building without CRIU support])])
 	    AS_IF([test "$have_criu" = "yes"], [
 		   AC_DEFINE([HAVE_CRIU], 1, [Define if CRIU is available])

--- a/src/crun.c
+++ b/src/crun.c
@@ -115,29 +115,35 @@ struct commands_s commands[] = { { COMMAND_CREATE, "create", crun_command_create
                                  { COMMAND_UPDATE, "update", crun_command_update },
                                  { COMMAND_PAUSE, "pause", crun_command_pause },
                                  { COMMAND_UNPAUSE, "resume", crun_command_unpause },
-                                 /* Not calling it yet 'checkpoint' as this might confuse tools
-                                  * testing for checkpoint support like Podman does.
-                                  * Once it is ready for Podman, this can be renamed to 'checkpoint' */
-                                 { COMMAND_CHECKPOINT, "_checkpoint", crun_command_checkpoint },
-                                 { COMMAND_RESTORE, "_restore", crun_command_restore },
+#ifdef HAVE_CRIU
+                                 { COMMAND_CHECKPOINT, "checkpoint", crun_command_checkpoint },
+                                 { COMMAND_RESTORE, "restore", crun_command_restore },
+#endif
                                  {
                                      0,
                                  } };
 
 static char doc[] = "\nCOMMANDS:\n"
-                    "\tcreate  - create a container\n"
-                    "\tdelete  - remove definition for a container\n"
-                    "\texec    - exec a command in a running container\n"
-                    "\tlist    - list known containers\n"
-                    "\tkill    - send a signal to the container init process\n"
-                    "\tps      - show the processes in the container\n"
-                    "\trun     - run a container\n"
-                    "\tspec    - generate a configuration file\n"
-                    "\tstart   - start a container\n"
-                    "\tstate   - output the state of a container\n"
-                    "\tpause   - pause all the processes in the container\n"
-                    "\tresume  - unpause the processes in the container\n"
-                    "\tupdate  - update container resource constraints\n";
+#ifdef HAVE_CRIU
+                    "\tcheckpoint  - checkpoint a container\n"
+#endif
+                    "\tcreate      - create a container\n"
+                    "\tdelete      - remove definition for a container\n"
+                    "\texec        - exec a command in a running container\n"
+                    "\tlist        - list known containers\n"
+                    "\tkill        - send a signal to the container init process\n"
+                    "\tps          - show the processes in the container\n"
+#ifdef HAVE_CRIU
+                    "\trestore     - restore a container\n"
+#endif
+                    "\trun         - run a container\n"
+                    "\tspec        - generate a configuration file\n"
+                    "\tstart       - start a container\n"
+                    "\tstate       - output the state of a container\n"
+                    "\tpause       - pause all the processes in the container\n"
+                    "\tresume      - unpause the processes in the container\n"
+                    "\tupdate      - update container resource constraints\n";
+
 static char args_doc[] = "COMMAND [OPTION...]";
 
 static struct commands_s *

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -82,6 +82,7 @@ struct libcrun_checkpoint_restore_s
   bool shell_job;
   bool ext_unix_sk;
   bool detach;
+  const char *console_socket;
 };
 typedef struct libcrun_checkpoint_restore_s libcrun_checkpoint_restore_t;
 

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -39,6 +39,34 @@
 #  define CRIU_RESTORE_LOG_FILE "restore.log"
 #  define DESCRIPTORS_FILENAME "descriptors.json"
 
+static const char *console_socket = NULL;
+
+static int
+criu_notify (char *action, criu_notify_arg_t na)
+{
+  if (strncmp (action, "orphan-pts-master", 17) == 0)
+    {
+      /* CRIU sends us the master FD via the 'orphan-pts-master'
+       * callback and we are passing it on to the '--console-socket'
+       * if it exists. */
+      cleanup_close int console_socket_fd = -1;
+      int master_fd;
+      int ret;
+
+      if (! console_socket)
+        return 0;
+      master_fd = criu_get_orphan_pts_master_fd ();
+
+      console_socket_fd = open_unix_domain_client_socket (console_socket, 0, NULL);
+      if (UNLIKELY (console_socket_fd < 0))
+        return console_socket_fd;
+      ret = send_fd_to_socket (console_socket_fd, master_fd, NULL);
+      if (UNLIKELY (ret < 0))
+        return ret;
+    }
+  return 0;
+}
+
 int
 libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, libcrun_container_t *container,
                                          libcrun_checkpoint_restore_t *cr_options, libcrun_error_t *err)
@@ -209,6 +237,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   criu_set_ext_unix_sk (cr_options->ext_unix_sk);
   criu_set_shell_job (cr_options->shell_job);
   criu_set_tcp_established (cr_options->tcp_established);
+  criu_set_orphan_pts_master (true);
 
   /* Set up logging. */
   criu_set_log_level (4);
@@ -465,10 +494,14 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
         }
     }
 
+  console_socket = cr_options->console_socket;
+  criu_set_notify_cb (criu_notify);
+
   /* Set boolean options . */
   criu_set_ext_unix_sk (cr_options->ext_unix_sk);
   criu_set_shell_job (cr_options->shell_job);
   criu_set_tcp_established (cr_options->tcp_established);
+  criu_set_orphan_pts_master (true);
 
   criu_set_log_level (4);
   criu_set_log_file (CRIU_RESTORE_LOG_FILE);

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -33,6 +33,7 @@
 #  include "linux.h"
 #  include "status.h"
 #  include "utils.h"
+#  include "cgroup.h"
 
 #  define CRIU_CHECKPOINT_LOG_FILE "dump.log"
 #  define CRIU_RESTORE_LOG_FILE "restore.log"
@@ -44,11 +45,13 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
 {
   runtime_spec_schema_config_schema *def = container->container_def;
   cleanup_free char *descriptors_path = NULL;
+  cleanup_free char *freezer_path = NULL;
   cleanup_close int descriptors_fd = -1;
   cleanup_free char *external = NULL;
   cleanup_free char *path = NULL;
   cleanup_close int image_fd = -1;
   cleanup_close int work_fd = -1;
+  int cgroup_mode;
   size_t i;
   int ret;
 
@@ -185,6 +188,21 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
           break;
         }
     }
+
+  /* Tell CRIU to use the freezer to pause all container processes. */
+  cgroup_mode = libcrun_get_cgroup_mode (err);
+  if (cgroup_mode < 0)
+    return cgroup_mode;
+
+  if (cgroup_mode == CGROUP_MODE_UNIFIED)
+    /* This needs CRIU 3.14. */
+    xasprintf (&freezer_path, "/sys/fs/cgroup/%s", status->cgroup_path);
+  else
+    xasprintf (&freezer_path, "/sys/fs/cgroup/freezer/%s", status->cgroup_path);
+
+  ret = criu_set_freeze_cgroup (freezer_path);
+  if (UNLIKELY (ret != 0))
+    return crun_make_error (err, ret, "CRIU: failed setting freezer %d\n", ret);
 
   /* Set boolean options . */
   criu_set_leave_running (cr_options->leave_running);

--- a/src/restore.c
+++ b/src/restore.c
@@ -39,7 +39,8 @@ enum
   OPTION_TCP_ESTABLISHED,
   OPTION_SHELL_JOB,
   OPTION_EXT_UNIX_SK,
-  OPTION_PID_FILE
+  OPTION_PID_FILE,
+  OPTION_CONSOLE_SOCKET,
 };
 
 static char doc[] = "OCI runtime";
@@ -59,6 +60,8 @@ static struct argp_option options[]
         { "shell-job", OPTION_SHELL_JOB, 0, 0, "allow shell jobs", 0 },
         { "detach", 'd', 0, 0, "detach from the container's process", 0 },
         { "pid-file", OPTION_PID_FILE, "FILE", 0, "where to write the PID of the container", 0 },
+        { "console-socket", OPTION_CONSOLE_SOCKET, "SOCKET", 0,
+          "path to a socket that will receive the master end of the tty", 0 },
         {
             0,
         } };
@@ -99,6 +102,10 @@ parse_opt (int key, char *arg arg_unused, struct argp_state *state arg_unused)
 
     case 'd':
       cr_options.detach = true;
+      break;
+
+    case OPTION_CONSOLE_SOCKET:
+      cr_options.console_socket = argp_mandatory_argument (arg, state);
       break;
 
     case OPTION_PID_FILE:


### PR DESCRIPTION
This pull requests adds the missing pieces of crun checkpoint/restore and enables it.

Missing pieces were, from my point of view, to make Podman's checkpoint/restore tests successful. With this Podman's checkpoint restore finishes successfully:
```
# ginkgo -v --tags exclude_graphdriver_btrfs --focus="checkpoint"  test/e2e/.
...
Ran 16 of 1076 Specs in 63.152 seconds
SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 1060 Skipped
PASS
```

The changes in this PR to enable this are:
 * Require at least CRIU 3.15, currently unreleased - using criu-dev branch for my tests
 * Correctly reconnect console socket after restore - this requires 3.15
 * Use cgroup freezer to stop all processes in the container instead of ptrace - this requires 3.15
 * Activate the `checkpoint` and `restore` command which were hidden and prefixed with `_` 
   (as long as CRIU >= 3.15 is not detected during build-time, the subcommands will stay deactivated.)

Once CRIU 3.15 is released I plan to update crun's CI to make sure the checkpoint/restore tests are being run. Once crun with CRIU 3.15 has been built and once it hits Podman's CI the checkpoint/restore tests on crun based systems will be running automatically.

Just a draft to see what crun's CI thinks of this change.