### PR TITLE
Exec: add support for `--apparmor`,`--process-label`,`--no-new-privs` and adhere if noNewPriviledges is `false` in spec

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -40,6 +40,8 @@ struct exec_options_s
   const char *process;
   const char *console_socket;
   const char *pid_file;
+  char *process_label;
+  char *apparmor;
   char *cwd;
   char *user;
   char **env;
@@ -54,7 +56,9 @@ enum
   OPTION_PID_FILE,
   OPTION_CWD,
   OPTION_PRESERVE_FDS,
-  OPTION_NO_NEW_PRIVS
+  OPTION_NO_NEW_PRIVS,
+  OPTION_PROCESS_LABEL,
+  OPTION_APPARMOR
 };
 
 static struct exec_options_s exec_options;
@@ -72,6 +76,8 @@ static struct argp_option options[]
         { "pid-file", OPTION_PID_FILE, "FILE", 0, "where to write the PID of the container", 0 },
         { "preserve-fds", OPTION_PRESERVE_FDS, "N", 0, "pass additional FDs to the container", 0 },
         { "no-new-privs", OPTION_NO_NEW_PRIVS, 0, 0, "set the no new privileges value for the process", 0 },
+        { "process-label", OPTION_PROCESS_LABEL, "VALUE", 0, "set the asm process label for the process commonly used with selinux", 0 },
+        { "apparmor", OPTION_APPARMOR, "VALUE", 0, "set the apparmor profile for the process", 0 },
         {
             0,
         } };
@@ -131,6 +137,14 @@ parse_opt (int key, char *arg, struct argp_state *state)
 
     case OPTION_NO_NEW_PRIVS:
       exec_options.no_new_privs = true;
+      break;
+
+    case OPTION_PROCESS_LABEL:
+      exec_options.process_label = argp_mandatory_argument (arg, state);
+      break;
+
+    case OPTION_APPARMOR:
+      exec_options.apparmor = argp_mandatory_argument (arg, state);
       break;
 
     case OPTION_PRESERVE_FDS:
@@ -249,6 +263,13 @@ crun_command_exec (struct crun_global_arguments *global_args, int argc, char **a
       process->env = exec_options.env;
       process->env_len = exec_options.env_size;
       process->user = make_oci_process_user (exec_options.user);
+
+      if (exec_options.process_label != NULL)
+        process->selinux_label = exec_options.process_label;
+
+      if (exec_options.apparmor != NULL)
+        process->apparmor_profile = exec_options.apparmor;
+
       if (exec_options.cap_size > 0)
         {
           runtime_spec_schema_config_schema_process_capabilities *capabilities


### PR DESCRIPTION
### Extend `exec`
Following PR adds support for **runc** like

* `exec --no-new-privs` : set the no new privileges value for the process
**Reason:** As of now crun always sets `no_new_privileges` to **TRUE** even if baseconfig has its value set to **FALSE** however it should allow users to set value when baseconfig has configured value **FALSE**.

* `exec --apparmor`: set the apparmor profile for the process.
* `exec --process-label`:  set the asm process label for the process commonly used with selinux. 

Reference: https://manpages.debian.org/testing/runc/runc-exec.8.en.html#OPTIONS