### PR TITLE
seccomp: drop SECCOMP_FILTER_FLAG_LOG by default

### DIFF
--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -187,7 +187,7 @@ libcrun_apply_seccomp (int infd, int listener_receiver_fd, const char *receiver_
 
   /* if no seccomp flag was specified use a sane default.  */
   if (seccomp_flags == NULL)
-    flags = SECCOMP_FILTER_FLAG_LOG | SECCOMP_FILTER_FLAG_SPEC_ALLOW;
+    flags = SECCOMP_FILTER_FLAG_SPEC_ALLOW;
   else
     {
       size_t i = 0;


### PR DESCRIPTION
commit fefabffa2816ea343068ed036a86944393db189a introduced support for
seccomp flags and hardcoded the default to ALLOW|LOG.

Change the default to SECCOMP_FILTER_FLAG_SPEC_ALLOW.

Closes: https://github.com/containers/crun/issues/683

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>