### PR TITLE
Adapt checkpoint/restore test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
       env: TEST=alpine-build
     - arch: amd64
       env: TEST=clang-format
+    - arch: amd64
+      env: TEST=checkpoint-restore
   matrix:
   - TEST=make-arm64
   - TEST=make-amd64
@@ -80,7 +82,7 @@ before_install:
 - if test $TEST = clang-format; then sudo docker build -t crun-clang-format tests/clang-format; fi
 - git clone --depth=1 git://github.com/lloyd/yajl
 - "(cd yajl && ./configure -p /usr && make && sudo make install)"
-# CRIU supports armhfp, aarch64, ppc64le, s390x and x86_64. The PPA has only packages for x86_64
+# The Travis environment is too unprivileged to run CRIU on anything but x86_64 (aarch64, ppc64le and s390x are LXD containers)
 - if test $TRAVIS_CPU_ARCH = amd64; then sudo add-apt-repository -y ppa:criu/ppa; sudo apt-get -q update; sudo apt-get -y install criu; fi
 script:
 - if test $TEST = make-arm64 || test $TEST = make-amd64 || test $TEST = make-ppc64le || test $TEST = make-s390x; then ./autogen.sh && ./configure CFLAGS='-Wall -Werror' && make -j $(nproc) && make syntax-check; fi
@@ -92,3 +94,4 @@ script:
 - if test $TEST = coverity; then ./autogen.sh && eval "${COVERITY_SCAN_BUILD}"; fi
 - if test $TEST = alpine-build; then sudo docker run --privileged --rm -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave -v $(pwd):/crun crun-alpine-build; fi
 - if test $TEST = clang-format; then ./autogen.sh && ./configure && sudo docker run --rm -w /crun -v $(pwd):/crun crun-clang-format make clang-format; fi
+- if test $TEST = checkpoint-restore; then ./autogen.sh && ./configure && make -j $(nproc) && sudo python3 tests/test_checkpoint_restore.py; fi

--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -58,7 +58,7 @@ def test_cr1():
         first_cmdline = cmdline_fd.read()
         cmdline_fd.close()
 
-        run_crun_command(["_checkpoint", "--image-path=%s" % cr_dir, cid])
+        run_crun_command(["checkpoint", "--image-path=%s" % cr_dir, cid])
 
         bundle = os.path.join(
             get_tests_root(),
@@ -66,7 +66,7 @@ def test_cr1():
         )
 
         run_crun_command([
-            "_restore",
+            "restore",
             "-d",
             "--image-path=%s" % cr_dir,
             "--bundle=%s" % bundle,


### PR DESCRIPTION
Now that crun supports 'checkpoint' and 'restore' instead of '_checkpoint' and '_restore', the tests also need to be adapted.

Also run the test in Travis using sudo to actually test it in CI.

