### PR TITLE
rpm: fix license

### DIFF
--- a/rpm/crun.spec.in
+++ b/rpm/crun.spec.in
@@ -3,7 +3,7 @@ Name: crun
 Version: @RPM_VERSION@
 Release: 1%{?dist}
 Source0: https://github.com/containers/crun/releases/download/%{version}/%{name}-@VERSION@.tar.gz
-License: GPLv3+
+License: GPLv2+
 URL: https://github.com/containers/crun
 
 # We always run autogen.sh


### PR DESCRIPTION
the license was changed tp GPL 2+ last year, adapt the rpm spec file.

Closes: https://github.com/containers/crun/issues/693

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>