### PR TITLE
Fix: Change `LinuxDeviceCgroup.linux.resources.devices.allow` to `bool` in  default Spec & Update crun manual

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -239,6 +239,10 @@ Delete all the containers that satisfy the specified regex.
 crun [global options] exec [options] CONTAINER CMD
 
 .PP
+\fB\-\-apparmor\fP=\fBPROFILE\fP
+Set the apparmor profile for the process.
+
+.PP
 \fB\-\-console\-socket\fP=\fBSOCKET\fP
 Path to a UNIX socket that will receive the ptmx end of the tty for
 the container.
@@ -260,12 +264,20 @@ Detach the container process from the current session.
 Specify an environment variable.
 
 .PP
+\fB\-\-no\-new\-privs\fP
+Set the no new privileges value for the process.
+
+.PP
 \fB\-\-preserve\-fds\fP=\fBN\fP
 Additional number of FDs to pass into the container.
 
 .PP
 \fB\-\-process\fP=\fBFILE\fP
 Path to a file containing the process JSON configuration.
+
+.PP
+\fB\-\-process\-label\fP=\fBVALUE\fP
+Set the asm process label for the process commonly used with selinux.
 
 .PP
 \fB\-\-pid\-file\fP=\fBPATH\fP
@@ -311,6 +323,10 @@ By default \fB\fCtable\fR is used.
 .SH SPEC OPTIONS
 .PP
 crun [global options] spec [options]
+
+.PP
+\fB\-b DIR\fP \fB\-\-bundle\fP=\fBDIR\fP
+Path to the root of the bundle dir (default ".").
 
 .PP
 \fB\-\-rootless\fP

--- a/crun.1.md
+++ b/crun.1.md
@@ -186,6 +186,9 @@ Delete all the containers that satisfy the specified regex.
 
 crun [global options] exec [options] CONTAINER CMD
 
+**--apparmor**=**PROFILE**
+Set the apparmor profile for the process.
+
 **--console-socket**=**SOCKET**
 Path to a UNIX socket that will receive the ptmx end of the tty for
 the container.
@@ -202,11 +205,17 @@ Detach the container process from the current session.
 **--env**=**ENV**
 Specify an environment variable.
 
+**--no-new-privs**
+Set the no new privileges value for the process.
+
 **--preserve-fds**=**N**
 Additional number of FDs to pass into the container.
 
 **--process**=**FILE**
 Path to a file containing the process JSON configuration.
+
+**--process-label**=**VALUE**
+Set the asm process label for the process commonly used with selinux.
 
 **--pid-file**=**PATH**
 Path to the file that will contain the new process PID.
@@ -245,6 +254,9 @@ By default `table` is used.
 ## SPEC OPTIONS
 
 crun [global options] spec [options]
+
+**-b DIR** **--bundle**=**DIR**
+Path to the root of the bundle dir (default ".").
 
 **--rootless**
 Generate a config.json file that is usable by an unprivileged user.

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -237,7 +237,7 @@ static const char spec_file[] = "\
 		\"resources\": {\n\
 			\"devices\": [\n\
 				{\n\
-					\"allow\": \"false\",\n\
+					\"allow\": false,\n\
 					\"access\": \"rwm\"\n\
 				}\n\
 			]\n\


### PR DESCRIPTION
####  1. Change `LinuxDeviceCgroup.linux.resources.devices.allow` to `bool` in  default Spec
**Reason:** Upstream Go based (https://github.com/opencontainers/runtime-spec) parser is unable to parse crun generated spec. Introduced in PR https://github.com/containers/crun/pull/636
   **Logs:**
```bash
ERRO[0000] json: cannot unmarshal string into Go struct field LinuxDeviceCgroup.linux.resources.devices.allow of type bool
```
#### 2. Update `crun` man pages