### PR TITLE
cgroup: fix regression when setting limits

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -1620,7 +1620,11 @@ libcrun_cgroup_enter (struct libcrun_cgroup_args *args, libcrun_error_t *err)
   if (LIKELY (ret >= 0))
     {
       if (cgroup_mode == CGROUP_MODE_UNIFIED && (root_uid != (uid_t) -1 || root_gid != (gid_t) -1))
-        return chown_cgroups (*path, root_uid, root_gid, err);
+        {
+          ret = chown_cgroups (*path, root_uid, root_gid, err);
+          if (UNLIKELY (ret < 0))
+              return ret;
+        }
 
       if (args->resources)
         return libcrun_update_cgroup_resources (args->cgroup_mode, args->resources, *path, err);


### PR DESCRIPTION
when running in a user namespace, make sure to honor the cgroup
limits.

fix a regression caused by 3e2b3f224561e1845a95183d7f34247e965ccb8c

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>