### PR TITLE
linux: allow arbitrary IDs with single ID userns

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -558,6 +558,18 @@ The current user is mapped to the ID 0 in the container, and any
 additional id specified in the files \fB\fC/etc/subuid\fR and \fB\fC/etc/subgid\fR
 is automatically added starting with ID 1.
 
+.SH Intermediate user namespace
+.PP
+If the configuration specifies a new user namespace made of a single
+mapping to the root user, but either the UID or the GID are set as
+nonzero then crun automatically creates another user namespace to map
+the root user to the specified UID and GID.
+
+.PP
+It enables running unprivileged containers with UID and GID different
+than zero, even when a single UID and GID are available, e.g. rootless
+users on a system without newuidmap/newgidmap.
+
 
 .SH CGROUP v2
 .PP

--- a/crun.1
+++ b/crun.1
@@ -413,7 +413,7 @@ Allow shell jobs
 crun [global options] restore [options] CONTAINER
 
 .PP
-\fB-b\fP, \fB\-\-bundle\fP=\fBDIR\fP
+\fB\-b DIR\fP \fB\-\-bundle\fP=\fBDIR\fP
 Container bundle directory (default ".")
 
 .PP
@@ -443,6 +443,7 @@ Detach from the container's process
 .PP
 \fB\-\-pid\-file\fP=\fBFILE\fP
 Where to write the PID of the container
+
 
 .SH Extensions to OCI
 .SH \fB\fCrun.oci.seccomp.receiver=PATH\fR
@@ -560,9 +561,8 @@ is automatically added starting with ID 1.
 
 .SH CGROUP v2
 .PP
-crun has some basic support for cgroup v2.  Since the OCI spec is
-designed for cgroup v1, in some cases there is need to convert from
-the cgroup v1 configuration to cgroup v2.
+If the cgroup configuration found is for cgroup v1, crun attempts a
+conversion when running on a cgroup v2 system.
 
 .PP
 These are the OCI resources currently supported with cgroup v2 and how

--- a/crun.1.md
+++ b/crun.1.md
@@ -448,6 +448,17 @@ The current user is mapped to the ID 0 in the container, and any
 additional id specified in the files `/etc/subuid` and `/etc/subgid`
 is automatically added starting with ID 1.
 
+## Intermediate user namespace
+
+If the configuration specifies a new user namespace made of a single
+mapping to the root user, but either the UID or the GID are set as
+nonzero then crun automatically creates another user namespace to map
+the root user to the specified UID and GID.
+
+It enables running unprivileged containers with UID and GID different
+than zero, even when a single UID and GID are available, e.g. rootless
+users on a system without newuidmap/newgidmap.
+
 # CGROUP v2
 
 If the cgroup configuration found is for cgroup v1, crun attempts a

--- a/crun.1.md
+++ b/crun.1.md
@@ -450,9 +450,8 @@ is automatically added starting with ID 1.
 
 # CGROUP v2
 
-crun has some basic support for cgroup v2.  Since the OCI spec is
-designed for cgroup v1, in some cases there is need to convert from
-the cgroup v1 configuration to cgroup v2.
+If the cgroup configuration found is for cgroup v1, crun attempts a
+conversion when running on a cgroup v2 system.
 
 These are the OCI resources currently supported with cgroup v2 and how
 they are converted when needed from the cgroup v1 configuration.

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -403,6 +403,40 @@ sync_socket_send_sync (int fd, bool flush_errors, libcrun_error_t *err)
   return 0;
 }
 
