### PR TITLE
src/libcrun: rm unused vars

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1573,7 +1573,6 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   cleanup_close int socket_pair_0 = -1;
   cleanup_close int socket_pair_1 = -1;
   cleanup_close int seccomp_fd = -1;
-  cleanup_close int seccomp_receiver_fd = -1;
   cleanup_close int console_socket_fd = -1;
   cleanup_close int hooks_out_fd = -1;
   cleanup_close int hooks_err_fd = -1;

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -761,8 +761,6 @@ read_all_file_at (int dirfd, const char *path, char **out, size_t *len, libcrun_
 int
 read_all_file (const char *path, char **out, size_t *len, libcrun_error_t *err)
 {
-  cleanup_close int fd = -1;
-
   if (strcmp (path, "-") == 0)
     path = "/dev/stdin";
 


### PR DESCRIPTION
Unless I'm missing something obvious, these has no effect other
than calling close(-1) upon return which does not make sense.