### PR TITLE
Fix checkpoint/restore with cgroup v1

### DIFF
--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -33,11 +33,6 @@ def test_cr1():
     add_all_namespaces(conf)
     # User namespace support not working yet for checkpoint/restore
     conf['linux']['namespaces'].remove({'type':'user'})
-    for i in conf['mounts']:
-        # Also remove the cgroup mount as CRIU cgroup2 support
-        # has not been yet merged upstream
-        if i['type'] == 'cgroup':
-            conf['mounts'].remove(i)
     cid = None
     cr_dir = os.path.join(get_tests_root(), 'checkpoint')
     try:


### PR DESCRIPTION
Unfortunately I never tested the checkpoint/restore support with cgroup v1 system to detect that it was not working.

CRIU must be told how to mount each cgroup v1 controller/folder from which location back into the container. With v2 it is all happening automatically as it is just a single mount.

This adds cgroup v1 support to crun's checkpoint/restore implementation and also makes sure tests are running with a mounted cgroup in the container.

Fixes: #538