### PR TITLE
cgroup: support array of strings

### DIFF
--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -72,6 +72,8 @@ LIBCRUN_PUBLIC int libcrun_cgroup_read_pids (const char *path, bool recurse, pid
 int libcrun_cgroup_enter (struct libcrun_cgroup_args *args, libcrun_error_t *err);
 int libcrun_cgroups_create_symlinks (int dirfd, libcrun_error_t *err);
 
+int parse_sd_array (char *s, char **out, char **next, libcrun_error_t *err);
+
 typedef const char *cgroups_subsystem_t;
 
 const cgroups_subsystem_t *libcrun_get_cgroups_subsystems ();

--- a/tests/fuzzing/run-tests.sh
+++ b/tests/fuzzing/run-tests.sh
@@ -6,7 +6,7 @@ TIMEOUT=${TIMEOUT:=10}
 RUN_TIME=${RUN_TIME:=600}
 VERBOSITY=${VERBOSITY:=}
 
-N_TESTS=6
+N_TESTS=7
 
 SINGLE_RUN_TIME=$(expr $RUN_TIME / $N_TESTS)
 
@@ -35,3 +35,4 @@ run_test 2 $CORPUS/seccomp
 run_test 3 $CORPUS/signals
 run_test 4 $CORPUS/paths
 run_test 5 random-data
+run_test 6 $CORPUS/annotations

--- a/tests/tests_libcrun_fuzzer.c
+++ b/tests/tests_libcrun_fuzzer.c
@@ -260,6 +260,27 @@ test_read_files (uint8_t *buf, size_t len)
 }
 
 static int
+test_parse_sd_array (uint8_t *buf, size_t len)
+{
+#ifdef HAVE_SYSTEMD
+  char *out = NULL, *next = NULL;
+  cleanup_free char *data = NULL;
+  libcrun_error_t err = NULL;
+
+  data = make_nul_terminated (buf, len);
+  if (data == NULL)
+    return 0;
+
+  if (parse_sd_array (data, &out, &next, &err) < 0)
+    crun_error_release (&err);
+#else
+  (void) buf;
+  (void) len;
+#endif
+  return 0;
+}
+
+static int
 run_one_container (uint8_t *buf, size_t len, bool detach)
 {
   cleanup_free char *conf = NULL;
@@ -350,6 +371,11 @@ run_one_test (int mode, uint8_t *buf, size_t len)
     case 5:
       /* expects random data.  */
       test_generate_ebpf (buf, len);
+      break;
+
+    case 6:
+      /* expects annotations data.  */
+      test_parse_sd_array (buf, len);
       break;
 
       /* ALL mode.  */


### PR DESCRIPTION
add support for array of strings so that it can be used like:

"annotations" : {
    "org.systemd.property.After" : "['firewalld.service']"
},

Reported: https://github.com/cri-o/cri-o/pull/4766#issuecomment-820828260

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>