### PR TITLE
libcrun: add function append_paths

### DIFF
--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -247,6 +247,8 @@ int safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *p
 
 ssize_t safe_write (int fd, const void *buf, ssize_t count);
 
+int append_paths (char **out, libcrun_error_t *err, ...);
+
 LIBCRUN_PUBLIC int libcrun_str2sig (const char *name);
 
 #endif


### PR DESCRIPTION
it enables appending path components and taking care of dropping additional slashes between them.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
