### PR TITLE
nix build --file nix/ --arg enableSystemd false

### DIFF
--- a/build-aux/release.sh
+++ b/build-aux/release.sh
@@ -45,7 +45,7 @@ cp ./result/bin/crun $OUTDIR/crun-$VERSION-linux-amd64
 rm -rf result
 
 $RUNTIME run --rm --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix \
-    nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/ --arg disableSystemd true
+    nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/ --arg enableSystemd false
 cp ./result/bin/crun $OUTDIR/crun-$VERSION-linux-amd64-disable-systemd
 
 rm -rf result

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,4 +1,4 @@
-{ system ? builtins.currentSystem, disableSystemd ? false }:
+{ system ? builtins.currentSystem, enableSystemd ? true }:
 let
   pkgs = (import ./nixpkgs.nix {
     config = {
@@ -62,7 +62,7 @@ let
     nativeBuildInputs = [ autoreconfHook bash git pkg-config python3 which ];
     buildInputs = [ glibc glibc.static criu libcap libseccomp protobufc systemd yajl ];
     configureFlags = [ "--enable-static" ]
-      ++ lib.optional disableSystemd [ "--disable-systemd" ];
+      ++ lib.optional (!enableSystemd) [ "--disable-systemd" ];
     prePatch = ''
       export CFLAGS='-static'
       export LDFLAGS='-s -w -static-libgcc -static'


### PR DESCRIPTION
From https://github.com/NixOS/nixpkgs/search?q=enableSystemd, in nix style most packages are using `enableSystemd` instead of `disableSystemd`.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@gmail.com>