### PR TITLE
linux, init: allow mappings without root

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3879,7 +3879,7 @@ libcrun_create_final_userns (libcrun_container_t *container, libcrun_error_t *er
 
   ret = unshare (CLONE_NEWUSER);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "unshare (CLONE_USERNS)");
+    return crun_make_error (err, errno, "unshare (CLONE_NEWUSER)");
 
   ret = TEMP_FAILURE_RETRY (write (p[1], "0", 1));
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3000,6 +3000,63 @@ configure_init_status (struct init_status_s *ns, libcrun_container_t *container,
   return 0;
 }
 
+/* Detect if root is available in the container.  */
+static bool
+root_mapped_in_container_p (runtime_spec_schema_defs_id_mapping **mappings, size_t len)
+{
+  size_t i;
+
+  for (i = 0; i < len; i++)
+    if (mappings[i]->container_id == 0)
+        return true;
+
+  return false;
+}
+
+static int
+set_id_init (libcrun_container_t *container, libcrun_error_t *err)
+{
+  runtime_spec_schema_config_schema *def = container->container_def;
+  uid_t uid = 0;
+  gid_t gid = 0;
+  int ret;
+
+  if (def->process && def->process->user && def->linux)
+    {
+      /*
+        If it is running in a user namespace and root is not mapped
+        use the UID/GID specified for running the container.
+      */
+      bool root_mapped = false;
+
+      if (def->linux->uid_mappings_len != 0)
+        {
+          root_mapped = root_mapped_in_container_p (def->linux->uid_mappings,
+                                                    def->linux->uid_mappings_len);
+          if (!root_mapped)
+            uid = def->process->user->uid;
+        }
+
+      if (def->linux->gid_mappings_len != 0)
+        {
+          root_mapped = root_mapped_in_container_p (def->linux->gid_mappings,
+                                                    def->linux->gid_mappings_len);
+          if (!root_mapped)
+            gid = def->process->user->gid;
+        }
+    }
+
+  ret = setresuid (uid, uid, uid);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "setresuid to %d", uid);
+
+  ret = setresgid (gid, gid, gid);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "setresgid to %d", gid);
+
+  return 0;
+}
+
 static int
 init_container (libcrun_container_t *container, int sync_socket_container, struct init_status_s *init_status,
                 libcrun_error_t *err)
@@ -3072,13 +3129,9 @@ init_container (libcrun_container_t *container, int sync_socket_container, struc
                                     def->linux->namespaces[init_status->userns_index_origin]->path);
         }
 
-      ret = setresuid (0, 0, 0);
+      ret = set_id_init (container, err);
       if (UNLIKELY (ret < 0))
-        return crun_make_error (err, errno, "setresuid(0)");
-
-      ret = setresgid (0, 0, 0);
-      if (UNLIKELY (ret < 0))
-        return crun_make_error (err, errno, "setresgid(0)");
+        return ret;
     }
 
   ret = join_namespaces (def, init_status->fd, init_status->fd_len, init_status->index, false, err);
@@ -3575,19 +3628,9 @@ libcrun_join_process (libcrun_container_t *container, pid_t pid_to_join, libcrun
               send_error_to_sync_socket_and_die (sync_fd, true, err);
             }
 
-          ret = setresuid (0, 0, 0);
+          ret = set_id_init (container, err);
           if (UNLIKELY (ret < 0))
-            {
-              crun_make_error (err, errno, "setgid");
-              send_error_to_sync_socket_and_die (sync_fd, true, err);
-            }
-
-          ret = setresgid (0, 0, 0);
-          if (UNLIKELY (ret < 0))
-            {
-              crun_make_error (err, errno, "setuid");
-              send_error_to_sync_socket_and_die (sync_fd, true, err);
-            }
+            send_error_to_sync_socket_and_die (sync_fd, true, err);
 
           ptmx_fd = open_terminal (container, &pty, err);
           if (UNLIKELY (ptmx_fd < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2358,13 +2358,13 @@ set_required_caps (struct all_caps_s *caps, uid_t uid, gid_t gid, int no_new_pri
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "error while setting PR_SET_KEEPCAPS");
 
-  ret = setgid (gid);
+  ret = setresgid (gid, gid, gid);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "cannot setgid to %d", gid);
+    return crun_make_error (err, errno, "cannot setresgid to %d", gid);
 
-  ret = setuid (uid);
+  ret = setresuid (uid, uid, uid);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "cannot setuid to %d", uid);
+    return crun_make_error (err, errno, "cannot setresuid to %d", uid);
 
   ret = capset (&hdr, data);
   if (UNLIKELY (ret < 0))

--- a/tests/containerd/Dockerfile
+++ b/tests/containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:eoan
+FROM ubuntu:groovy
 
 ENV GOPATH=/root/go
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/go/bin
@@ -6,7 +6,7 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/go/b
 RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get install -y bash golang-1.13 libbtrfs-dev libnl-3-dev libnet1-dev \
-            protobuf-c-compiler python-minimal libcap-dev libaio-dev \
+            protobuf-c-compiler libcap-dev libaio-dev \
             curl libprotobuf-c-dev libprotobuf-dev socat libseccomp-dev \
             pigz lsof make git gcc build-essential pkgconf libtool \
             libsystemd-dev libcap-dev libyajl-dev \


### PR DESCRIPTION
set the UID/GID used the initial configuration to the final UID/GID used in the container when root is not available in the container user namespace.

Such configuration can happen for example when a single mapping is used for rootless containers and it is mapped to the final UID/GID used in the container.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
