### PR TITLE
container: call prestart hooks before rootfs is RO

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1809,7 +1809,7 @@ make_parent_mount_private (const char *rootfs, libcrun_error_t *err)
 }
 
 int
-libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_error_t *err)
+libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, set_mounts_cb_t cb, void *cb_data, libcrun_error_t *err)
 {
   int rootfsfd = -1;
   int ret = 0, is_user_ns = 0;
@@ -1889,6 +1889,14 @@ libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_
   if (! get_private_data (container)->mount_dev_from_host)
     {
       ret = create_missing_devs (container, is_user_ns ? true : false, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+    }
+
+  /* Notify the callback after all the mounts are ready but before making them read-only.  */
+  if (cb)
+    {
+      ret = cb (cb_data, err);
       if (UNLIKELY (ret < 0))
         return ret;
     }

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -29,11 +29,13 @@
 
 typedef int (*container_entrypoint_t) (void *args, char *notify_socket, int sync_socket, libcrun_error_t *err);
 
+typedef int (*set_mounts_cb_t) (void *args, libcrun_error_t *err);
+
 pid_t libcrun_run_linux_container (libcrun_container_t *container, container_entrypoint_t entrypoint, void *args,
                                    int *sync_socket_out, libcrun_error_t *err);
 int get_notify_fd (libcrun_context_t *context, libcrun_container_t *container, int *notify_socket_out,
                    libcrun_error_t *err);
-int libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, libcrun_error_t *err);
+int libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, set_mounts_cb_t cb, void *cb_data, libcrun_error_t *err);
 int libcrun_init_caps (libcrun_error_t *err);
 int libcrun_do_pivot_root (libcrun_container_t *container, bool no_pivot, const char *rootfs, libcrun_error_t *err);
 int libcrun_reopen_dev_null (libcrun_error_t *err);


### PR DESCRIPTION
call the prestart hooks before making the mounts read-only to keep the
same behavior runc has.

Closes: https://github.com/containers/crun/issues/667

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>