### PR TITLE
exec: check read bytes from sync

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2595,10 +2595,10 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
         }
     }
 
-  TEMP_FAILURE_RETRY (read (pipefd0, &b, sizeof (b)));
+  ret = TEMP_FAILURE_RETRY (read (pipefd0, &b, sizeof (b)));
   TEMP_FAILURE_RETRY (close (pipefd0));
   pipefd0 = -1;
-  if (b != '0')
+  if (ret != 1 || b != '0')
     ret = -1;
   else
     {


### PR DESCRIPTION
when reading from the exec sync pipe, make sure it reads exactly one
byte otherwise return an error.

Closes: https://github.com/containers/crun/issues/511

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>