### PR TITLE
utils: use /proc/self/fd to open unix socket

### DIFF
--- a/contrib/seccomp-notify-plugin-rust/src/seccompwatcher.rs
+++ b/contrib/seccomp-notify-plugin-rust/src/seccompwatcher.rs
@@ -26,7 +26,6 @@ type Errno = i32;
 
 type SyscallHandler = fn(req: &mut nc::seccomp_notif_t) -> Result<bool, Errno>;
 
-#[no_mangle]
 pub struct LibcrunLoadSeccompNotifyConf {
     _runtime_root_path: *const c_char,
     _name: *const c_char,


### PR DESCRIPTION
when the patch is longer than sizeof (sockaddr_un.sun_path)

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
