### PR TITLE
crun 0.20: install required python3-jinja2 package in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora
 
 RUN dnf install -y git dnf-utils gcc meson ninja-build libseccomp-static libcap-static \
     make python git gcc automake autoconf libcap-devel systemd-devel yajl-devel libseccomp-devel cmake \
-    go-md2man glibc-static python3-libmount libtool pcre2-static \
+    go-md2man glibc-static python3-libmount libtool pcre2-static python3-jinja2 \
     && yum-builddep -y systemd \
     && git clone --depth 1 https://github.com/systemd/systemd.git \
     && (mkdir systemd/build; cd systemd/build; meson -Dstatic-libsystemd=true -Dselinux=false ..; ninja version.h; ninja libsystemd.a; cp libsystemd.a /usr/lib64) \


### PR DESCRIPTION
Trying to build the 0.20 release with the Dockerfile fails with the following error:

```
$ podman build -t build-crun:latest -t "build-crun:0.20" -f Dockerfile .
[...]
Program mount found: YES (/usr/bin/mount)
Program umount found: YES (/usr/bin/umount)
Program loadkeys /usr/sbin/loadkeys /sbin/loadkeys found: NO
Program setfont /usr/sbin/setfont /sbin/setfont found: NO
Program nologin found: YES (/usr/sbin/nologin)

../meson.build:620:8: ERROR: Problem encountered: python3 jinja2 missing

A full log can be found at /systemd/build/meson-logs/meson-log.txt
ninja: error: loading 'build.ninja': No such file or directory
ninja: error: loading 'build.ninja': No such file or directory
cp: cannot stat 'libsystemd.a': No such file or directory
Error: error building at STEP "RUN dnf install -y git dnf-utils gcc meson ninja-build libseccomp-static libcap-static     make python git gcc automake autoconf libcap-devel systemd-devel yajl-devel libseccomp-deve
l cmake     go-md2man glibc-static python3-libmount libtool pcre2-static     && yum-builddep -y systemd     && git clone --depth 1 https://github.com/systemd/systemd.git     && (mkdir systemd/build; cd systemd/bui
ld; meson -Dstatic-libsystemd=true -Dselinux=false ..; ninja version.h; ninja libsystemd.a; cp libsystemd.a /usr/lib64)     && (git clone --depth=1 https://github.com/lloyd/yajl.git; cd yajl; ./configure LDFLAGS=-
static; cd build; make -j $(nproc); find . -name '*.a' -exec cp \{\} /usr/lib64 \;)": error while running runtime: exit status 1
```

Adding `python3-jinja2` to `dnf install ...` fixes this. :slightly_smiling_face: 
