### PR TITLE
container: ignore resetting keyring SELinux label

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+* crun-0.20.1
+
+- container: ignore error when resetting the SELinux label for the
+  keyring.
+
 * crun-0.20
 
 - container: call prestart hooks before rootfs is RO.

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -337,15 +337,9 @@ libcrun_create_keyring (const char *name, const char *label, libcrun_error_t *er
     }
 
 out:
+  /* Best effort attempt to reset the SELinux label used for new keyrings.  */
   if (label_set)
-    {
-      int tmp_ret;
-
-      tmp_ret = write (labelfd, "", 0);
-      /* do not override a previous error.  */
-      if (UNLIKELY (tmp_ret < 0 && ret >= 0))
-        return crun_make_error (err, errno, "reset `%s`", keycreate);
-    }
+    write (labelfd, "", 0);
   return ret;
 }
 


### PR DESCRIPTION
ignore the error when resetting the SELinux label for newly created keyrings.

If an error happen the label is left configured to the container process SELinux label.

commit 52019563aa5732414c00a91b61add7f3d75464ea introduced the issue.

Closes: https://github.com/containers/crun/issues/687

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
