### PR TITLE
linux: drop optimization to avoid fork

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3304,16 +3304,6 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
               break;
             }
         }
-      /* It creates a new PID namespace, without a user namespace, we can try to
-         join it immediately without another fork.  */
-      if (i == init_status.fd_len && (init_status.all_namespaces & CLONE_NEWUSER) == 0)
-        {
-          if (unshare (CLONE_NEWPID) == 0)
-            {
-              init_status.namespaces_to_unshare &= ~CLONE_NEWPID;
-              init_status.must_fork = false;
-            }
-        }
     }
 #ifdef CLONE_NEWTIME
   if (init_status.all_namespaces & CLONE_NEWTIME)

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1368,6 +1368,10 @@ run_process_with_stdin_timeout_envp (char *path, char **args, const char *cwd, i
       char *tmp_args[] = { path, NULL };
       int dev_null_fd = -1;
 
+      ret = mark_for_close_fds_ge_than (3, err);
+      if (UNLIKELY (ret < 0))
+        libcrun_fail_with_error ((*err)->status, "%s", (*err)->msg);
+
       if (out_fd < 0 || err_fd < 0)
         {
           dev_null_fd = open ("/dev/null", O_WRONLY);


### PR DESCRIPTION
it causes issues with hooks that run in the container PID namespace instead of the runtime namespace.

revert 54b8ed3f54a98f869baf15167767b7a4c8622c2f

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
