### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ $ sudo apt-get install -y make git gcc build-essential pkgconf libtool \
 
 ```console
 # zypper install make automake autoconf gettext libtool gcc libcap-devel \
-systemd-devel yajl-devel libseccomp-devel python3 libtool go-md2man;
+systemd-devel libyajl-devel libseccomp-devel python3 libtool go-md2man \
+glibc-static;
 ```
 
 Note that Tumbleweed requires you to specify libseccomp's header file location


### PR DESCRIPTION
Minor tweak to zypper install hints for latest version.

libyajl-devel instead of yajl-devel as the latter does not exist in the default repos.  
glibc-static since at least in my head I assume these instructions are to help me build a usable binary.  

fixes #606