### PR TITLE
spec: add cgroup ns if on cgroup v2

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -1904,7 +1904,7 @@ libcrun_cgroup_pause_unpause (const char *cgroup_path, const bool pause, libcrun
   int cgroup_mode;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (cgroup_mode < 0)
+  if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
 
   return libcrun_cgroup_pause_unpause_with_mode (cgroup_path, cgroup_mode, pause, err);
@@ -1996,7 +1996,7 @@ libcrun_cgroup_read_pids (const char *path, bool recurse, pid_t **pids, libcrun_
     return 0;
 
   mode = libcrun_get_cgroup_mode (err);
-  if (mode < 0)
+  if (UNLIKELY (mode < 0))
     return mode;
 
   switch (mode)
@@ -2146,7 +2146,7 @@ libcrun_cgroup_destroy (const char *id, const char *path, const char *scope, int
     return -1;
 
   mode = libcrun_get_cgroup_mode (err);
-  if (mode < 0)
+  if (UNLIKELY (mode < 0))
     return mode;
 
   ret = libcrun_cgroup_killall (path, err);

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2239,7 +2239,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
     }
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (cgroup_mode < 0)
+  if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
 
   pid = libcrun_run_linux_container (container, container_init, &container_args, &sync_socket, err);
@@ -2824,7 +2824,7 @@ libcrun_get_container_state_string (const char *id, libcrun_container_status_t *
       int cgroup_mode;
 
       cgroup_mode = libcrun_get_cgroup_mode (err);
-      if (cgroup_mode < 0)
+      if (UNLIKELY (cgroup_mode < 0))
         return cgroup_mode;
 
       ret = libcrun_cgroup_is_container_paused (status->cgroup_path, cgroup_mode, &paused, err);
@@ -3487,7 +3487,7 @@ libcrun_container_restore (libcrun_context_t *context, const char *id, libcrun_c
   def = container->container_def;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (cgroup_mode < 0)
+  if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
 
   cgroup_manager = CGROUP_MANAGER_CGROUPFS;

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -99,7 +99,7 @@ struct sync_socket_message_s
 
 typedef runtime_spec_schema_defs_hook hook;
 
-static char spec_file[] = "\
+static const char spec_file[] = "\
   {\n\
 	\"ociVersion\": \"1.0.0\",\n\
 	\"process\": {\n\

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -79,7 +79,7 @@ restore_cgroup_v1_mount (runtime_spec_schema_config_schema *def, libcrun_error_t
   uint32_t i;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (cgroup_mode < 0)
+  if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
 
   if (cgroup_mode == CGROUP_MODE_UNIFIED)
@@ -306,7 +306,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
     return crun_make_error (err, 0, "error setting CRIU root to %s\n", path);
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (cgroup_mode < 0)
+  if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
 
   /* For cgroup v1 we need to tell CRIU to handle all cgroup mounts as external mounts. */

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -741,7 +741,7 @@ do_mount_cgroup_v2 (libcrun_container_t *container, int targetfd, const char *ta
   int cgroup_mode;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (cgroup_mode < 0)
+  if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
 
   ret = do_mount (container, "cgroup2", targetfd, target, "cgroup2", mountflags, NULL, LABEL_NONE, err);
@@ -954,7 +954,7 @@ do_mount_cgroup (libcrun_container_t *container, const char *source, int targetf
   int cgroup_mode;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (cgroup_mode < 0)
+  if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
 
   switch (cgroup_mode)
@@ -3737,7 +3737,7 @@ libcrun_linux_container_update (libcrun_container_status_t *status, const char *
   int cgroup_mode;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (cgroup_mode < 0)
+  if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
 
   ret = parse_json_file (&tree, content, &ctx, err);


### PR DESCRIPTION
Upper-level tools (podman etc) now set cgroupns in case cgroup v2
unified is detected. Let's do the same during crun spec.

Related: https://github.com/opencontainers/runc/pull/2322
