### PR TITLE
libcrun: update masked and readonly paths of /proc

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -246,15 +246,18 @@ static char spec_file[] = "\
 			}\n\
 		],\n\
 		\"maskedPaths\": [\n\
+			\"/proc/acpi\",\n\
+			\"/proc/asound\",\n\
 			\"/proc/kcore\",\n\
+			\"/proc/keys\",\n\
 			\"/proc/latency_stats\",\n\
 			\"/proc/timer_list\",\n\
 			\"/proc/timer_stats\",\n\
 			\"/proc/sched_debug\",\n\
-			\"/sys/firmware\"\n\
+			\"/sys/firmware\",\n\
+			\"/proc/scsi\"\n\
 		],\n\
 		\"readonlyPaths\": [\n\
-			\"/proc/asound\",\n\
 			\"/proc/bus\",\n\
 			\"/proc/fs\",\n\
 			\"/proc/irq\",\n\


### PR DESCRIPTION
Related issues:
* https://github.com/moby/moby/pull/37404
* https://github.com/moby/moby/pull/38299
* https://github.com/moby/moby/pull/36368
* https://github.com/moby/moby/pull/35399

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>