### PR TITLE
linux: fix a race condition writing to the socket

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1000,7 +1000,7 @@ has_new_pid_namespace (runtime_spec_schema_config_schema *def)
 
 static int
 container_delete_internal (libcrun_context_t *context, runtime_spec_schema_config_schema *def, const char *id,
-                           bool force, bool only_cleanup, libcrun_error_t *err)
+                           bool force, bool killall, libcrun_error_t *err)
 {
   int ret;
   cleanup_container_status libcrun_container_status_t status = {};
@@ -1031,7 +1031,7 @@ container_delete_internal (libcrun_context_t *context, runtime_spec_schema_confi
         return crun_make_error (err, 0, "the container `%s` is not in 'stopped' state", id);
     }
 
-  if (! only_cleanup && ! status.detached)
+  if (killall)
     {
       if (force)
         {
@@ -1088,7 +1088,7 @@ int
 libcrun_container_delete (libcrun_context_t *context, runtime_spec_schema_config_schema *def, const char *id,
                           bool force, libcrun_error_t *err)
 {
-  return container_delete_internal (context, def, id, force, false, err);
+  return container_delete_internal (context, def, id, force, true, err);
 }
 
 int
@@ -1866,7 +1866,7 @@ static void
 force_delete_container_status (libcrun_context_t *context, runtime_spec_schema_config_schema *def)
 {
   libcrun_error_t tmp_err = NULL;
-  container_delete_internal (context, def, context->id, 1, true, &tmp_err);
+  container_delete_internal (context, def, context->id, true, false, &tmp_err);
   crun_error_release (&tmp_err);
 }
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2959,7 +2959,7 @@ init_container (libcrun_container_t *container, int sync_socket_container, struc
   pid_t pid_container = 0;
   size_t i;
   int ret;
-  char success = 0;
+  const char success = 0;
 
   ret = libcrun_set_oom (container, err);
   if (UNLIKELY (ret < 0))
@@ -3072,8 +3072,13 @@ init_container (libcrun_container_t *container, int sync_socket_container, struc
           ret = TEMP_FAILURE_RETRY (write (sync_socket_container, &pid_container, sizeof (pid_container)));
           if (UNLIKELY (ret < 0))
             return crun_make_error (err, errno, "write to sync socket");
+
           _exit (EXIT_SUCCESS);
         }
+
+      ret = expect_success_from_sync_socket (sync_socket_container, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
     }
 
   ret = libcrun_container_setgroups (container, err);
@@ -3096,6 +3101,8 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
   char *notify_socket_env = NULL;
   cleanup_close int sync_socket_host = -1;
   bool clone_can_create_userns;
+  const char failure = 1;
+  const char success = 0;
   int sync_socket[2];
   pid_t pid;
   size_t i;
@@ -3236,6 +3243,10 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
           if (UNLIKELY (ret < 0))
             return crun_make_error (err, errno, "read pid from sync socket");
 
+          ret = TEMP_FAILURE_RETRY (write (sync_socket_host, &success, 1));
+          if (UNLIKELY (ret < 0))
+            return ret;
+
           /* Cleanup the first process.  */
           waitpid (pid, NULL, 0);
 
@@ -3261,8 +3272,6 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
   ret = init_container (container, sync_socket_container, &init_status, err);
   if (UNLIKELY (ret < 0))
     {
-      char failure = 1;
-
       ret = TEMP_FAILURE_RETRY (write (sync_socket_container, &failure, 1));
       if (UNLIKELY (ret < 0))
         goto localfail;
@@ -3275,8 +3284,6 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
     }
   else
     {
-      char success = 0;
-
       ret = TEMP_FAILURE_RETRY (write (sync_socket_container, &success, 1));
       if (UNLIKELY (ret < 0))
         return ret;

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -128,7 +128,8 @@ read_pid_stat (pid_t pid, struct pid_stat *st, libcrun_error_t *err)
   st->state = *s;
 
   /* Seek to the starttime argument.  */
-  for (it = s + 1, i = 0; i < 19 && it != NULL; i++, it = strchr (it, ' ') + 1);
+  for (it = s + 1, i = 0; i < 19 && it != NULL; i++, it = strchr (it, ' ') + 1)
+    ;
 
   if (it == NULL || i != 19)
     return crun_make_error (err, 0, "could not read process start time");

--- a/tests/init.c
+++ b/tests/init.c
@@ -209,10 +209,14 @@ int main (int argc, char **argv)
     }
   if (strcmp (argv[1], "pause") == 0)
     {
+      unsigned int remaining = 120;
+
       close (1);
       close (2);
-      /* Make sure the process doesn't hang forever.  */
-      sleep (120);
+
+      while (remaining)
+        remaining = sleep (remaining);
+
       exit (0);
     }
   if (strcmp (argv[1], "forkbomb") == 0)

--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -91,7 +91,7 @@ def test_cr1():
     return 0
 
 all_tests = {
-    "checkpoint restore" : test_cr1,
+    "checkpoint-restore" : test_cr1,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix a potential race condition when writing the pid to the sync socket as the child process also uses the same socket.  Now the child process waits until the grand-parent received the pid.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>
