### PR TITLE
README.md: use console syntax hl for cli examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ containers, the containers run `/bin/true`:
 crun requires fewer resources, so it is also possible to set stricter
 limits on the memory and number of PIDs allowed in the container:
 
-``` shell
+```console
 # podman --runtime /usr/bin/runc run --rm --pids-limit 1 fedora echo it works
 Error: container_linux.go:346: starting container process caused "process_linux.go:319: getting the final child's pid from pipe caused \"EOF\"": OCI runtime error
 
@@ -64,16 +64,16 @@ These dependencies are required for the build:
 
 ### Fedora
 
-``` shell
-dnf install -y make python git gcc automake autoconf libcap-devel \
+```console
+$ sudo dnf install -y make python git gcc automake autoconf libcap-devel \
     systemd-devel yajl-devel libseccomp-devel \
     go-md2man glibc-static python3-libmount libtool
 ```
 
 ### RHEL/CentOS 8
 
-``` shell
-yum --enablerepo='*' install -y make automake autoconf gettext \
+```console
+$ sudo yum --enablerepo='*' install -y make automake autoconf gettext \
     libtool gcc libcap-devel systemd-devel yajl-devel \
     libseccomp-devel python36 libtool
 ```
@@ -82,25 +82,25 @@ go-md2man is not available on RHEL/CentOS 8, so if you'd like to build
 the man page, you also need to manually install go-md2man. It can be
 installed with:
 
-``` shell
-yum --enablerepo='*' install -y golang
-export GOPATH=$HOME/go
-go get github.com/cpuguy83/go-md2man
-export PATH=$PATH:$GOPATH/bin
+```console
+$ sudo yum --enablerepo='*' install -y golang
+$ export GOPATH=$HOME/go
+$ go get github.com/cpuguy83/go-md2man
+$ export PATH=$PATH:$GOPATH/bin
 ```
 
 ### Ubuntu
 
-``` shell
-apt-get install -y make git gcc build-essential pkgconf libtool \
+```console
+$ sudo apt-get install -y make git gcc build-essential pkgconf libtool \
    libsystemd-dev libcap-dev libseccomp-dev libyajl-dev \
    go-md2man libtool autoconf python3 automake
 ```
 
 ### Alpine
 
-``` shell
-apk add gcc automake autoconf libtool gettext pkgconf git make musl-dev \
+```console
+# apk add gcc automake autoconf libtool gettext pkgconf git make musl-dev \
     python3 libcap-dev libseccomp-dev yajl-dev argp-standalone go-md2man
 ```
 
@@ -112,16 +112,16 @@ afterwards.
 
 Once all the dependencies are installed:
 
-``` shell
-./autogen.sh
-./configure
-make
+```console
+$ ./autogen.sh
+$ ./configure
+$ make
 ```
 
 To install into default PREFIX (`/usr/local`):
 
-``` shell
-sudo make install
+```console
+$ sudo make install
 ```
 
 ### Shared Libraries
@@ -141,8 +141,8 @@ stripped ELF binary for [glibc](https://www.gnu.org/software/libc).
 
 To build the binaries by locally installing the nix package manager:
 
-``` shell
-nix build -f nix/
+```console
+$ nix build -f nix/
 ```
 
 ### Ansible
@@ -151,13 +151,13 @@ An [Ansible Role](https://github.com/alvistack/ansible-role-crun) is
 also available to automate the installation of the above statically
 linked binary on its supported OS:
 
-``` shell
-sudo su -
-mkdir -p ~/.ansible/roles
-cd ~/.ansible/roles
-git clone https://github.com/alvistack/ansible-role-crun.git crun
-cd ~/.ansible/roles/crun
-pip3 install --upgrade --ignore-installed --requirement requirements.txt
-molecule converge
-molecule verify
+```console
+$ sudo su -
+# mkdir -p ~/.ansible/roles
+# cd ~/.ansible/roles
+# git clone https://github.com/alvistack/ansible-role-crun.git crun
+# cd ~/.ansible/roles/crun
+# pip3 install --upgrade --ignore-installed --requirement requirements.txt
+# molecule converge
+# molecule verify
 ```


### PR DESCRIPTION
... and add `$` / `#` / `sudo` appropriately.

Surely there's a fine line between `shell` and `console`, but I feel the latter is more appropriate here. For one thing, lines started with `#` are no longer typeset as comments.