### PR TITLE
libcrun: set default verbosity to ERROR

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -301,6 +301,9 @@ main (int argc, char **argv)
   if (command == NULL)
     libcrun_fail_with_error (0, "unknown command %s", argv[first_argument]);
 
+  if (arguments.debug)
+    libcrun_set_verbosity (LIBCRUN_VERBOSITY_WARNING);
+
   ret = command->handler (&arguments, argc - first_argument, argv + first_argument, &err);
   if (ret && err)
     libcrun_fail_with_error (err->status, "%s", err->msg);

--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -299,7 +299,7 @@ log_write_to_journald (int errno_, const char *msg, bool warning, void *arg arg_
 
 static crun_output_handler output_handler = log_write_to_stderr;
 static void *output_handler_arg = NULL;
-static int output_verbosity = LIBCRUN_VERBOSITY_WARNING;
+static int output_verbosity = LIBCRUN_VERBOSITY_ERROR;
 
 void
 libcrun_set_verbosity (int verbosity)


### PR DESCRIPTION
Closes: https://github.com/containers/crun/issues/496

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>
