### PR TITLE
linux: always remount bind mounts

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -658,9 +658,6 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
           return crun_make_error (err, saved_errno, "mount `%s` to `/%s`", source, target);
         }
 
-      if ((flags & MS_BIND) && (flags & ~(MS_BIND | MS_RDONLY | ALL_PROPAGATIONS)))
-        needs_remount = true;
-
       if (targetfd >= 0)
         {
           /* We need to reopen the path as the previous targetfd is underneath the new mountpoint.  */
@@ -698,8 +695,9 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
         }
     }
 
-  if (mountflags & MS_RDONLY)
+  if (mountflags & (MS_BIND | MS_RDONLY))
     needs_remount = true;
+
   if (data && fstype && strcmp (fstype, "proc") == 0)
     {
       single_instance = true;

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -35,7 +35,7 @@ def test_resources_pid_limit():
     add_all_namespaces(conf)
 
     fn = "/sys/fs/cgroup/pids/pids.max"
-    if not os.path.exists("/sys/fs/cgroup/pids"):
+    if is_cgroup_v2_unified():
         fn = "/sys/fs/cgroup/pids.max"
         conf['linux']['namespaces'].append({"type" : "cgroup"})
 
@@ -43,6 +43,7 @@ def test_resources_pid_limit():
 
     out, _ = run_and_get_output(conf)
     if "1024" not in out:
+        sys.stderr.write("found %s instead of 1024\n" % out)
         return -1
     return 0
 
@@ -72,7 +73,7 @@ def test_resources_pid_limit_userns():
     conf['linux']['gidMappings'] = mappings
 
     fn = "/sys/fs/cgroup/pids/pids.max"
-    if not os.path.exists("/sys/fs/cgroup/pids"):
+    if is_cgroup_v2_unified():
         fn = "/sys/fs/cgroup/pids.max"
         conf['linux']['namespaces'].append({"type" : "cgroup"})
 
@@ -80,6 +81,7 @@ def test_resources_pid_limit_userns():
 
     out, _ = run_and_get_output(conf)
     if "1024" not in out:
+        sys.stderr.write("found %s instead of 1024\n" % out)
         return -1
     return 0
 


### PR DESCRIPTION
it is useful to reset flags like nodev,noexec,nosuid if they are not
specified in the bind mount itself.

Closes: https://github.com/containers/crun/issues/639

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>