### PR TITLE
seccomp: custom annotation to load raw bpf

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -467,6 +467,17 @@ are available on the \fB\fCld.so(8)\fR man page.
 If the annotation \fB\fCrun.oci.seccomp\_fail\_unknown\_syscall\fR is present, then crun
 will fail when an unknown syscall is encountered in the seccomp configuration.
 
+.SH \fB\fCrun.oci.seccomp\_bpf\_data=PATH\fR
+.PP
+If the annotation \fB\fCrun.oci.seccomp\_bpf\_data\fR is present, then crun
+ignores the seccomp section in the OCI configuration file and use the specified data
+as the raw data to the \fB\fCseccomp(SECCOMP\_SET\_MODE\_FILTER)\fR syscall.
+The data must be encoded in base64.
+
+.PP
+It is an experimental feature, and the annotation will be removed once
+it is supported in the OCI runtime specs.
+
 .SH \fB\fCrun.oci.keep\_original\_groups=1\fR
 .PP
 If the annotation \fB\fCrun.oci.keep\_original\_groups\fR is present, then crun

--- a/crun.1.md
+++ b/crun.1.md
@@ -371,6 +371,16 @@ are available on the `ld.so(8)` man page.
 If the annotation `run.oci.seccomp_fail_unknown_syscall` is present, then crun
 will fail when an unknown syscall is encountered in the seccomp configuration.
 
+## `run.oci.seccomp_bpf_data=PATH`
+
+If the annotation `run.oci.seccomp_bpf_data` is present, then crun
+ignores the seccomp section in the OCI configuration file and use the specified data
+as the raw data to the `seccomp(SECCOMP_SET_MODE_FILTER)` syscall.
+The data must be encoded in base64.
+
+It is an experimental feature, and the annotation will be removed once
+it is supported in the OCI runtime specs.
+
 ## `run.oci.keep_original_groups=1`
 
 If the annotation `run.oci.keep_original_groups` is present, then crun

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1839,7 +1839,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   if (UNLIKELY (ret < 0))
     return ret;
 
-  if (def->linux && def->linux->seccomp)
+  if (def->linux && (def->linux->seccomp || find_annotation (container, "run.oci.seccomp_bpf_data")))
     {
       ret = open_seccomp_output (context->id, &seccomp_fd, false, context->state_root, err);
       if (UNLIKELY (ret < 0))
@@ -1949,9 +1949,33 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
       if (annotation && strcmp (annotation, "0") != 0)
         seccomp_gen_options = LIBCRUN_SECCOMP_FAIL_UNKNOWN_SYSCALL;
 
-      ret = libcrun_generate_seccomp (container, seccomp_fd, seccomp_gen_options, err);
-      if (UNLIKELY (ret < 0))
-        return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
+      if ((annotation = find_annotation (container, "run.oci.seccomp_bpf_data")) != NULL)
+        {
+          cleanup_free char *bpf_data = NULL;
+          size_t size = 0;
+          size_t in_size;
+          int consumed;
+
+          in_size = strlen (annotation);
+          bpf_data = xmalloc (in_size + 1);
+
+          consumed = base64_decode (annotation, in_size, bpf_data, in_size, &size);
+          if (UNLIKELY (consumed != (int) in_size))
+            return crun_make_error (err, 0, "invalid seccomp BPF data");
+
+          ret = safe_write (seccomp_fd, bpf_data, (ssize_t) size);
+          if (UNLIKELY (ret < 0))
+            {
+              crun_make_error (err, 0, "write to seccomp fd");
+              return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
+            }
+        }
+      else
+        {
+          ret = libcrun_generate_seccomp (container, seccomp_fd, seccomp_gen_options, err);
+          if (UNLIKELY (ret < 0))
+            return cleanup_watch (context, pid, sync_socket, terminal_fd, err);
+        }
       close_and_reset (&seccomp_fd);
     }
 

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -251,4 +251,6 @@ int append_paths (char **out, libcrun_error_t *err, ...);
 
 LIBCRUN_PUBLIC int libcrun_str2sig (const char *name);
 
+int base64_decode (const char *iptr, size_t isize, char *optr, size_t osize, size_t *nbytes);
+
 #endif


### PR DESCRIPTION
Add an annotation `run.oci.seccomp_bpf_file` to ignore the seccomp
section in the OCI configuration file and use the specified file as
the raw data to the `seccomp(SECCOMP_SET_MODE_FILTER)` syscall.

I am using this feature for some experiments

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>