### PR TITLE
seccomp: support notify listener

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -129,6 +129,7 @@ TESTS = tests/test_capabilities.py \
 	tests/test_resources.py \
 	tests/test_start.py \
 	tests/test_exec.py \
+	tests/test_seccomp.py \
 	$(UNIT_TESTS)
 
 .version:

--- a/contrib/seccomp-receiver/Makefile
+++ b/contrib/seccomp-receiver/Makefile
@@ -1,0 +1,2 @@
+CFLAGS = -I../..
+seccomp-receiver: seccomp-receiver.c

--- a/contrib/seccomp-receiver/seccomp-receiver.c
+++ b/contrib/seccomp-receiver/seccomp-receiver.c
@@ -1,0 +1,133 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2021 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE
+
+#include <config.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/un.h>
+#include <sys/socket.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <stdio.h>
+
+#define error(status, errno, fmt, ...) do {                             \
+    if (errno)                                                          \
+      fprintf (stderr, "crun: " fmt, ##__VA_ARGS__);                    \
+    else                                                                \
+      fprintf (stderr, "crun: %s:" fmt, strerror (errno), ##__VA_ARGS__); \
+    if (status)                                                         \
+      exit (status);                                                    \
+  } while(0)
+
+static int
+open_unix_domain_socket (const char *path)
+{
+  struct sockaddr_un addr = {};
+  int ret;
+  int fd = socket (AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0)
+    error (EXIT_FAILURE, errno, "error creating UNIX socket");
+
+  strcpy (addr.sun_path, path);
+  addr.sun_family = AF_UNIX;
+  ret = bind (fd, (struct sockaddr *) &addr, sizeof (addr));
+  if (ret < 0)
+    error (EXIT_FAILURE, errno, "error binding UNIX socket");
+
+  ret = listen (fd, 1);
+  if (ret < 0)
+    error (EXIT_FAILURE, errno, "listen");
+
+  return fd;
+}
+
+static void
+print_payload (int from)
+{
+  int fd = -1;
+  struct iovec iov[1];
+  struct msghdr msg = {};
+  char ctrl_buf[2048] = {};
+  char data[2048];
+  int ret;
+  struct cmsghdr *cmsg;
+
+  iov[0].iov_base = data;
+  iov[0].iov_len = sizeof (data) - 1;
+
+  msg.msg_name = NULL;
+  msg.msg_namelen = 0;
+  msg.msg_iov = iov;
+  msg.msg_iovlen = 1;
+  msg.msg_controllen = CMSG_SPACE (sizeof (int));
+  msg.msg_control = ctrl_buf;
+
+  do
+    ret = recvmsg (from, &msg, 0);
+  while (ret < 0 && errno == EINTR);
+  if (ret < 0)
+    {
+      error (0, errno, "recvmsg");
+      return;
+    }
+
+  data[iov[0].iov_len] = '\0';
+  puts (data);
+
+  cmsg = CMSG_FIRSTHDR (&msg);
+  if (cmsg == NULL)
+    {
+      error (0, 0, "no msg received");
+      return;
+    }
+  memcpy (&fd, CMSG_DATA (cmsg), sizeof (fd));
+  close (fd);
+}
+
+int
+main (int argc, char **argv)
+{
+  char buf[8192];
+  int ret, fd, socket;
+  if (argc < 2)
+    error (EXIT_FAILURE, 0, "usage %s PATH\n", argv[0]);
+
+  unlink (argv[1]);
+
+  socket = open_unix_domain_socket (argv[1]);
+  while (1)
+    {
+      struct termios tset;
+      int conn;
+
+      do
+        conn = accept (socket, NULL, NULL);
+      while (conn < 0 && errno == EINTR);
+      if (conn < 0)
+        error (EXIT_FAILURE, errno, "accept");
+
+      print_payload (conn);
+    }
+
+  return 0;
+}

--- a/src/create.c
+++ b/src/create.c
@@ -138,7 +138,9 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
     }
 
   /* Make sure the bundle is an absolute path.  */
