### PR TITLE
kill: fix race condition with pidfd_open

### DIFF
--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -119,7 +119,7 @@ read_pid_stat (pid_t pid, struct pid_stat *st, libcrun_error_t *err)
   if (fd < 0)
     {
       /* The process already exited.  */
-      if (errno == ENOENT)
+      if (errno == ENOENT || errno == ESRCH)
         {
           memset (st, 0, sizeof (*st));
           return 0;


### PR DESCRIPTION
in addition to ENOENT, add check for ESRCH that could be returned by
some code paths in the procfs.

Closes: https://github.com/containers/crun/issues/660

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>