### PR TITLE
linux: clone before setns(CLONE_NEWPID|CLONE_NEWTIME)

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3170,10 +3170,10 @@ init_container (libcrun_container_t *container, int sync_socket_container, struc
   if (UNLIKELY (ret < 0))
     return ret;
 
-  if (init_status->namespaces_to_unshare)
+  if (init_status->namespaces_to_unshare & ~CLONE_NEWCGROUP)
     {
       /* New namespaces to create for the container.  */
-      ret = unshare (init_status->namespaces_to_unshare);
+      ret = unshare (init_status->namespaces_to_unshare & ~CLONE_NEWCGROUP);
       if (UNLIKELY (ret < 0))
         return crun_make_error (err, errno, "unshare");
     }
@@ -3328,7 +3328,7 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
     }
   else
     {
-      int can_clone = init_status.namespaces_to_unshare & ~CLONE_NEWTIME;
+      int can_clone = init_status.namespaces_to_unshare & ~(CLONE_NEWTIME|CLONE_NEWCGROUP);
 
       pid = syscall_clone (can_clone | SIGCHLD, NULL);
       if (UNLIKELY (pid < 0))

--- a/tests/podman/run-tests.sh
+++ b/tests/podman/run-tests.sh
@@ -18,10 +18,7 @@ export GO111MODULE=off
 ulimit -u unlimited
 export TMPDIR=/var/tmp
 
-# Skip some tests that are not currently supported:
-#
-# - checkpoint
-#  crun doesn't support CRIU.
+# Skip some tests that are not currently supported in the testing environment:
 #
 # - search|trust|inspect|logs|generate|import|mounted rw|inherit host devices|privileged CapEff|
 #   Flaky or not using the runtime.
@@ -34,8 +31,9 @@ export TMPDIR=/var/tmp
 #
 # - podman run exit 12*|podman run exit code on failure to exec|failed to start
 #   assumption that "create" must fail if the executable is not found.  We must add lookup for the executable in $PATH to mimic the runc behavior.
+#   device-cgroup-rule|capabilities|network|overlay volume flag|prune removes a pod with a stopped container: not working on github actions
 
 
-ginkgo --focus='.*' --skip='.*(checkpoint|selinux|notify_socket|systemd|podman run exit 12*|podman run exit code on failure to exec|failed to start|search|trust|inspect|logs|generate|import|mounted rw|inherit host devices|privileged CapEff|).*' \
-	 -v -tags "seccomp   ostree selinux  varlink exclude_graphdriver_devicemapper" \
+ginkgo --focus='.*' --skip='.*(selinux|notify_socket|systemd|podman run exit 12*|podman run exit code on failure to exec|failed to start|search|trust|inspect|logs|generate|import|mounted rw|inherit host devices|privileged CapEff|device-cgroup-rule|capabilities|network|--add-host|removes a pod with a container|prune removes a pod with a stopped container|overlay volume flag).*' \
+	 -v -tags "seccomp ostree selinux varlink exclude_graphdriver_devicemapper" \
 	 -timeout=50m -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -64,7 +64,7 @@ def test_resources_unified_invalid_controller():
         # must raise an exception, fail if it doesn't.
         return -1
     except Exception as e:
-        if 'the requested controller `foo` is not available' in e.stdout.decode("utf-8").strip():
+        if 'the requested cgroup controller `foo` is not available' in e.stdout.decode("utf-8").strip():
             return 0
         return -1
     finally:


### PR DESCRIPTION
follow-up to https://github.com/containers/crun/pull/569

if the container is joining an existing pid namespace, make sure to fork the process first as it could cause hooks to run in the target pidns.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
