### PR TITLE
linux: ignore ENOSYS on keyctl

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -275,7 +275,14 @@ libcrun_create_keyring (const char *name, libcrun_error_t *err)
 {
   int ret = syscall_keyctl_join (name);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "create keyring `%s`", name);
+    {
+      if (errno == ENOSYS)
+        {
+          libcrun_warning ("could not create a new keyring: keyctl_join is not supported");
+          return 0;
+        }
+      return crun_make_error (err, errno, "create keyring `%s`", name);
+    }
   return 0;
 }
 


### PR DESCRIPTION
Closes: https://github.com/containers/crun/issues/594

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>