+/*
+  Create an intermediate user namespace if there is a single id mapped
+  inside of the container user namespace and the container wants to run
+  with a different UID/GID than root.
+*/
+static bool
+need_intermediate_userns (runtime_spec_schema_config_schema *def)
+{
+  runtime_spec_schema_config_schema_process *process = def->process;
+  uid_t container_uid;
+  gid_t container_gid;
+
+  if (process == NULL)
+    return false;
+
+  container_uid = process->user ? process->user->uid : 0;
+  container_gid = process->user ? process->user->gid : 0;
+
+  if (container_uid == 0 && container_gid == 0)
+    return false;
+
+  if (def->linux->uid_mappings_len != 1 || def->linux->gid_mappings_len != 1)
+    return false;
+
+  if (def->linux->uid_mappings[0]->size != 1 || def->linux->gid_mappings[0]->size != 1)
+    return false;
+
+  if (def->linux->uid_mappings[0]->container_id == container_uid
+      && def->linux->gid_mappings[0]->container_id == container_gid)
+    return false;
+
+  return true;
+}
+
 static libcrun_container_t *
 make_container (runtime_spec_schema_config_schema *container_def)
 {
@@ -411,6 +445,8 @@ make_container (runtime_spec_schema_config_schema *container_def)
 
   container->host_uid = geteuid ();
   container->host_gid = getegid ();
+
+  container->use_intermediate_userns = need_intermediate_userns (container_def);
 
   return container;
 }
@@ -896,6 +932,13 @@ container_init_setup (void *args, char *notify_socket, int sync_socket, const ch
 
       close_and_reset (&entrypoint_args->seccomp_fd);
       close_and_reset (&entrypoint_args->seccomp_receiver_fd);
+    }
+
+  if (entrypoint_args->container->use_intermediate_userns)
+    {
+      ret = libcrun_create_final_userns (entrypoint_args->container, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
     }
 
   capabilities = def->process ? def->process->capabilities : NULL;

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -66,6 +66,8 @@ struct libcrun_container_s
   uid_t container_uid;
   gid_t container_gid;
 
+  bool use_intermediate_userns;
+
   void *private_data;
   struct libcrun_context_s *context;
 };

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2593,6 +2593,18 @@ libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err)
   return libcrun_set_sysctl_from_schema (container->container_def, err);
 }
 
