### PR TITLE
Fix permission error when using both user namespaces & NOTIFY_SOCKET

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1660,7 +1660,7 @@ open_seccomp_output (const char *id, int *fd, bool readonly, const char *state_r
 }
 
 /* Find the uid:gid that is mapped to root inside the container user namespace.  */
-static void
+void
 get_root_in_the_userns_for_cgroups (runtime_spec_schema_config_schema *def, uid_t host_uid, gid_t host_gid, uid_t *uid,
                                     gid_t *gid)
 {

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -143,4 +143,8 @@ LIBCRUN_PUBLIC int libcrun_container_checkpoint (libcrun_context_t *context, con
 LIBCRUN_PUBLIC int libcrun_container_restore (libcrun_context_t *context, const char *id,
                                               libcrun_checkpoint_restore_t *cr_options, libcrun_error_t *err);
 
+// Not part of the public API, just a method in container.c we need to access from linux.c
+void get_root_in_the_userns_for_cgroups (runtime_spec_schema_config_schema *def, uid_t host_uid, gid_t host_gid,
+                                         uid_t *uid, gid_t *gid);
+
 #endif


### PR DESCRIPTION
If $NOTIFY_SOCKET is set, then crun will create a proxy for this socket
in the crun state directory, and bind mount it into the container.
However, the bind mounting happens after switching to the user
namespace; if UID remapping means that the container does not in fact
have permission to read that socket, then the bind mount fails.

Because the container needs permission to read _every path component_
for the source of the bind mount, and the crun state directory /run/crun
is usually root-owned and mode 0700, this actually happens _always_ when
using containers without uid 0 mapped in.

This patch fixexs the issue by first running open_tree on the
/run/crun/<container>/notify directory in the original user namespace to
_create_ the bind mount, and only putting it in the container filesystem
with move_mount after the namespace switch.

Note that when running as non-root, open_tree in the source namespace
fails - in that case, we still fall back to the bind-mount by name path
that is currently followed. In fact, this will always work, however,
since a non-root user cannot create a user namespace where UIDs are
mapped to anything _but_ the original user; and the original user can
read crun's state directory.

Fixes #588