### PR TITLE
seccomp: ignore ENOENT

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1420,6 +1420,10 @@ wait_for_process (pid_t pid, libcrun_context_t *context, int terminal_fd, int no
       conf.bundle_path = context->bundle;
       conf.oci_config_path = oci_config_path;
 
+      ret = set_blocking_fd (seccomp_notify_fd, 0, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+
       ret = libcrun_load_seccomp_notify_plugins (&seccomp_notify_ctx, seccomp_notify_plugins, &conf, err);
       if (UNLIKELY (ret < 0))
         return ret;

--- a/src/libcrun/seccomp_notify.c
+++ b/src/libcrun/seccomp_notify.c
@@ -165,7 +165,11 @@ libcrun_seccomp_notify_plugins (struct seccomp_notify_context_s *ctx, int seccom
 
   ret = ioctl (seccomp_fd, SECCOMP_IOCTL_NOTIF_RECV, ctx->sreq);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "ioctl");
+    {
+      if (errno == ENOENT)
+        return 0;
+      return crun_make_error (err, errno, "ioctl");
+    }
 
   for (i = 0; i < ctx->n_plugins; i++)
     {


### PR DESCRIPTION
ioctl (fd, SECCOMP_IOCTL_NOTIF_RECV, &req) returns ENOENT if the
syscall was aborted by the time the seccomp fd was signaled to be
ready.

Also, make the seccomp fd not blocking.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>