### PR TITLE
cgroup: enable all controllers in the root

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -265,6 +265,11 @@ enable_controllers (const char *path, libcrun_error_t *err)
 
   controllers_to_enable = ret;
 
+  /* Enable all possible controllers in the root cgroup.  */
+  ret = write_controller_file ("/sys/fs/cgroup", controllers_to_enable, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   for (it = strchr (tmp_path + 1, '/'); it;)
     {
       cleanup_free char *cgroup_path = NULL;


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>