### PR TITLE
`kvm/krun`: crun should silently/gracefully switch to `krun` as backend runtime when invoked as `krun`

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -120,6 +120,9 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
   cleanup_free char *config_file_cleanup = NULL;
 
   crun_context.preserve_fds = 0;
+  /* Check if global handler is configured and pass it down to crun context */
+  crun_context.handler = global_args->handler;
+
   argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &crun_context);
 
   crun_assert_n_args (argc - first_arg, 1, 1);

--- a/src/crun.c
+++ b/src/crun.c
@@ -21,6 +21,9 @@
 #include <stdlib.h>
 #include <argp.h>
 #include <string.h>
+#ifdef HAVE_LIBKRUN
+#  include <libgen.h>
+#endif
 
 #include "crun.h"
 #include "libcrun/utils.h"
@@ -204,6 +207,9 @@ print_version (FILE *stream, struct argp_state *state arg_unused)
 #ifdef HAVE_CRIU
   fprintf (stream, "+CRIU ");
 #endif
+#ifdef HAVE_LIBKRUN
+  fprintf (stream, "+LIBKRUN ");
+#endif
   fprintf (stream, "+YAJL\n");
 }
 
@@ -300,6 +306,12 @@ main (int argc, char **argv)
   int ret, first_argument = 0;
 
   argp_program_version_hook = print_version;
+#ifdef HAVE_LIBKRUN
+  if (strcmp (basename (argv[0]), "krun") == 0)
+    {
+      arguments.handler = "krun";
+    }
+#endif
 
   argp_parse (&argp, argc, argv, ARGP_IN_ORDER, &first_argument, &arguments);
 

--- a/src/crun.h
+++ b/src/crun.h
@@ -25,6 +25,7 @@ struct crun_global_arguments
   char *root;
   char *log;
   char *log_format;
+  const char *handler;
 
   bool command;
   bool debug;

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -33,6 +33,7 @@ struct libcrun_context_s
   const char *console_socket;
   const char *pid_file;
   const char *notify_socket;
+  const char *handler;
   int preserve_fds;
 
   crun_output_handler output_handler;

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -75,4 +75,5 @@ int libcrun_container_setgroups (libcrun_container_t *container,
                                  libcrun_error_t *err);
 int libcrun_kill_linux (libcrun_container_status_t *status, int signal, libcrun_error_t *err);
 int libcrun_create_final_userns (libcrun_container_t *container, libcrun_error_t *err);
+int libcrun_create_kvm_device (libcrun_container_t *container, libcrun_error_t *err);
 #endif

--- a/src/run.c
+++ b/src/run.c
@@ -125,6 +125,8 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
   cleanup_free char *config_file_cleanup = NULL;
 
   crun_context.preserve_fds = 0;
+  /* Check if global handler is configured and pass it down to crun context */
+  crun_context.handler = global_args->handler;
 
   argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &crun_context);
   crun_assert_n_args (argc - first_arg, 1, 1);


### PR DESCRIPTION
[under-review] `kvm/krun`: crun should silently/gracefully switch to `krun` as backend runtime when invoked as `krun`