### PR TITLE
status: add fields for `owner` and `created` timestamp

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1670,6 +1670,7 @@ write_container_status (libcrun_container_t *container, libcrun_context_t *conte
                         char *scope, char *created, libcrun_error_t *err)
 {
   cleanup_free char *cwd = getcwd (NULL, 0);
+  cleanup_free char *owner = get_user_name (geteuid ());
   char *external_descriptors = libcrun_get_external_descriptors (container);
   char *rootfs = container->container_def->root ? container->container_def->root->path : "";
   libcrun_container_status_t status = { .pid = pid,
@@ -1678,6 +1679,7 @@ write_container_status (libcrun_container_t *container, libcrun_context_t *conte
                                         .rootfs = rootfs,
                                         .bundle = cwd,
                                         .created = created,
+                                        .owner = owner,
                                         .systemd_cgroup = context->systemd_cgroup,
                                         .detached = context->detach,
                                         .external_descriptors = external_descriptors };
@@ -2943,7 +2945,7 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
   yajl_gen_string (gen, YAJL_STR (status.created), strlen (status.created));
 
   yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));
-  yajl_gen_string (gen, YAJL_STR (""), strlen (""));
+  yajl_gen_string (gen, YAJL_STR (status.owner), strlen (status.owner));
 
   {
     size_t i;

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -269,6 +269,14 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   if (UNLIKELY (r != yajl_gen_status_ok))
     goto yajl_error;
 
+  r = yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
+  r = yajl_gen_string (gen, YAJL_STR (status->owner), strlen (status->owner));
+  if (UNLIKELY (r != yajl_gen_status_ok))
+    goto yajl_error;
+
   r = yajl_gen_string (gen, YAJL_STR ("detached"), strlen ("detached"));
   if (UNLIKELY (r != yajl_gen_status_ok))
     goto yajl_error;
@@ -389,6 +397,11 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
     if (UNLIKELY (tmp == NULL))
       return crun_make_error (err, 0, "'created' missing in %s", file);
     status->created = xstrdup (YAJL_GET_STRING (tmp));
+  }
+  {
+    const char *owner[] = { "owner", NULL };
+    tmp = yajl_tree_get (tree, owner, yajl_t_string);
+    status->owner = tmp ? xstrdup (YAJL_GET_STRING (tmp)) : NULL;
   }
   {
     const char *detached[] = { "detached", NULL };
@@ -549,6 +562,7 @@ libcrun_free_container_status (libcrun_container_status_t *status)
   free (status->external_descriptors);
   free (status->created);
   free (status->scope);
+  free (status->owner);
 }
 
 int

--- a/src/libcrun/status.h
+++ b/src/libcrun/status.h
@@ -43,6 +43,7 @@ struct libcrun_container_status_s
   char *created;
   int detached;
   char *external_descriptors;
+  char *owner;
 };
 typedef struct libcrun_container_status_s libcrun_container_status_t;
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -2146,3 +2146,14 @@ base64_decode (const char *iptr, size_t isize, char *optr, size_t osize, size_t 
     }
   return consumed;
 }
+
+char *
+get_user_name (uid_t uid)
+{
+  struct passwd pd;
+  struct passwd *temp_result_ptr;
+  char pwdbuffer[200];
+  if (! getpwuid_r (uid, &pd, pwdbuffer, sizeof (pwdbuffer), &temp_result_ptr))
+    return xstrdup (pd.pw_name);
+  return xstrdup ("");
+}

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -268,6 +268,8 @@ int get_file_type (mode_t *mode, bool nofollow, const char *path);
 
 int get_file_type_fd (int fd, mode_t *mode);
 
+char *get_user_name (uid_t uid);
+
 int safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *path, int flags, int mode,
                  libcrun_error_t *err);
 

--- a/src/list.c
+++ b/src/list.c
@@ -133,7 +133,7 @@ crun_command_list (struct crun_global_arguments *global_args, int argc, char **a
     error (EXIT_FAILURE, 0, "yajl_gen_alloc failed");
 
   if (! list_options.quiet && list_options.format == LIST_TABLE)
-    printf ("%-*s%-10s%-8s %-39s\n", max_length, "NAME", "PID", "STATUS", "BUNDLE PATH");
+    printf ("%-*s%-10s%-8s %-39s %-30s %s\n", max_length, "NAME", "PID", "STATUS", "BUNDLE PATH", "CREATED", "OWNER");
   else if (list_options.format == LIST_JSON)
     {
       yajl_gen_config (gen, yajl_gen_beautify, 1);
@@ -181,11 +181,15 @@ crun_command_list (struct crun_global_arguments *global_args, int argc, char **a
               yajl_gen_string (gen, YAJL_STR (container_status), strlen (container_status));
               yajl_gen_string (gen, YAJL_STR ("bundle"), strlen ("bundle"));
               yajl_gen_string (gen, YAJL_STR (status.bundle), strlen (status.bundle));
+              yajl_gen_string (gen, YAJL_STR ("created"), strlen ("created"));
+              yajl_gen_string (gen, YAJL_STR (status.created), strlen (status.created));
+              yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));
+              yajl_gen_string (gen, YAJL_STR (status.owner), strlen (status.owner));
               yajl_gen_map_close (gen);
               break;
 
             case LIST_TABLE:
-              printf ("%-*s%-10d%-8s %-39s\n", max_length, it->name, pid, container_status, status.bundle);
+              printf ("%-*s%-10d%-8s %-39s %-30s %s\n", max_length, it->name, pid, container_status, status.bundle, status.created, status.owner);
               break;
             }
         }


### PR DESCRIPTION
Following PR adds support for
* Adds a new field `owner` to `status`: Shows owners of launched containers.
* Adds a new field `created` to `list`:  Shows created timestamp for container.

Example output
```bash
NAME       PID       STATUS   BUNDLE PATH              CREATED                        OWNER
container 201048    running  /home/flouthoc/container  2021-06-17T19:21:42.000628462Z flouthoc

```