### PR TITLE
libcrun: fallback to openat if openat2 returns EPERM

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -332,7 +332,7 @@ safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *path,
         {
           if (errno == ENOSYS)
             openat2_supported = false;
-          if (errno == ENOSYS || errno == EINVAL)
+          if (errno == ENOSYS || errno == EINVAL || errno == EPERM)
             goto fallback;
           return crun_make_error (err, errno, "openat2 `%s`", path);
         }


### PR DESCRIPTION
systemd-nspawn explictly blocks openat2 by default, relying on
implementations to fall back to older, openat code. However, it does
that by setting up a seccomp rule that returns EPERM, which libcrun is
treating as an error and thus not falling back.

Add EPERM to the list of ENOSYS/EINVAL for which openat2 errors are
ignored, and the openat fallback is attempted.

Closes: https://github.com/containers/crun/issues/545

Signed-off-by: Faidon Liambotis <paravoid@debian.org>