+static uid_t
+get_uid_for_intermediate_userns (libcrun_container_t *container)
+{
+  if (container->use_intermediate_userns)
+    return 0;
+
+  if (container->container_def->process && container->container_def->process->user)
+    return container->container_def->process->user->uid;
+
+  return 0;
+}
+
 static int
 open_terminal (libcrun_container_t *container, char **pty, libcrun_error_t *err)
 {
@@ -2610,7 +2622,9 @@ open_terminal (libcrun_container_t *container, char **pty, libcrun_error_t *err)
   if (container->container_def->process && container->container_def->process->user
       && container->container_def->process->user->uid)
     {
-      ret = chown (*pty, container->container_def->process->user->uid, -1);
+      uid_t uid = get_uid_for_intermediate_userns (container);
+
+      ret = chown (*pty, uid, -1);
       if (UNLIKELY (ret < 0))
         return crun_make_error (err, errno, "chown `%s`", *pty);
     }
@@ -3781,6 +3795,118 @@ libcrun_kill_linux (libcrun_container_status_t *status, int signal, libcrun_erro
   ret = syscall_pidfd_send_signal (pidfd, signal, NULL, 0);
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "send signal to pidfd");
+
+  return 0;
+}
+
+/*
+   Used when creating an intermediate user namespace.
+   If the container is running with a single UID/GID mapped, and specifies
+   a different UID/GID, then create an intermediate user namespace to do
+   all the configuration as root, and then once the container is set up,
+   create a new user namespace to map root to the desired UID/GID.
+   This implementation has some issues as some namespaces in the container
+   won't be owned by the final user namespace and it creates a process inside
+   the container PID namespace, so the next created process won't have pid=2.
+   Some of these issues could be solved or at least mitigated, but it is not worth
+   at the moment to add more complexity to address these corner cases.
+*/
+int
+libcrun_create_final_userns (libcrun_container_t *container, libcrun_error_t *err)
+{
+  runtime_spec_schema_config_schema *def = container->container_def;
+  cleanup_close int closep0 = -1;
+  cleanup_close int closep1 = -1;
+  int pid_status;
+  pid_t pid, target_pid;
+  int p[2];
+  int ret;
+  int i, to_unshare;
+
+  ret = pipe2 (p, O_CLOEXEC);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "create pipe2");
+
+  closep0 = p[0];
+  closep1 = p[1];
+
+  target_pid = getpid ();
+
+  pid = fork ();
+  if (UNLIKELY (pid < 0))
+    return crun_make_error (err, errno, "fork");
+
+  if (pid == 0)
+    {
+      cleanup_free char *uid_map_file = NULL;
+      cleanup_free char *gid_map_file = NULL;
+      cleanup_free char *uid_map = NULL;
+      cleanup_free char *gid_map = NULL;
+      char buffer[1];
+      size_t len;
+      uid_t uid;
+      gid_t gid;
+
+      close_and_reset (&closep1);
+
+      ret = TEMP_FAILURE_RETRY (read (p[0], buffer, sizeof (buffer)));
+      if (UNLIKELY (ret < 0))
+        _exit (errno);
+
+      if (container->container_def->process && container->container_def->process->user)
+        {
+          uid = container->container_def->process->user->uid;
+          gid = container->container_def->process->user->gid;
+        }
+      xasprintf (&uid_map_file, "/proc/%d/uid_map", target_pid);
+      xasprintf (&gid_map_file, "/proc/%d/gid_map", target_pid);
+
+      len = xasprintf (&gid_map, "%d 0 1", gid);
+      ret = write_file (gid_map_file, gid_map, len, err);
+      if (UNLIKELY (ret < 0))
+        _exit (crun_error_get_errno (err));
+
+      len = xasprintf (&uid_map, "%d 0 1", uid);
+      ret = write_file (uid_map_file, uid_map, len, err);
+      if (UNLIKELY (ret < 0))
+        _exit (crun_error_get_errno (err));
+
+      _exit (EXIT_SUCCESS);
+    }
+
+  close_and_reset (&closep0);
+
+  ret = unshare (CLONE_NEWUSER);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "unshare (CLONE_USERNS)");
+
+  ret = TEMP_FAILURE_RETRY (write (p[1], "0", 1));
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "write to sync pipe");
+
+  ret = TEMP_FAILURE_RETRY (waitpid (pid, &pid_status, 0));
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "waitpid for exec child pid");
+
+  if (UNLIKELY (WEXITSTATUS (pid_status) != 0))
+    return crun_make_error (err, WEXITSTATUS (pid_status), "setting mapping for final userns");
+
+  to_unshare = 0;
+  for (i = 0; i < def->linux->namespaces_len; i++)
+    {
+      if (def->linux->namespaces[i]->path != NULL
+          && def->linux->namespaces[i]->path[0] != '\0')
+        continue;
+
+      to_unshare |= libcrun_find_namespace (def->linux->namespaces[i]->type);
+    }
+
+  if (to_unshare)
+    {
+      ret = unshare (to_unshare & (CLONE_NEWIPC|CLONE_NEWNET|CLONE_NEWNS));
+      if (UNLIKELY (ret < 0))
+        return crun_make_error (err, errno, "unshare");
+    }
 
   return 0;
 }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2360,11 +2360,11 @@ set_required_caps (struct all_caps_s *caps, uid_t uid, gid_t gid, int no_new_pri
 
   ret = setgid (gid);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "cannot setgid");
+    return crun_make_error (err, errno, "cannot setgid to %d", gid);
 
   ret = setuid (uid);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "cannot setuid");
+    return crun_make_error (err, errno, "cannot setuid to %d", uid);
 
   ret = capset (&hdr, data);
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -70,4 +70,5 @@ int libcrun_find_namespace (const char *name);
 char *libcrun_get_external_descriptors (libcrun_container_t *container);
 int libcrun_container_setgroups (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_kill_linux (libcrun_container_status_t *status, int signal, libcrun_error_t *err);
+int libcrun_create_final_userns (libcrun_container_t *container, libcrun_error_t *err);
 #endif


### PR DESCRIPTION
Create an intermediate user namespace if there is a single id mapped inside of the container user namespace and the container is configured to not run as root in the user namespace.
    
With such configuration, crun automatically creates a new user namespace where the desired UID/GID is mapped to root in the
intermediate user namespace used to configure the container.
    
This enables running with an UID/GID different than root when a rootless user has no access to multiple IDs:
    
$ podman run --rm --user 1000:1000 --uidmap 0:0:1 fedora:33 id
uid=1000(1000) gid=1000(1000) groups=1000(1000)
    
One limitation in the current implementation is that some namespaces, like pidns are not owned by the final user namespace.
    
Idea copied from bubblewrap.
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
