### PR TITLE
utils: set HOME to root if the user not found

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1157,7 +1157,8 @@ set_home_env (uid_t id)
   if (stream == NULL)
     {
       if (errno == ENOENT)
-        return 0;
+        goto exit;
+
       return -1;
     }
 
@@ -1186,6 +1187,10 @@ set_home_env (uid_t id)
           return 0;
         }
     }
+
+exit:
+  /* If the user was not found, set it to something reasonable.  */
+  setenv ("HOME", "/", 1);
   return 0;
 }
 

--- a/tests/podman/run-tests.sh
+++ b/tests/podman/run-tests.sh
@@ -20,7 +20,7 @@ export TMPDIR=/var/tmp
 
 # Skip some tests that are not currently supported in the testing environment:
 #
-# - search|pull from docker|trust|inspect|logs|generate|import|mounted rw|inherit host devices|privileged CapEff|
+# - search|pull from docker|trust|inspect|logs|generate|import|mounted rw|inherit host devices|privileged CapEff|prune unused images|podman images filter|image list filter
 #   Flaky or not using the runtime.
 #
 # - selinux
@@ -34,6 +34,6 @@ export TMPDIR=/var/tmp
 #   device-cgroup-rule|capabilities|network|overlay volume flag|prune removes a pod with a stopped container: not working on github actions
 
 
-ginkgo --focus='.*' --skip='.*(selinux|notify_socket|systemd|podman run exit 12*|podman run exit code on failure to exec|failed to start|search|trust|inspect|logs|generate|import|mounted rw|inherit host devices|play kube|cgroups=disabled|privileged CapEff|device-cgroup-rule|capabilities|network|pull from docker|--add-host|removes a pod with a container|prune removes a pod with a stopped container|overlay volume flag).*' \
+ginkgo --focus='.*' --skip='.*(selinux|notify_socket|systemd|podman run exit 12*|podman run exit code on failure to exec|failed to start|search|trust|inspect|logs|generate|import|mounted rw|inherit host devices|play kube|cgroups=disabled|privileged CapEff|device-cgroup-rule|capabilities|network|pull from docker|--add-host|removes a pod with a container|prune removes a pod with a stopped container|overlay volume flag|prune unused images|podman images filter|image list filter).*' \
 	 -v -tags "seccomp ostree selinux varlink exclude_graphdriver_devicemapper" \
 	 -timeout=50m -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -217,6 +217,18 @@ def test_sd_notify_proxy():
                     pass
             return 0
 
+def test_empty_home():
+    conf = base_config()
+    conf['process']['args'] = ['/sbin/init', 'printenv', 'HOME']
+    add_all_namespaces(conf)
+    try:
+        out, _ = run_and_get_output(conf)
+        if "/" not in str(out):
+            return -1
+    except Exception as e:
+        return -1
+    return 0
+
 all_tests = {
     "start" : test_start,
     "start-override-config" : test_start_override_config,
@@ -228,6 +240,7 @@ all_tests = {
     "test-cwd-relative": test_cwd_relative,
     "test-cwd-relative-subdir": test_cwd_relative_subdir,
     "test-cwd-absolute": test_cwd_absolute,
+    "empty-home": test_empty_home,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
if there is no HOME env variable set and the user is not found, then
set the home directory to '/'.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>