-  if (bundle)
+  if (bundle == NULL)
+    bundle = bundle_cleanup = getcwd (NULL, 0);
+  else
     {
       if (bundle[0] != '/')
         {
@@ -160,7 +162,7 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
   if (container == NULL)
     libcrun_fail_with_error (0, "error loading config.json");
 
-  crun_context.bundle = bundle ? bundle : ".";
+  crun_context.bundle = bundle;
   if (getenv ("LISTEN_FDS"))
     crun_context.preserve_fds += strtoll (getenv ("LISTEN_FDS"), NULL, 10);
 

--- a/src/create.c
+++ b/src/create.c
@@ -114,7 +114,7 @@ static struct argp run_argp = { options, parse_opt, args_doc, doc, NULL, NULL, N
 int
 crun_command_create (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
-  int first_arg, ret;
+  int first_arg = 0, ret;
   cleanup_container libcrun_container_t *container = NULL;
   cleanup_free char *bundle_cleanup = NULL;
   cleanup_free char *config_file_cleanup = NULL;

--- a/src/crun.c
+++ b/src/crun.c
@@ -297,7 +297,7 @@ int
 main (int argc, char **argv)
 {
   libcrun_error_t err = NULL;
-  int ret, first_argument;
+  int ret, first_argument = 0;
 
   argp_program_version_hook = print_version;
 

--- a/src/delete.c
+++ b/src/delete.c
@@ -86,7 +86,7 @@ static struct argp run_argp = { options, parse_opt, args_doc, doc, NULL, NULL, N
 int
 crun_command_delete (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
-  int first_arg, ret;
+  int first_arg = 0, ret;
 
   libcrun_context_t crun_context = {
     0,

--- a/src/exec.c
+++ b/src/exec.c
@@ -202,7 +202,7 @@ make_oci_process_user (const char *userspec)
 int
 crun_command_exec (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
-  int first_arg, ret = 0;
+  int first_arg = 0, ret = 0;
   libcrun_context_t crun_context = {
     0,
   };

--- a/src/kill.c
+++ b/src/kill.c
@@ -87,7 +87,7 @@ static struct argp run_argp = { options, parse_opt, args_doc, doc, NULL, NULL, N
 int
 crun_command_kill (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
-  int first_arg, signal, ret;
+  int first_arg = 0, signal, ret;
 
   libcrun_context_t crun_context = {
     0,

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -1819,6 +1819,9 @@ read_pids_cgroup (int dfd, bool recurse, pid_t **pids, size_t *n_pids, size_t *a
   if (UNLIKELY (ret < 0))
     return ret;
 
+  if (len == 0)
+    return 0;
+
   for (n_new_pids = 0, it = buffer; it; it = strchr (it + 1, '\n'))
     n_new_pids++;
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2500,7 +2500,7 @@ libcrun_container_run (libcrun_context_t *context, libcrun_container_t *containe
   int container_ret_status[2];
   cleanup_close int pipefd0 = -1;
   cleanup_close int pipefd1 = -1;
-  libcrun_error_t tmp_err;
+  libcrun_error_t tmp_err = NULL;
 
   container->context = context;
 
@@ -2667,7 +2667,7 @@ libcrun_container_create (libcrun_context_t *context, libcrun_container_t *conta
         {
           if (exit_code != 0)
             {
-              libcrun_error_t tmp_err;
+              libcrun_error_t tmp_err = NULL;
               libcrun_container_delete (context, def, context->id, true, &tmp_err);
               crun_error_release (err);
             }

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2643,6 +2643,7 @@ libcrun_get_container_state_string (const char *id, libcrun_container_status_t *
 int
 libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, libcrun_error_t *err)
 {
+  const char *const OCI_CONFIG_VERSION = "1.0.0";
   libcrun_container_status_t status = {};
   const char *state_root = context->state_root;
   const char *container_status = NULL;
@@ -2670,7 +2671,7 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
 
   yajl_gen_map_open (gen);
   yajl_gen_string (gen, YAJL_STR ("ociVersion"), strlen ("ociVersion"));
-  yajl_gen_string (gen, YAJL_STR ("1.0.0"), strlen ("1.0.0"));
+  yajl_gen_string (gen, YAJL_STR (OCI_CONFIG_VERSION), strlen (OCI_CONFIG_VERSION));
 
   yajl_gen_string (gen, YAJL_STR ("id"), strlen ("id"));
   yajl_gen_string (gen, YAJL_STR (id), strlen (id));

--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -442,3 +442,37 @@ libcrun_set_log_format (const char *format, libcrun_error_t *err)
 
   return 0;
 }
+
+int
+yajl_error_to_crun_error (int yajl_status, libcrun_error_t *err)
+{
+  switch (yajl_status)
+    {
+    case yajl_gen_status_ok:
+      return 0;
+
+    case yajl_gen_keys_must_be_strings:
+      return crun_make_error (err, 0, "generate JSON document: gen keys must be strings");
+
+    case yajl_max_depth_exceeded:
+      return crun_make_error (err, 0, "generate JSON document: max depth exceeded");
+
+    case yajl_gen_in_error_state:
+      return crun_make_error (err, 0, "generate JSON document: complete JSON document generated");
+
+    case yajl_gen_generation_complete:
+      return crun_make_error (err, 0, "generate JSON document: called while in error state");
+
+    case yajl_gen_invalid_number:
+      return crun_make_error (err, 0, "generate JSON document: invalid number");
+
+    case yajl_gen_no_buf:
+      return crun_make_error (err, 0, "generate JSON document: no buffer provided");
+
+    case yajl_gen_invalid_string:
+      return crun_make_error (err, 0, "generate JSON document: invalid string");
+
+    default:
+      return crun_make_error (err, 0, "generate JSON document");
+    }
+}

--- a/src/libcrun/error.h
+++ b/src/libcrun/error.h
@@ -94,6 +94,8 @@ LIBCRUN_PUBLIC int libcrun_init_logging (crun_output_handler *output_handler, vo
 
 LIBCRUN_PUBLIC int libcrun_error_release (libcrun_error_t *err);
 
+int yajl_error_to_crun_error (int yajl_status, libcrun_error_t *err);
+
 enum
 {
   LIBCRUN_VERBOSITY_ERROR,

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -168,7 +168,8 @@ cleanup_seccompp (void *p)
 #define cleanup_seccomp __attribute__ ((cleanup (cleanup_seccompp)))
 
 int
-libcrun_apply_seccomp (int infd, int listener_receiver_fd, char **seccomp_flags, size_t seccomp_flags_len,
+libcrun_apply_seccomp (int infd, int listener_receiver_fd, const char *receiver_fd_payload,
+                       size_t receiver_fd_payload_len, char **seccomp_flags, size_t seccomp_flags_len,
                        libcrun_error_t *err)
 {
 #ifdef HAVE_SECCOMP
@@ -233,7 +234,8 @@ libcrun_apply_seccomp (int infd, int listener_receiver_fd, char **seccomp_flags,
     {
       int fd = ret;
 
-      ret = send_fd_to_socket (listener_receiver_fd, fd, err);
+      ret = send_fd_to_socket_with_payload (listener_receiver_fd, fd,
+                                            receiver_fd_payload, receiver_fd_payload_len, err);
       if (UNLIKELY (ret < 0))
         return crun_error_wrap (err, "send listener fd `%d` to receiver", fd);
     }

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -298,11 +298,14 @@ libcrun_generate_seccomp (libcrun_container_t *container, int outfd, unsigned in
     {
       uint32_t arch_token;
       const char *arch = seccomp->architectures[i];
-      char lowercase_arch[32];
+      char *end, lowercase_arch[32] = {
+        0,
+      };
 
       if (has_prefix (arch, "SCMP_ARCH_"))
         arch += 10;
-      stpncpy (lowercase_arch, arch, sizeof (lowercase_arch));
+      end = stpncpy (lowercase_arch, arch, sizeof (lowercase_arch) - 1);
+      *end = '\0';
       make_lowercase (lowercase_arch);
 #  ifdef SECCOMP_ARCH_RESOLVE_NAME
       arch_token = seccomp_arch_resolve_name (lowercase_arch);

--- a/src/libcrun/seccomp.h
+++ b/src/libcrun/seccomp.h
@@ -32,6 +32,7 @@ enum
 };
 
 int libcrun_generate_seccomp (libcrun_container_t *container, int outfd, unsigned int options, libcrun_error_t *err);
-int libcrun_apply_seccomp (int infd, int listener_receiver_fd, char **flags, size_t flags_len, libcrun_error_t *err);
+int libcrun_apply_seccomp (int infd, int listener_receiver_fd, const char *receiver_fd_payload,
+                           size_t receiver_fd_payload_len, char **flags, size_t flags_len, libcrun_error_t *err);
 
 #endif

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -171,7 +171,7 @@ int
 libcrun_write_container_status (const char *state_root, const char *id, libcrun_container_status_t *status,
                                 libcrun_error_t *err)
 {
-  int ret;
+  int r, ret;
   cleanup_free char *file = get_state_directory_status_file (state_root, id);
   cleanup_free char *file_tmp = NULL;
   size_t len;
@@ -199,46 +199,99 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   yajl_gen_config (gen, yajl_gen_beautify, 1);
   yajl_gen_config (gen, yajl_gen_validate_utf8, 1);
 
-  yajl_gen_map_open (gen);
-  yajl_gen_string (gen, YAJL_STR ("pid"), strlen ("pid"));
-  yajl_gen_integer (gen, status->pid);
+  r = yajl_gen_map_open (gen);
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  yajl_gen_string (gen, YAJL_STR ("process-start-time"), strlen ("process-start-time"));
-  yajl_gen_integer (gen, status->process_start_time);
+  r = yajl_gen_string (gen, YAJL_STR ("pid"), strlen ("pid"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  yajl_gen_string (gen, YAJL_STR ("cgroup-path"), strlen ("cgroup-path"));
+  r = yajl_gen_integer (gen, status->pid);
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
+  r = yajl_gen_string (gen, YAJL_STR ("process-start-time"), strlen ("process-start-time"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
+  r = yajl_gen_integer (gen, status->process_start_time);
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
+  r = yajl_gen_string (gen, YAJL_STR ("cgroup-path"), strlen ("cgroup-path"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
   tmp = status->cgroup_path ? status->cgroup_path : "";
-  yajl_gen_string (gen, YAJL_STR (tmp), strlen (tmp));
+  r = yajl_gen_string (gen, YAJL_STR (tmp), strlen (tmp));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  yajl_gen_string (gen, YAJL_STR ("scope"), strlen ("scope"));
+  r = yajl_gen_string (gen, YAJL_STR ("scope"), strlen ("scope"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
   tmp = status->scope ? status->scope : "";
-  yajl_gen_string (gen, YAJL_STR (tmp), strlen (tmp));
+  r = yajl_gen_string (gen, YAJL_STR (tmp), strlen (tmp));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  yajl_gen_string (gen, YAJL_STR ("rootfs"), strlen ("rootfs"));
-  yajl_gen_string (gen, YAJL_STR (status->rootfs), strlen (status->rootfs));
+  r = yajl_gen_string (gen, YAJL_STR ("rootfs"), strlen ("rootfs"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  yajl_gen_string (gen, YAJL_STR ("systemd-cgroup"), strlen ("systemd-cgroup"));
-  yajl_gen_bool (gen, status->systemd_cgroup);
+  r = yajl_gen_string (gen, YAJL_STR (status->rootfs), strlen (status->rootfs));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  yajl_gen_string (gen, YAJL_STR ("bundle"), strlen ("bundle"));
-  yajl_gen_string (gen, YAJL_STR (status->bundle), strlen (status->bundle));
+  r = yajl_gen_string (gen, YAJL_STR ("systemd-cgroup"), strlen ("systemd-cgroup"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  yajl_gen_string (gen, YAJL_STR ("created"), strlen ("created"));
-  yajl_gen_string (gen, YAJL_STR (status->created), strlen (status->created));
+  r = yajl_gen_bool (gen, status->systemd_cgroup);
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  yajl_gen_string (gen, YAJL_STR ("detached"), strlen ("detached"));
-  yajl_gen_bool (gen, status->detached);
+  r = yajl_gen_string (gen, YAJL_STR ("bundle"), strlen ("bundle"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  yajl_gen_string (gen, YAJL_STR ("external_descriptors"), strlen ("external_descriptors"));
-  yajl_gen_string (gen, YAJL_STR (status->external_descriptors), strlen (status->external_descriptors));
+  r = yajl_gen_string (gen, YAJL_STR (status->bundle), strlen (status->bundle));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  yajl_gen_map_close (gen);
+  r = yajl_gen_string (gen, YAJL_STR ("created"), strlen ("created"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
-  if (yajl_gen_get_buf (gen, &buf, &len) != yajl_gen_status_ok)
-    {
-      ret = crun_make_error (err, 0, "cannot generate status file");
-      goto exit;
-    }
+  r = yajl_gen_string (gen, YAJL_STR (status->created), strlen (status->created));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
+  r = yajl_gen_string (gen, YAJL_STR ("detached"), strlen ("detached"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
+  r = yajl_gen_bool (gen, status->detached);
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
+  r = yajl_gen_string (gen, YAJL_STR ("external_descriptors"), strlen ("external_descriptors"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
+  r = yajl_gen_string (gen, YAJL_STR (status->external_descriptors), strlen (status->external_descriptors));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
+  r = yajl_gen_map_close (gen);
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
+  r = yajl_gen_get_buf (gen, &buf, &len);
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
 
   if (UNLIKELY (safe_write (fd_write, buf, (ssize_t) len) < 0))
     {
@@ -259,6 +312,12 @@ exit:
     yajl_gen_free (gen);
 
   return ret;
+
+yajl_error:
+  if (gen)
+    yajl_gen_free (gen);
+
+  return yajl_error_to_crun_error (r, err);
 }
 
 int

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -923,16 +923,28 @@ open_unix_domain_socket (const char *path, int dgram, libcrun_error_t *err)
 int
 send_fd_to_socket (int server, int fd, libcrun_error_t *err)
 {
+  return send_fd_to_socket_with_payload (server, fd, NULL, 0, err);
+}
+
+int
+send_fd_to_socket_with_payload (int server, int fd, const char *payload, size_t payload_len, libcrun_error_t *err)
+{
   int ret;
   struct cmsghdr *cmsg = NULL;
-  struct iovec iov[1];
+  struct iovec iov[2];
   struct msghdr msg = {};
-  char ctrl_buf[CMSG_SPACE (sizeof (int))] = {};
+  char ctrl_buf[CMSG_SPACE (1 + sizeof (int))] = {};
   char data[1];
 
   data[0] = ' ';
   iov[0].iov_base = data;
   iov[0].iov_len = sizeof (data);
+
+  if (payload_len > 0)
+    {
+      iov[0].iov_base = (void *) payload;
+      iov[0].iov_len = payload_len;
+    }
 
   msg.msg_name = NULL;
   msg.msg_namelen = 0;

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -168,7 +168,9 @@ get_file_type_fd (int fd, mode_t *mode)
   int ret;
 
 #ifdef HAVE_STATX
-  struct statx stx;
+  struct statx stx = {
+    0,
+  };
 
   ret = statx (fd, "", AT_EMPTY_PATH | AT_STATX_DONT_SYNC, STATX_TYPE, &stx);
   if (UNLIKELY (ret < 0))
@@ -195,7 +197,9 @@ get_file_type_at (int dirfd, mode_t *mode, bool nofollow, const char *path)
   int ret;
 
 #ifdef HAVE_STATX
-  struct statx stx;
+  struct statx stx = {
+    0,
+  };
 
   ret = statx (dirfd, path, (nofollow ? AT_SYMLINK_NOFOLLOW : 0) | AT_STATX_DONT_SYNC, STATX_TYPE, &stx);
   if (UNLIKELY (ret < 0))
@@ -591,7 +595,9 @@ get_file_size (int fd, off_t *size)
   struct stat st;
   int ret;
 #ifdef HAVE_STATX
-  struct statx stx;
+  struct statx stx = {
+    0,
+  };
 
   ret = statx (fd, "", AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW | AT_STATX_DONT_SYNC, STATX_SIZE, &stx);
   if (UNLIKELY (ret < 0))
@@ -1763,7 +1769,9 @@ copy_rec_stat_file_at (int dfd, const char *path, mode_t *mode, off_t *size, dev
   int ret;
 
 #ifdef HAVE_STATX
-  struct statx stx;
+  struct statx stx = {
+    0,
+  };
 
   ret = statx (dfd, path, AT_SYMLINK_NOFOLLOW | AT_STATX_DONT_SYNC,
                STATX_TYPE | STATX_MODE | STATX_SIZE | STATX_UID | STATX_GID, &stx);

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -221,6 +221,8 @@ int open_unix_domain_socket (const char *path, int dgram, libcrun_error_t *err);
 
 int send_fd_to_socket (int server, int fd, libcrun_error_t *err);
 
+int send_fd_to_socket_with_payload (int server, int fd, const char *payload, size_t payload_len, libcrun_error_t *err);
+
 int create_socket_pair (int *pair, libcrun_error_t *err);
 
 int receive_fd_from_socket (int from, libcrun_error_t *err);

--- a/src/pause.c
+++ b/src/pause.c
@@ -64,7 +64,7 @@ static struct argp run_argp = { options, parse_opt, args_doc, doc, NULL, NULL, N
 int
 crun_command_pause (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
-  int first_arg, ret;
+  int first_arg = 0, ret;
 
   libcrun_context_t crun_context = {
     0,

--- a/src/run.c
+++ b/src/run.c
@@ -143,7 +143,9 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
     }
 
   /* Make sure the bundle is an absolute path.  */
-  if (bundle)
+  if (bundle == NULL)
+    bundle = bundle_cleanup = getcwd (NULL, 0);
+  else
     {
       if (bundle[0] != '/')
         {
@@ -165,7 +167,7 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
   if (UNLIKELY (ret < 0))
     return ret;
 
-  crun_context.bundle = bundle ? bundle : ".";
+  crun_context.bundle = bundle;
   if (getenv ("LISTEN_FDS"))
     crun_context.preserve_fds += strtoll (getenv ("LISTEN_FDS"), NULL, 10);
 

--- a/src/run.c
+++ b/src/run.c
@@ -119,7 +119,7 @@ static struct argp run_argp = { options, parse_opt, args_doc, doc, NULL, NULL, N
 int
 crun_command_run (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
-  int first_arg, ret;
+  int first_arg = 0, ret;
   cleanup_container libcrun_container_t *container = NULL;
   cleanup_free char *bundle_cleanup = NULL;
   cleanup_free char *config_file_cleanup = NULL;

--- a/src/start.c
+++ b/src/start.c
@@ -65,7 +65,7 @@ static struct argp run_argp = { options, parse_opt, args_doc, doc, NULL, NULL, N
 int
 crun_command_start (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
-  int first_arg, ret;
+  int first_arg = 0, ret;
 
   libcrun_context_t crun_context = {
     0,

--- a/src/state.c
+++ b/src/state.c
@@ -71,7 +71,7 @@ static struct argp run_argp = { options, parse_opt, args_doc, doc, NULL, NULL, N
 int
 crun_command_state (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
-  int first_arg, ret;
+  int first_arg = 0, ret;
   libcrun_context_t crun_context = {
     0,
   };

--- a/src/unpause.c
+++ b/src/unpause.c
@@ -64,7 +64,7 @@ static struct argp run_argp = { options, parse_opt, args_doc, doc, NULL, NULL, N
 int
 crun_command_unpause (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
-  int first_arg, ret;
+  int first_arg = 0, ret;
 
   libcrun_context_t crun_context = {
     0,

--- a/src/update.c
+++ b/src/update.c
@@ -229,7 +229,7 @@ static struct argp run_argp = { options, parse_opt, args_doc, doc, NULL, NULL, N
 int
 crun_command_update (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
-  int first_arg, ret;
+  int first_arg = 0, ret;
   char *content = NULL;
   size_t len;
 

--- a/tests/init.c
+++ b/tests/init.c
@@ -310,7 +310,7 @@ int main (int argc, char **argv)
 
   if (strcmp (argv[1], "check-feature") == 0)
     {
-      if (argc < 2)
+      if (argc < 3)
         error (EXIT_FAILURE, 0, "`check-feature` requires an argument");
 
       if (strcmp (argv[2], "open_tree") == 0)

--- a/tests/test_seccomp.py
+++ b/tests/test_seccomp.py
@@ -1,0 +1,103 @@
+#!/bin/env python3
+# crun - OCI runtime written in C
+#
+# Copyright (C) 2021 Giuseppe Scrivano <giuseppe@scrivano.org>
+# crun is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# crun is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with crun.  If not, see <http://www.gnu.org/licenses/>.
+
+import time
+import json
+import subprocess
+import os
+import socket
+import shutil
+import sys
+import array
+from tests_utils import *
+
+def is_seccomp_listener_supported():
+    r = subprocess.call(["./tests/init", "check-feature", "open_tree"])
+    return r == 0
+
+# taken from https://docs.python.org/3/library/socket.html#socket.socket.recvmsg
+def recv_fds(sock, msglen, maxfds):
+    fds = array.array("i")   # Array of ints
+    msg, ancdata, flags, addr = sock.recvmsg(msglen, socket.CMSG_LEN(maxfds * fds.itemsize))
+    for cmsg_level, cmsg_type, cmsg_data in ancdata:
+        if cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS:
+            # Append data, ignoring any truncated integers at the end.
+            fds.frombytes(cmsg_data[:len(cmsg_data) - (len(cmsg_data) % fds.itemsize)])
+    return msg, list(fds)
+
+def test_seccomp_listener():
+    if not is_seccomp_listener_supported():
+        return 77
+
+    listener_path = "%s/seccomp-listener" % get_tests_root()
+    listener_metadata = "SOME-RANDOM-METADATA"
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(listener_path)
+    sock.listen(1)
+
+    conf = base_config()
+    add_all_namespaces(conf)
+    conf['linux']['seccomp'] = {
+        'defaultAction': 'SCMP_ACT_ALLOW',
+        'listenerPath': listener_path,
+        'listenerMetadata': listener_metadata,
+    }
+    conf['process']['args'] = ['/init', 'true']
+    cid = None
+    try:
+        _, cid = run_and_get_output(conf, command='run', detach=True)
+        conn = sock.accept()
+        msg, fds = recv_fds(conn[0], 4096, 1)
+        if len(fds) != 1:
+            print("invalid number of FDs received", file=sys.stderr)
+            return 1
+
+        m = json.loads(msg)
+        if m['ociVersion'] != '0.2.0':
+            print("invalid OCI version", file=sys.stderr)
+            return 1
+        if len(m['fds']) != 1:
+            print("invalid fds", file=sys.stderr)
+            return 1
+        if 'pid' not in m != 1:
+            print("invalid pid", file=sys.stderr)
+            return 1
+        if m['metadata'] != listener_metadata:
+            print("invalid metadata", file=sys.stderr)
+            return 1
+        state = m['state']
+        if state['status'] != 'creating':
+            print("invalid status", file=sys.stderr)
+            return 1
+        if state['id'] != cid:
+            print("invalid container id", file=sys.stderr)
+            return 1
+        return 0
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+        os.unlink(listener_path)
+
+    return -1
+
+all_tests = {
+    "seccomp-listener" : test_seccomp_listener,
+}
+
+if __name__ == "__main__":
+    tests_main(all_tests)


### PR DESCRIPTION
The OCI runtime specs[1] recently gained the support for seccomp
notifications.

[1] https://github.com/opencontainers/runtime-spec/pull/1074

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
