### PR TITLE
Makefile.am: link libcrun to $(FOUND_LIBS)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ libocispec/libocispec.la:
 
 libcrun_la_SOURCES = $(libcrun_SOURCES)
 libcrun_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -fvisibility=hidden
-libcrun_la_LIBADD = libocispec/libocispec.la $(maybe_libyajl.la)
+libcrun_la_LIBADD = libocispec/libocispec.la $(FOUND_LIBS) $(maybe_libyajl.la)
 libcrun_la_LDFLAGS = -Wl,--version-script=$(abs_top_srcdir)/libcrun.lds
 
 # build a version with all the symbols visible for testing


### PR DESCRIPTION
otherwise libcrun consumers fail at runtime with
symbol lookup errors

Closes: https://github.com/containers/crun/issues/711
Issue: https://github.com/containers/crun/issues/340
Downstream-bug: https://bugs.gentoo.org/717750
Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>