### PR TITLE
Makefile.am: make sure libocispec uses main branch

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -161,7 +161,7 @@ endif HAVE_MD2MAN
 generate-man: crun.1
 
 sync:
-	(cd libocispec; git pull https://github.com/containers/libocispec)
+	(cd libocispec; git pull https://github.com/containers/libocispec main)
 
 coverity:
 	$(MAKE) $(AM_MAKEFLAGS) -C libocispec


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>