### PR TITLE
utils: fix symlink lookup

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1552,7 +1552,7 @@ do_mounts (libcrun_container_t *container, int rootfsfd, const char *rootfs, lib
         {
           int destfd, tmpfd;
 
-          destfd = openat (rootfsfd, target, O_DIRECTORY);
+          destfd = safe_openat (rootfsfd, rootfs, rootfs_len, target, O_DIRECTORY, 0, err);
           if (UNLIKELY (destfd < 0))
             return crun_make_error (err, errno, "open target to write for tmpcopyup");
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -436,8 +436,10 @@ crun_safe_ensure_at (bool dir, int dirfd, const char *dirpath, size_t dirpath_le
             depth--;
           else
             {
+              /* Start from the root.  */
               close_and_reset (&wd_cleanup);
               cwd = dirfd;
+              goto next;
             }
         }
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -362,6 +362,15 @@ fallback:
   while (*path_in_chroot == '/')
     path_in_chroot++;
 
+  /* If the path is empty we are at the root, dup the dirfd itself.  */
+  if (path_in_chroot[0] == '\0')
+    {
+      ret = dup (dirfd);
+      if (UNLIKELY (ret < 0))
+        return crun_make_error (err, errno, "dup `%s`", rootfs);
+      return ret;
+    }
+
   ret = openat (dirfd, path_in_chroot, flags, mode);
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "open `%s`", path);


### PR DESCRIPTION
commit 99538d805bb62fbda6e82627d8daa0b90c97a8d0 introduced this
regression.

This issue happens only on old kernel that lack openat2.

The error happens with a command like:

$ podman run --rm -v /etc/localtime:/etc/localtime ubi8 echo "This works"
Error: open `..`: No such file or directory: OCI not found

We already have tests in place to detect this case, but they were
running on newer kernels so the code path was completely skipped.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>