### PR TITLE
cgroup: Refactor libcrun-cgroup-destory to support cleaning custom controllers.

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -38,28 +38,6 @@
 #include <fcntl.h>
 #include <libgen.h>
 
-static const cgroups_subsystem_t cgroups_subsystems[] = {
-  "cpuset",
-  "cpu",
-  "devices",
-  "pids",
-  "memory",
-  "net_cls,net_prio",
-  "freezer",
-  "blkio",
-  "hugetlb",
-  "cpu,cpuacct",
-  "perf_event",
-  "unified",
-  NULL
-};
-
-const cgroups_subsystem_t *
-libcrun_get_cgroups_subsystems (libcrun_error_t *err arg_unused)
-{
-  return cgroups_subsystems;
-}
-
 struct symlink_s
 {
   const char *name;
@@ -2185,42 +2163,11 @@ libcrun_cgroup_killall (const char *path, libcrun_error_t *err)
   return libcrun_cgroup_killall_signal (path, SIGKILL, err);
 }
 
-int
-libcrun_cgroup_destroy (const char *id, const char *path, const char *scope, int manager, libcrun_error_t *err)
+static int
+do_cgroup_destroy (const char *path, int mode, libcrun_error_t *err)
 {
-  int ret;
-  size_t i;
-  int mode;
-  const cgroups_subsystem_t *subsystems;
   bool repeat = true;
-
-  (void) id;
-  (void) manager;
-  (void) scope;
-
-  if (path == NULL || *path == '\0')
-    return 0;
-
-  subsystems = libcrun_get_cgroups_subsystems (err);
-  if (UNLIKELY (subsystems == NULL))
-    return -1;
-
-  mode = libcrun_get_cgroup_mode (err);
-  if (UNLIKELY (mode < 0))
-    return mode;
-
-  ret = libcrun_cgroup_killall (path, err);
-  if (UNLIKELY (ret < 0))
-    crun_error_release (err);
-
-#ifdef HAVE_SYSTEMD
-  if (manager == CGROUP_MANAGER_SYSTEMD)
-    {
-      ret = destroy_systemd_cgroup_scope (scope, err);
-      if (UNLIKELY (ret < 0))
-        crun_error_release (err);
-    }
-#endif
+  int ret;
 
   do
     {
@@ -2243,14 +2190,37 @@ libcrun_cgroup_destroy (const char *id, const char *path, const char *scope, int
         }
       else
         {
-          for (i = 0; subsystems[i]; i++)
+          cleanup_free char *content = NULL;
+          size_t content_size;
+          char *controller;
+          char *saveptr;
+          bool has_data;
+
+          ret = read_all_file ("/proc/self/cgroup", &content, &content_size, err);
+          if (UNLIKELY (ret < 0))
+            {
+              if (crun_error_get_errno (err) == ENOENT)
+                {
+                  crun_error_release (err);
+                  return 0;
+                }
+              return ret;
+            }
+
+          for (has_data = read_proc_cgroup (content, &saveptr, NULL, &controller, NULL);
+               has_data;
+               has_data = read_proc_cgroup (NULL, &saveptr, NULL, &controller, NULL))
             {
               cleanup_free char *cgroup_path = NULL;
+              char *subsystem;
+              if (has_prefix (controller, "name="))
+                controller += 5;
 
-              if (mode == CGROUP_MODE_LEGACY && strcmp (subsystems[i], "unified") == 0)
+              subsystem = controller[0] == '\0' ? "unified" : controller;
+              if (mode == CGROUP_MODE_LEGACY && strcmp (subsystem, "unified") == 0)
                 continue;
 
-              ret = append_paths (&cgroup_path, err, CGROUP_ROOT, subsystems[i], path, NULL);
+              ret = append_paths (&cgroup_path, err, CGROUP_ROOT, subsystem, path, NULL);
               if (UNLIKELY (ret < 0))
                 return ret;
 
@@ -2278,6 +2248,43 @@ libcrun_cgroup_destroy (const char *id, const char *path, const char *scope, int
             crun_error_release (err);
         }
   } while (repeat);
+
+  return 0;
+}
+
+int
+libcrun_cgroup_destroy (const char *id, const char *path, const char *scope, int manager, libcrun_error_t *err)
+{
+  int ret;
+  int mode;
+
+  (void) id;
+  (void) manager;
+  (void) scope;
+
+  if (path == NULL || *path == '\0')
+    return 0;
+
+  mode = libcrun_get_cgroup_mode (err);
+  if (UNLIKELY (mode < 0))
+    return mode;
+
+  ret = libcrun_cgroup_killall (path, err);
+  if (UNLIKELY (ret < 0))
+    crun_error_release (err);
+
+#ifdef HAVE_SYSTEMD
+  if (manager == CGROUP_MANAGER_SYSTEMD)
+    {
+      ret = destroy_systemd_cgroup_scope (scope, err);
+      if (UNLIKELY (ret < 0))
+        crun_error_release (err);
+    }
+#endif
+
+  ret = do_cgroup_destroy (path, mode, err);
+  if (UNLIKELY (ret < 0))
+    crun_error_release (err);
 
   return 0;
 }

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -75,10 +75,6 @@ int libcrun_cgroups_create_symlinks (int dirfd, libcrun_error_t *err);
 
 int parse_sd_array (char *s, char **out, char **next, libcrun_error_t *err);
 
-typedef const char *cgroups_subsystem_t;
-
-const cgroups_subsystem_t *libcrun_get_cgroups_subsystems ();
-
 int libcrun_cgroup_has_oom (const char *path, int cgroup_mode, libcrun_error_t *err);
 
 #endif

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -852,7 +852,6 @@ do_mount_cgroup_v1 (libcrun_container_t *container, const char *source, int targ
                     unsigned long mountflags, libcrun_error_t *err)
 {
   int ret;
-  const cgroups_subsystem_t *subsystems = NULL;
   cleanup_free char *content = NULL;
   char *from;
   cleanup_close int tmpfsdirfd = -1;
@@ -862,10 +861,6 @@ do_mount_cgroup_v1 (libcrun_container_t *container, const char *source, int targ
 #if CLONE_NEWCGROUP
   has_cgroupns = get_private_data (container)->unshare_flags & CLONE_NEWCGROUP;
 #endif
-
-  subsystems = libcrun_get_cgroups_subsystems (err);
-  if (UNLIKELY (subsystems == NULL))
-    return -1;
 
   ret = do_mount (container, source, targetfd, target, "tmpfs", mountflags & ~MS_RDONLY, "size=1024k", LABEL_MOUNT,
                   err);


### PR DESCRIPTION
Refactor libcrun-cgroup-destory to support cleaning custom controllers by picking subsystems dynamically.
+ Adds `libcrun_cgroup_destroy_subsystem`
- Removes `libcrun_get_cgroups_subsystems`