### PR TITLE
NEWS: tag 0.18

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,18 @@
+* crun-0.18
+
+- fix build without CLONE_NEWCGROUP.
+- fix conversion from blkio to io.
+- add custom annotation to load raw BPF.
+- set working directory for libkrun
+- fix symlink lookup on old kernels that lack openat2
+- skip +cpu on EINVAL in cgroup root.  Enabling the cpu controller is
+  not permitted if there are already realtime processes running on the
+  system.
+- Fix permission error when using NOTIFY_SOCKET with username spaces.
+- set HOME to root if the user not found.
+- simplify mount logic to not use a temporary mount.
+- ignore ENOSYS from keyctl.
+
 * crun-0.17
 
 - allow creating user namespaces without root being mapped.

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -64,6 +64,18 @@
 #  define RLIMIT_RTTIME 15
 #endif
 
+#ifndef OPEN_TREE_CLONE
+#  define OPEN_TREE_CLONE 1
+#endif
+
+#ifndef MOVE_MOUNT_F_EMPTY_PATH
+#  define MOVE_MOUNT_F_EMPTY_PATH 0x00000004
+#endif
+
+#ifndef MOVE_MOUNT_T_EMPTY_PATH
+#  define MOVE_MOUNT_T_EMPTY_PATH 0x00000040
+#endif
+
 struct remount_s
 {
   struct remount_s *next;


### PR DESCRIPTION
- fix build without CLONE_NEWCGROUP.
- fix conversion from blkio to io.
- add custom annotation to load raw BPF.
- set working directory for libkrun.
- fix symlink lookup on old kernels that lack openat2
- skip +cpu on EINVAL in cgroup root.  Enabling the cpu controller is
  not permitted if there are already realtime processes running on the
  system.
- Fix permission error when using NOTIFY_SOCKET with username spaces.
- set HOME to root if the user not found.
- simplify mount logic to not use a temporary mount.
- ignore ENOSYS from keyctl.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>