### PR TITLE
Fix SIGSEGV: For `run` on rootless container caused by case when spec has linux block set but cgroupsPath is not defined.

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -1856,7 +1856,7 @@ libcrun_cgroup_enter (struct libcrun_cgroup_args *args, libcrun_error_t *err)
     }
 
   /* Ignore errors only if there is no explicit path set in the configuration.  */
-  cgroup_path_empty = args->cgroup_path[0] == '\0';
+  cgroup_path_empty = (args->cgroup_path == NULL || args->cgroup_path[0] == '\0');
   if (rootless > 0 && cgroup_path_empty && (cgroup_mode != CGROUP_MODE_UNIFIED || manager != CGROUP_MANAGER_SYSTEMD))
     {
       /* Ignore cgroups errors and set there is no cgroup path to use.  */


### PR DESCRIPTION
Following issue is introduced after : https://github.com/containers/crun/pull/658 due to check on a pointer which is **NULL** in few cases ( Such as `crun run` for rootless spec where cgroupsPath is not set at all )

Reason: `cgroup_path` is passed as **NULL** when `def-linux` is defined and `def->linux->cgroups_path` is not set before passing arg to `libcrun_cgroup_enter` at  https://github.com/containers/crun/blob/master/src/libcrun/container.c#L2295 and https://github.com/containers/crun/blob/master/src/libcrun/container.c#L3538

GDB trace before fix:
```bash
Program received signal SIGSEGV, Segmentation fault.
0x000055555556e2f7 in libcrun_cgroup_enter (args=args@entry=0x7fffffffd7c0, err=err@entry=0x7fffffffdbc0) at src/libcrun/cgroup.c:1860
1860	  if (rootless > 0 && cgroup_path_empty && (cgroup_mode != CGROUP_MODE_UNIFIED || manager != CGROUP_MANAGER_SYSTEMD))
```