### PR TITLE
pause, resume: check for cgroup before using it

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -1520,6 +1520,9 @@ libcrun_cgroup_pause_unpause_with_mode (const char *cgroup_path, int cgroup_mode
   const char *state = "";
   int ret;
 
+  if (cgroup_path == NULL || cgroup_path[0] == '\0')
+    return crun_make_error (err, 0, "cannot %s the container without a cgroup", pause ? "pause" : "resume");
+
   if (cgroup_mode == CGROUP_MODE_UNIFIED)
     {
       state = pause ? "1" : "0";

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2959,6 +2959,7 @@ configure_init_status (struct init_status_s *ns, libcrun_container_t *container,
     {
       libcrun_warning ("non root user need to have an 'user' namespace");
       ns->all_namespaces |= CLONE_NEWUSER;
+      ns->namespaces_to_unshare |= CLONE_NEWUSER;
     }
 
   return 0;


### PR DESCRIPTION
make sure the container has a cgroup, otherwise return a better error message.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
