### PR TITLE
linux: cleanup mounts logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_PATH_PROG(MD2MAN, go-md2man)
 
 AM_CONDITIONAL([HAVE_MD2MAN], [test "x$ac_cv_path_MD2MAN" != x])
 
-AC_CHECK_HEADERS([error.h])
+AC_CHECK_HEADERS([error.h linux/openat2.h])
 
 AC_CHECK_FUNCS(copy_file_range fgetxattr statx fgetpwent_r issetugid)
 

--- a/src/create.c
+++ b/src/create.c
@@ -115,7 +115,7 @@ int
 crun_command_create (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
   int first_arg, ret;
-  libcrun_container_t *container;
+  cleanup_container libcrun_container_t *container;
   cleanup_free char *bundle_cleanup = NULL;
   cleanup_free char *config_file_cleanup = NULL;
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1670,8 +1670,8 @@ open_seccomp_output (const char *id, int *fd, bool readonly, const char *state_r
 
 /* Find the uid:gid that is mapped to root inside the container user namespace.  */
 void
-get_root_in_the_userns_for_cgroups (runtime_spec_schema_config_schema *def, uid_t host_uid, gid_t host_gid, uid_t *uid,
-                                    gid_t *gid)
+get_root_in_the_userns (runtime_spec_schema_config_schema *def, uid_t host_uid, gid_t host_gid, uid_t *uid,
+                        gid_t *gid)
 {
   *uid = -1;
   *gid = -1;
@@ -1899,7 +1899,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
   /* If we are root (either on the host or in a namespace), then chown the cgroup to root in the container user
    * namespace.  */
-  get_root_in_the_userns_for_cgroups (def, container->host_uid, container->host_gid, &root_uid, &root_gid);
+  get_root_in_the_userns (def, container->host_uid, container->host_gid, &root_uid, &root_gid);
 
   {
     struct libcrun_cgroup_args cg = {
@@ -3066,7 +3066,7 @@ libcrun_container_restore (libcrun_context_t *context, const char *id, libcrun_c
 
   /* If we are root (either on the host or in a namespace),
    * then chown the cgroup to root in the container user namespace. */
-  get_root_in_the_userns_for_cgroups (def, container->host_uid, container->host_gid, &root_uid, &root_gid);
+  get_root_in_the_userns (def, container->host_uid, container->host_gid, &root_uid, &root_gid);
 
   {
     struct libcrun_cgroup_args cg = {

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -479,6 +479,14 @@ libcrun_container_load_from_file (const char *path, libcrun_error_t *err)
   return make_container (container_def);
 }
 
+void
+libcrun_container_free (libcrun_container_t *ctr)
+{
+  if (ctr->container_def)
+    free_runtime_spec_schema_config_schema (ctr->container_def);
+  free (ctr);
+}
+
 static int
 block_signals (libcrun_error_t *err)
 {
@@ -1140,7 +1148,7 @@ static int
 run_poststop_hooks (libcrun_context_t *context, libcrun_container_t *container, runtime_spec_schema_config_schema *def,
                     libcrun_container_status_t *status, const char *state_root, const char *id, libcrun_error_t *err)
 {
-  cleanup_free libcrun_container_t *container_cleanup = NULL;
+  cleanup_container libcrun_container_t *container_cleanup = NULL;
   int ret;
 
   if (def == NULL)
@@ -1178,8 +1186,6 @@ run_poststop_hooks (libcrun_context_t *context, libcrun_container_t *container, 
       if (UNLIKELY (ret < 0))
         crun_error_write_warning_and_release (context->output_handler_arg, &err);
     }
-  if (container && container->container_def)
-    free_runtime_spec_schema_config_schema (container->container_def);
   return 0;
 }
 
@@ -2516,7 +2522,7 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
   {
     size_t i;
     cleanup_free char *config_file;
-    cleanup_free libcrun_container_t *container = NULL;
+    cleanup_container libcrun_container_t *container = NULL;
     cleanup_free char *dir = NULL;
 
     dir = libcrun_get_state_directory (state_root, id);
@@ -2550,7 +2556,6 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
           }
         yajl_gen_map_close (gen);
       }
-    free_runtime_spec_schema_config_schema (container->container_def);
   }
 
   yajl_gen_map_close (gen);
@@ -3009,7 +3014,7 @@ int
 libcrun_container_restore (libcrun_context_t *context, const char *id, libcrun_checkpoint_restore_t *cr_options,
                            libcrun_error_t *err)
 {
-  cleanup_free libcrun_container_t *container = NULL;
+  cleanup_container libcrun_container_t *container = NULL;
   runtime_spec_schema_config_schema *def;
   cleanup_free char *cgroup_path = NULL;
   libcrun_container_status_t status = {};

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -144,7 +144,7 @@ LIBCRUN_PUBLIC int libcrun_container_restore (libcrun_context_t *context, const 
                                               libcrun_checkpoint_restore_t *cr_options, libcrun_error_t *err);
 
 // Not part of the public API, just a method in container.c we need to access from linux.c
-void get_root_in_the_userns_for_cgroups (runtime_spec_schema_config_schema *def, uid_t host_uid, gid_t host_gid,
-                                         uid_t *uid, gid_t *gid);
+void get_root_in_the_userns (runtime_spec_schema_config_schema *def, uid_t host_uid, gid_t host_gid,
+                             uid_t *uid, gid_t *gid);
 
 #endif

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -95,6 +95,8 @@ LIBCRUN_PUBLIC libcrun_container_t *libcrun_container_load_from_file (const char
 
 LIBCRUN_PUBLIC libcrun_container_t *libcrun_container_load_from_memory (const char *json, libcrun_error_t *err);
 
+LIBCRUN_PUBLIC void libcrun_container_free (libcrun_container_t *);
+
 LIBCRUN_PUBLIC int libcrun_container_run (libcrun_context_t *context, libcrun_container_t *container,
                                           unsigned int options, libcrun_error_t *error);
 
@@ -146,5 +148,15 @@ LIBCRUN_PUBLIC int libcrun_container_restore (libcrun_context_t *context, const 
 // Not part of the public API, just a method in container.c we need to access from linux.c
 void get_root_in_the_userns (runtime_spec_schema_config_schema *def, uid_t host_uid, gid_t host_gid,
                              uid_t *uid, gid_t *gid);
+
+static inline void
+cleanup_containerp (libcrun_container_t **c)
+{
+  libcrun_container_t *container = *c;
+  if (container)
+    libcrun_container_free (container);
+}
+
+#define cleanup_container __attribute__ ((cleanup (cleanup_containerp)))
 
 #endif

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1391,6 +1391,27 @@ get_default_flags (libcrun_container_t *container, const char *destination, char
   return 0;
 }
 
+static char *
+append_mode_if_missing (char *data, const char *mode)
+{
+  char *new_data;
+  bool append;
+
+  if (data != NULL && strstr (data, "mode="))
+    return data;
+
+  append = data != NULL && data[0] != '\0';
+
+  if (append)
+    xasprintf (&new_data, "%s,%s", data, mode);
+  else
+    new_data = xstrdup (mode);
+
+  free (data);
+
+  return new_data;
+}
+
 static int
 do_mounts (libcrun_container_t *container, int rootfsfd, const char *rootfs, libcrun_error_t *err)
 {
@@ -1449,23 +1470,7 @@ do_mounts (libcrun_container_t *container, int rootfsfd, const char *rootfs, lib
           if (UNLIKELY (is_dir < 0))
             return is_dir;
 
-          if (data == NULL || strstr (data, "mode=") == NULL)
-            {
-              bool append;
-
-              append = data != NULL && data[0] != '\0';
-
-              if (data != NULL)
-                {
-                  free (data);
-                  data = NULL;
-                }
-
-              if (append)
-                xasprintf (&data, "%s,%s", data, "mode=1755");
-              else
-                data = xstrdup ("mode=1755");
-            }
+          data = append_mode_if_missing (data, "mode=1755");
         }
 
       if (is_dir)

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1690,7 +1690,7 @@ do_notify_socket (libcrun_container_t *container, const char *rootfs, libcrun_er
 
   if (get_private_data (container)->unshare_flags & CLONE_NEWUSER)
     {
-      get_root_in_the_userns_for_cgroups (container->container_def, 0, 0, &container_root_uid, &container_root_gid);
+      get_root_in_the_userns (container->container_def, 0, 0, &container_root_uid, &container_root_gid);
       if (container_root_uid != ((uid_t) -1) && container_root_gid != ((gid_t) -1))
         {
           ret = chown (host_notify_socket_path, container_root_uid, container_root_gid);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -94,9 +94,6 @@ struct private_data_s
   size_t rootfs_len;
   int notify_socket_tree_fd;
 
-  char *tmpmountdir;
-  char *tmpmountfile;
-
   /* Used to save stdin, stdout, stderr during checkpointing to descriptors.json
    * and needed during restore. */
   char *external_descriptors;
@@ -564,12 +561,11 @@ enum
 };
 
 static int
-do_mount (libcrun_container_t *container, const char *source, int targetfd, const char *target, const char *fstype,
-          unsigned long mountflags, const void *data, int label_how, libcrun_error_t *err)
+do_mount (libcrun_container_t *container, const char *source, int targetfd,
+          const char *target, const char *fstype, unsigned long mountflags, const void *data,
+          int label_how, libcrun_error_t *err)
 {
   cleanup_free char *data_with_label = NULL;
-  const char *temporary_mount = NULL;
-  bool use_temporary_mount = false;
   const char *real_target = target;
   bool single_instance = false;
   bool needs_remount = false;
@@ -588,28 +584,8 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd, cons
 
   if (targetfd >= 0)
     {
-      use_temporary_mount = (get_private_data (container)->unshare_flags & CLONE_NEWNS)
-                            && get_private_data (container)->tmpmountdir
-                            && (mountflags & (ALL_PROPAGATIONS | MS_BIND | MS_RDONLY));
       sprintf (target_buffer, "/proc/self/fd/%d", targetfd);
       real_target = target_buffer;
-    }
-
-  /* The temporary mount is used to solve a race condition where the mount point we created
-     on top of volumes that are accessible also from other containers.  The temporary mount
-     once configured is moved to its destination under the rootfs.  */
-  if (use_temporary_mount)
-    {
-      mode_t mode;
-
-      ret = get_file_type_fd (targetfd, &mode);
-      if (UNLIKELY (ret < 0))
-        return ret;
-
-      if ((mode & S_IFMT) == S_IFDIR)
-        temporary_mount = get_private_data (container)->tmpmountdir;
-      else
-        temporary_mount = get_private_data (container)->tmpmountfile;
     }
 
   if (label_how == LABEL_MOUNT)
@@ -622,10 +598,9 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd, cons
 
   if ((fstype && fstype[0]) || (mountflags & MS_BIND))
     {
-      const char *to = use_temporary_mount ? temporary_mount : real_target;
       unsigned long flags = mountflags & ~(ALL_PROPAGATIONS_NO_REC | MS_RDONLY);
 
-      ret = mount (source, to, fstype, flags, data);
+      ret = mount (source, real_target, fstype, flags, data);
       if (UNLIKELY (ret < 0))
         {
           int saved_errno = errno;
@@ -640,7 +615,7 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd, cons
 
               if (ret > 0)
                 {
-                  ret = mount ("/sys", to, "/sys", MS_BIND | MS_REC | MS_SLAVE, data);
+                  ret = mount ("/sys", real_target, "/sys", MS_BIND | MS_REC | MS_SLAVE, data);
                   if (LIKELY (ret == 0))
                     return 0;
                 }
@@ -655,16 +630,9 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd, cons
       if (targetfd >= 0)
         {
           /* We need to reopen the path as the previous targetfd is underneath the new mountpoint.  */
-          if (use_temporary_mount)
-            fd = open (temporary_mount, O_CLOEXEC | O_PATH);
-          else
-            fd = open_mount_target (container, target, err);
+          fd = open_mount_target (container, target, err);
           if (UNLIKELY (fd < 0))
-            {
-              if (use_temporary_mount)
-                umount (temporary_mount);
-              return fd;
-            }
+            return fd;
 
 #ifdef HAVE_FGETXATTR
           if (label_how == LABEL_XATTR)
@@ -676,17 +644,6 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd, cons
               (void) setxattr (proc_file, "security.selinux", label, strlen (label), 0);
             }
 #endif
-          /* We have a fd pointing to the new mountpoint (done in a safe location).  We can move
-             the mount to the destination under the rootfs.  */
-          if (use_temporary_mount)
-            {
-              ret = mount (temporary_mount, real_target, NULL, MS_MOVE, NULL);
-              if (UNLIKELY (ret < 0))
-                {
-                  umount (temporary_mount);
-                  return crun_make_error (err, errno, "move mount to '%s'", target);
-                }
-            }
 
           targetfd = fd;
           sprintf (target_buffer, "/proc/self/fd/%d", targetfd);
@@ -1819,184 +1776,6 @@ make_parent_mount_private (const char *rootfs, libcrun_error_t *err)
   return 0;
 }
 
-static bool
-has_shared_or_slave_parent_mount (const char *dir, runtime_spec_schema_config_schema *def)
-{
-  size_t i;
-
-  for (i = 0; i < def->mounts_len; i++)
-    {
-      bool has_propagation_flag = false;
-      bool is_bind = false;
-      size_t j;
-
-      if (def->mounts[i]->source == NULL)
-        continue;
-
-      for (j = 0; j < def->mounts[i]->options_len; j++)
-        {
-          if (strcmp (def->mounts[i]->options[j], "shared") == 0
-              || strcmp (def->mounts[i]->options[j], "rshared") == 0
-              || strcmp (def->mounts[i]->options[j], "slave") == 0
-              || strcmp (def->mounts[i]->options[j], "rslave") == 0)
-            {
-              has_propagation_flag = true;
-              break;
-            }
-        }
-      if (! has_propagation_flag)
-        continue;
-
-      for (j = 0; j < def->mounts[i]->options_len; j++)
-        {
-          if (strcmp (def->mounts[i]->options[j], "bind") == 0
-              || strcmp (def->mounts[i]->options[j], "rbind") == 0)
-            {
-              is_bind = true;
-              break;
-            }
-        }
-      if (! is_bind)
-        continue;
-
-      if (has_prefix (dir, def->mounts[i]->source))
-        return true;
-    }
-  return false;
-}
-
-static int
-allocate_tmp_mounts (libcrun_container_t *container, char **parent_tmpdir_out, char **tmpdir_out, char **tmpfile_out,
-                     libcrun_error_t *err)
-{
-  char *where = NULL;
-  int state = 0;
-  int ret;
-
-  for (state = 0;; state++)
-    {
-      cleanup_free char *parent_tmpdir = NULL;
-      cleanup_free char *state_dir = NULL;
-      cleanup_free char *tmpdir = NULL;
-      cleanup_free char *tmpfile = NULL;
-      char tmp_dir[32];
-      char *d;
-
-      switch (state)
-        {
-        case 0:
-          state_dir = libcrun_get_state_directory (container->context->state_root, container->context->id);
-          where = state_dir;
-          break;
-
-        case 1:
-          strcpy (tmp_dir, "/tmp/libcrun.XXXXXX");
-          d = mkdtemp (tmp_dir);
-          if (d == NULL)
-            continue;
-
-          parent_tmpdir = xstrdup (d);
-          where = parent_tmpdir;
-          break;
-
-        case 2:
-          strcpy (tmp_dir, "/dev/shm/libcrun.XXXXXX");
-          d = mkdtemp (tmp_dir);
-          if (d == NULL)
-            continue;
-
-          parent_tmpdir = xstrdup (d);
-          where = parent_tmpdir;
-          break;
-
-        case 3:
-          return 0;
-        }
-
-      /* If there is any shared mount in the container, disable the temporary mounts
-         logic as it requires the parent mount to be MS_PRIVATE and it could affect these
-         mounts.  */
-      if (has_shared_or_slave_parent_mount (where, container->container_def))
-        continue;
-
-      ret = append_paths (&tmpdir, err, where, "tmp-dir", NULL);
-      if (UNLIKELY (ret < 0))
-        return ret;
-
-      ret = crun_ensure_directory (tmpdir, 0700, true, err);
-      if (UNLIKELY (ret < 0))
-        {
-          /*If the current user has no access to the state directory (e.g. running in an
-            user namespace), then try with another directory.  */
-          if (crun_error_get_errno (err) == EPERM
-              || crun_error_get_errno (err) == EROFS
-              || crun_error_get_errno (err) == EACCES)
-            {
-              crun_error_release (err);
-              continue;
-            }
-          return ret;
-        }
-
-      ret = append_paths (&tmpfile, err, where, "tmp-file", NULL);
-      if (UNLIKELY (ret < 0))
-        goto cleanup;
-
-      ret = crun_ensure_file (tmpfile, 0700, true, err);
-      if (UNLIKELY (ret < 0))
-        goto cleanup;
-
-      /* Move ownership.  */
-      *parent_tmpdir_out = parent_tmpdir;
-      *tmpdir_out = tmpdir;
-      *tmpfile_out = tmpfile;
-      parent_tmpdir = tmpdir = tmpfile = NULL;
-      return 0;
-
-    cleanup:
-      if (tmpfile)
-        unlink (tmpfile);
-      if (tmpdir)
-        rmdir (tmpdir);
-      if (parent_tmpdir)
-        rmdir (parent_tmpdir);
-      return ret;
-    }
-
-  return 0;
-}
-
-static int
-cleanup_rmdir (void *p)
-{
-  int ret;
-  char **pp = (char **) p;
-  if (*pp)
-    {
-      cleanup_dir DIR *d = NULL;
-      struct dirent *de;
-      cleanup_close int dfd = open (*pp, O_DIRECTORY | O_RDONLY);
-      if (dfd < 0)
-        goto exit;
-      d = fdopendir (dfd);
-      if (d == NULL)
-        goto exit;
-
-      for (de = readdir (d); de; de = readdir (d))
-        {
-          if (strcmp (de->d_name, ".") == 0 || strcmp (de->d_name, "..") == 0)
-            continue;
-          ret = unlinkat (dirfd (d), de->d_name, 0);
-          if (ret < 0)
-            unlinkat (dirfd (d), de->d_name, AT_REMOVEDIR);
-        }
-      unlinkat (AT_FDCWD, *pp, AT_REMOVEDIR);
-    }
-exit:
-  free (*pp);
-  return 0;
-}
-
 int
 libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_error_t *err)
 {
@@ -2005,7 +1784,6 @@ libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_
   unsigned long rootfs_propagation = 0;
   cleanup_close int rootfsfd_cleanup = -1;
   runtime_spec_schema_config_schema *def = container->container_def;
-  __attribute__ ((cleanup (cleanup_rmdir))) char *tmpdirparent = NULL;
 
   if (rootfs == NULL || def->mounts == NULL)
     return 0;
@@ -2020,16 +1798,6 @@ libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_
 
   if (get_private_data (container)->unshare_flags & CLONE_NEWNS)
     {
-      char *tmpdir = NULL;
-      char *tmpfile = NULL;
-
-      ret = allocate_tmp_mounts (container, &tmpdirparent, &tmpdir, &tmpfile, err);
-      if (UNLIKELY (ret < 0))
-        return ret;
-
-      get_private_data (container)->tmpmountdir = tmpdir;
-      get_private_data (container)->tmpmountfile = tmpfile;
-
       ret = do_mount (container, NULL, -1, "/", NULL, rootfs_propagation, NULL, LABEL_MOUNT, err);
       if (UNLIKELY (ret < 0))
         return ret;
@@ -2037,13 +1805,6 @@ libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_
       ret = make_parent_mount_private (rootfs, err);
       if (UNLIKELY (ret < 0))
         return ret;
-
-      if (tmpdirparent != NULL || tmpdir != NULL)
-        {
-          ret = make_parent_mount_private (tmpdirparent ? tmpdirparent : tmpdir, err);
-          if (UNLIKELY (ret < 0))
-            return ret;
-        }
 
       ret = do_mount (container, rootfs, -1, rootfs, NULL, MS_BIND | MS_REC | MS_PRIVATE, NULL, LABEL_MOUNT, err);
       if (UNLIKELY (ret < 0))
@@ -2112,24 +1873,6 @@ libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_
   if (UNLIKELY (ret < 0))
     return ret;
 
-  if (get_private_data (container)->tmpmountdir)
-    {
-      rmdir (get_private_data (container)->tmpmountdir);
-      free (get_private_data (container)->tmpmountdir);
-      get_private_data (container)->tmpmountdir = NULL;
-    }
-  if (get_private_data (container)->tmpmountfile)
-    {
-      unlink (get_private_data (container)->tmpmountfile);
-      free (get_private_data (container)->tmpmountfile);
-      get_private_data (container)->tmpmountfile = NULL;
-    }
-  if (tmpdirparent)
-    {
-      rmdir (tmpdirparent);
-      free (tmpdirparent);
-      tmpdirparent = NULL;
-    }
   get_private_data (container)->rootfsfd = -1;
 
   return 0;

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -542,7 +542,10 @@ static int
 fs_move_mount_to (int fd, int dirfd, const char *name)
 {
 #ifdef HAVE_FSCONFIG_CMD_CREATE
-  return syscall_move_mount (fd, "", dirfd, name, MOVE_MOUNT_F_EMPTY_PATH);
+  if (name)
+    return syscall_move_mount (fd, "", dirfd, name, MOVE_MOUNT_F_EMPTY_PATH);
+
+  return syscall_move_mount (fd, "", dirfd, "", MOVE_MOUNT_T_EMPTY_PATH | MOVE_MOUNT_F_EMPTY_PATH);
 #else
   (void) syscall_move_mount;
   errno = ENOSYS;
@@ -1533,7 +1536,7 @@ do_mounts (libcrun_container_t *container, int rootfsfd, const char *rootfs, lib
           {
             cleanup_close int mfd = get_and_reset (fsfd_mounts[j].fd);
 
-            ret = fs_move_mount_to (mfd, rootfsfd, target);
+            ret = fs_move_mount_to (mfd, targetfd, NULL);
             if (LIKELY (ret == 0))
               {
                 ret = do_mount (container, NULL, mfd, target, NULL, flags, data, LABEL_NONE, err);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1029,10 +1029,7 @@ create_dev (libcrun_container_t *container, int devfd, struct device_s *device, 
   if (binds)
     {
       cleanup_close int fd = -1;
-      const char *rel_path = device->path;
-
-      while (*rel_path == '/')
-        rel_path++;
+      const char *rel_path = consume_slashes (device->path);
 
       if (rel_dev)
         {
@@ -1412,20 +1409,16 @@ do_mounts (libcrun_container_t *container, int rootfsfd, const char *rootfs, lib
 
   for (i = 0; i < def->mounts_len; i++)
     {
+      const char *target = consume_slashes (def->mounts[i]->destination);
       cleanup_free char *data = NULL;
       char *type;
       char *source;
       unsigned long flags = 0;
       unsigned long extra_flags = 0;
       int is_dir = 1;
-      char *target = NULL;
       cleanup_close int copy_from_fd = -1;
       cleanup_close int targetfd = -1;
       bool mounted = false;
-
-      target = def->mounts[i]->destination;
-      while (*target == '/')
-        target++;
 
       type = def->mounts[i]->type;
 

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -487,7 +487,9 @@ libcrun_free_container_status (libcrun_container_status_t *status)
   free (status->cgroup_path);
   free (status->bundle);
   free (status->rootfs);
+  free (status->external_descriptors);
   free (status->created);
+  free (status->scope);
 }
 
 int

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -336,7 +336,8 @@ safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *path,
   int ret;
   cleanup_close int fd = -1;
   static bool openat2_supported = true;
-  char buffer[PATH_MAX], *path_in_chroot;
+  const char *path_in_chroot;
+  char buffer[PATH_MAX];
 
   if (openat2_supported)
     {
@@ -359,8 +360,7 @@ fallback:
     return crun_make_error (err, errno, "cannot resolve `%s` under rootfs", path);
 
   path_in_chroot += rootfs_len;
-  while (*path_in_chroot == '/')
-    path_in_chroot++;
+  path_in_chroot = consume_slashes (path_in_chroot);
 
   /* If the path is empty we are at the root, dup the dirfd itself.  */
   if (path_in_chroot[0] == '\0')
@@ -402,8 +402,7 @@ crun_safe_ensure_at (bool dir, int dirfd, const char *dirpath, size_t dirpath_le
   if (max_readlinks <= 0)
     return crun_make_error (err, ELOOP, "resolve path `%s`", path);
 
-  while (*path == '/')
-    path++;
+  path = consume_slashes (path);
 
   npath = xstrdup (path);
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -41,6 +41,9 @@
 #include <linux/magic.h>
 #include <limits.h>
 #include <stdarg.h>
+#ifdef HAVE_LINUX_OPENAT2_H
+#  include <linux/openat2.h>
+#endif
 
 #ifndef CLOSE_RANGE_CLOEXEC
 #  define CLOSE_RANGE_CLOEXEC (1U << 2)

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -605,12 +605,21 @@ int
 check_running_in_user_namespace (libcrun_error_t *err)
 {
   cleanup_free char *buffer = NULL;
+  static int run_in_userns = -1;
   size_t len;
-  int ret = read_all_file ("/proc/self/uid_map", &buffer, &len, err);
+  int ret;
+
+  ret = run_in_userns;
+  if (ret >= 0)
+    return ret;
+
+  ret = read_all_file ("/proc/self/uid_map", &buffer, &len, err);
   if (UNLIKELY (ret < 0))
     return ret;
 
-  return strstr (buffer, "4294967295") ? 0 : 1;
+  ret = strstr (buffer, "4294967295") ? 0 : 1;
+  run_in_userns = ret;
+  return ret;
 }
 
 static int selinux_enabled = -1;

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -171,6 +171,8 @@ int crun_ensure_directory_at (int dirfd, const char *path, int mode, bool nofoll
 
 int crun_ensure_file_at (int dirfd, const char *path, int mode, bool nofollow, libcrun_error_t *err);
 
+int crun_safe_create_and_open_ref_at (bool dir, int dirfd, const char *dirpath, size_t dirpath_len, const char *path, int mode, libcrun_error_t *err);
+
 int crun_safe_ensure_directory_at (int dirfd, const char *dirpath, size_t dirpath_len, const char *path, int mode,
                                    libcrun_error_t *err);
 

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -145,6 +145,14 @@ xstrdup (const char *str)
   return ret;
 }
 
+static inline const char *
+consume_slashes (const char *t)
+{
+  while (*t == '/')
+    t++;
+  return t;
+}
+
 int xasprintf (char **str, const char *fmt, ...);
 
 int crun_path_exists (const char *path, libcrun_error_t *err);

--- a/src/run.c
+++ b/src/run.c
@@ -120,7 +120,7 @@ int
 crun_command_run (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
   int first_arg, ret;
-  cleanup_free libcrun_container_t *container = NULL;
+  cleanup_container libcrun_container_t *container = NULL;
   cleanup_free char *bundle_cleanup = NULL;
   cleanup_free char *config_file_cleanup = NULL;
 


### PR DESCRIPTION
a bunch of cleanups and some improvements for the mounts logic.

Noteworthy, it removes the "temporary mount" logic as it doesn't really add any benefit.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
