### PR TITLE
exec: move close_fds before applying seccomp

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -816,7 +816,7 @@ container_init_setup (void *args, char *notify_socket, int sync_socket, const ch
         return ret;
     }
 
-  ret = close_fds_ge_than (entrypoint_args->context->preserve_fds + 3, err);
+  ret = mark_for_close_fds_ge_than (entrypoint_args->context->preserve_fds + 3, err);
   if (UNLIKELY (ret < 0))
     crun_error_write_warning_and_release (entrypoint_args->context->output_handler_arg, &err);
 
@@ -2702,7 +2702,7 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
             return ret;
         }
 
-      ret = close_fds_ge_than (context->preserve_fds + 3, err);
+      ret = mark_for_close_fds_ge_than (context->preserve_fds + 3, err);
       if (UNLIKELY (ret < 0))
         libcrun_fail_with_error ((*err)->status, "%s", (*err)->msg);
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2702,6 +2702,10 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
             return ret;
         }
 
+      ret = close_fds_ge_than (context->preserve_fds + 3, err);
+      if (UNLIKELY (ret < 0))
+        libcrun_fail_with_error ((*err)->status, "%s", (*err)->msg);
+
       if (! process->no_new_privileges)
         {
           ret = libcrun_apply_seccomp (seccomp_fd, seccomp_receiver_fd, seccomp_flags, seccomp_flags_len, err);
@@ -2726,10 +2730,6 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
           if (UNLIKELY (ret < 0))
             libcrun_fail_with_error ((*err)->status, "%s", (*err)->msg);
         }
-
-      ret = close_fds_ge_than (context->preserve_fds + 3, err);
-      if (UNLIKELY (ret < 0))
-        libcrun_fail_with_error ((*err)->status, "%s", (*err)->msg);
 
       if (process->no_new_privileges)
         {

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1401,7 +1401,7 @@ run_process_with_stdin_timeout_envp (char *path, char **args, const char *cwd, i
 }
 
 int
-close_fds_ge_than (int n, libcrun_error_t *err)
+mark_for_close_fds_ge_than (int n, libcrun_error_t *err)
 {
   cleanup_close int cfd = -1;
   cleanup_dir DIR *dir = NULL;

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -214,7 +214,7 @@ size_t format_default_id_mapping (char **ret, uid_t container_id, uid_t host_id,
 int run_process_with_stdin_timeout_envp (char *path, char **args, const char *cwd, int timeout, char **envp,
                                          char *stdin, size_t stdin_len, int out_fd, int err_fd, libcrun_error_t *err);
 
-int close_fds_ge_than (int n, libcrun_error_t *err);
+int mark_for_close_fds_ge_than (int n, libcrun_error_t *err);
 
 void get_current_timestamp (char *out);
 


### PR DESCRIPTION
otherwise the seccomp profile could block some of the syscalls involved.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>