### PR TITLE
Doc: cgroups v2 and RT processes unsupported

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -645,6 +645,11 @@ users on a system without newuidmap/newgidmap.
 
 .SH CGROUP v2
 .PP
+\fBNote\fP: cgroup v2 does not yet support control of realtime processes and
+the cpu controller can only be enabled when all RT processes are in the root
+cgroup. This will make crun fail while running alongside RT processes.
+
+.PP
 If the cgroup configuration found is for cgroup v1, crun attempts a
 conversion when running on a cgroup v2 system.
 

--- a/crun.1.md
+++ b/crun.1.md
@@ -513,6 +513,10 @@ users on a system without newuidmap/newgidmap.
 
 # CGROUP v2
 
+**Note**: cgroup v2 does not yet support control of realtime processes and
+the cpu controller can only be enabled when all RT processes are in the root
+cgroup. This will make crun fail while running alongside RT processes.
+
 If the cgroup configuration found is for cgroup v1, crun attempts a
 conversion when running on a cgroup v2 system.
 


### PR DESCRIPTION
As discussed in #704 crun is not happy when running alongside RT
Processes

This is documented on kernel: https://www.kernel.org/doc/Documentation/cgroup-v2.txt