### PR TITLE
ebpf: handle access(2) syscall correctly

### DIFF
--- a/src/libcrun/ebpf.c
+++ b/src/libcrun/ebpf.c
@@ -70,6 +70,9 @@ struct bpf_program
 #  define BPF_JMP_IMM(OP, DST, IMM, OFF) \
     ((struct bpf_insn){ .code = BPF_JMP | BPF_OP (OP) | BPF_K, .dst_reg = DST, .src_reg = 0, .off = OFF, .imm = IMM })
 
+#  define BPF_JMP_REG(OP, DST, SRC, OFF) \
+    ((struct bpf_insn){ .code = BPF_JMP | BPF_OP (OP) | BPF_X, .dst_reg = DST, .src_reg = SRC, .off = OFF, .imm = 0 })
+
 #  define BPF_MOV64_IMM(DST, IMM) \
     ((struct bpf_insn){ .code = BPF_ALU64 | BPF_MOV | BPF_K, .dst_reg = DST, .src_reg = 0, .off = 0, .imm = IMM })
 
@@ -180,7 +183,7 @@ bpf_program_append_dev (struct bpf_program *program, const char *access, char ty
   /*
     if (request.type != device.type)
       goto next_block:
-    if ((request.access & device.access) == 0)
+    if ((request.access & device.access) != request.access)
       goto next_block:
     if (device.major != '*' && request.major != device.major) == 0)
       goto next_block:
@@ -207,7 +210,7 @@ bpf_program_append_dev (struct bpf_program *program, const char *access, char ty
       struct bpf_insn i[] = {
         BPF_MOV32_REG (BPF_REG_1, BPF_REG_3),
         BPF_ALU32_IMM (BPF_AND, BPF_REG_1, bpf_access),
-        BPF_JMP_IMM (BPF_JEQ, BPF_REG_1, 0, number_instructions - 2),
+        BPF_JMP_REG (BPF_JNE, BPF_REG_1, BPF_REG_3, number_instructions - 2),
       };
       number_instructions -= 3;
       program = bpf_program_append (program, i, sizeof (i));

--- a/tests/init.c
+++ b/tests/init.c
@@ -197,6 +197,16 @@ int main (int argc, char **argv)
       return open_only (argv[2]);
     }
 
+  if (strcmp (argv[1], "access") == 0)
+    {
+      if (argc < 3)
+        error (EXIT_FAILURE, 0, "'access' requires an argument");
+
+      if (access (argv[2], F_OK) < 0)
+        error (EXIT_FAILURE, errno, "could not access %s", argv[2]);
+      return 0;
+    }
+
   if (strcmp (argv[1], "cwd") == 0)
     {
       int ret;

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -83,10 +83,41 @@ def test_allow_device():
         return -1
     return 0
 
+def test_allow_access():
+    if is_rootless():
+        return 77
+
+    try:
+        os.stat("/dev/fuse")
+    except:
+        return 77
+
+    conf = base_config()
+    add_all_namespaces(conf)
+    conf['process']['args'] = ['/init', 'access', '/dev/fuse']
+    conf['linux']['resources'] = {"devices": [{"allow": False, "access": "rwm"},
+                                              {"allow": True, "type": "c", "major": 10, "minor": 229, "access": "rw"}]}
+    dev = {
+	"destination": "/dev",
+	"type": "bind",
+	"source": "/dev",
+	"options": [
+            "rbind",
+	    "rw"
+	]
+    }
+    conf['mounts'].append(dev)
+    try:
+        run_and_get_output(conf)
+    except Exception as e:
+        return -1
+    return 0
+
 
 all_tests = {
     "deny-devices" : test_deny_devices,
     "allow-device" : test_allow_device,
+    "allow-access" : test_allow_access,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently the call to `access(dev_name, F_OK)` fails even if the permissions for the device file are set to `rw`. It looks like the problem is in the ebpf filtering program. The check
https://github.com/containers/crun/blob/4096e14c6f5a5684709dfaa4279ac814fdaec2ba/src/libcrun/ebpf.c#L183-L184
denies the access since with `F_OK` no read or write bits are set. Changing the comparison logic to
```c
    if ((request.access & device.access) != request.access)
      goto next_block:
```
solves the issue. The same way it is implemented in systemd:

https://github.com/systemd/systemd/blob/da0d560905d186baababb3abdaf3f6a159897cb2/src/core/bpf-devices.c#L145

The issue is not reproducable when the permissions are set to `rwm` since in that case the ebpf checking is skipped: 
https://github.com/containers/crun/blob/4096e14c6f5a5684709dfaa4279ac814fdaec2ba/src/libcrun/ebpf.c#L193-L194