### PR TITLE
container: Set primary process to 1 via `LISTEN_PID` by default if configuration is missing

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -120,6 +120,7 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
   cleanup_free char *config_file_cleanup = NULL;
 
   crun_context.preserve_fds = 0;
+  crun_context.listen_fds = 0;
   /* Check if global handler is configured and pass it down to crun context */
   crun_context.handler = global_args->handler;
 
@@ -167,7 +168,10 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
 
   crun_context.bundle = bundle;
   if (getenv ("LISTEN_FDS"))
-    crun_context.preserve_fds += strtoll (getenv ("LISTEN_FDS"), NULL, 10);
+    {
+      crun_context.listen_fds = strtoll (getenv ("LISTEN_FDS"), NULL, 10);
+      crun_context.preserve_fds += crun_context.listen_fds;
+    }
 
   return libcrun_container_create (&crun_context, container, 0, err);
 }

--- a/src/exec.c
+++ b/src/exec.c
@@ -229,6 +229,7 @@ crun_command_exec (struct crun_global_arguments *global_args, int argc, char **a
   };
 
   crun_context.preserve_fds = 0;
+  crun_context.listen_fds = 0;
 
   argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &exec_options);
   crun_assert_n_args (argc - first_arg, exec_options.process ? 1 : 2, -1);
@@ -243,7 +244,10 @@ crun_command_exec (struct crun_global_arguments *global_args, int argc, char **a
   crun_context.preserve_fds = exec_options.preserve_fds;
 
   if (getenv ("LISTEN_FDS"))
-    crun_context.preserve_fds += strtoll (getenv ("LISTEN_FDS"), NULL, 10);
+    {
+      crun_context.listen_fds = strtoll (getenv ("LISTEN_FDS"), NULL, 10);
+      crun_context.preserve_fds += crun_context.listen_fds;
+    }
 
   if (exec_options.process)
     return libcrun_container_exec_process_file (&crun_context, argv[first_arg], exec_options.process, err);

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1206,6 +1206,13 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket, int sync_s
         }
     }
 
+  // set primary process to 1 explicitly if nothing is configured and LISTEN_FD is not set
+  if (entrypoint_args->context->listen_fds > 0 && getenv ("LISTEN_PID") == NULL)
+    {
+      setenv ("LISTEN_PID", "1", 1);
+      libcrun_warning ("setting LISTEN_PID=1 since no previous configuration was found");
+    }
+
   if (def->process && def->process->cwd)
     if (UNLIKELY (chdir (def->process->cwd) < 0))
       return crun_make_error (err, errno, "chdir");

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -35,6 +35,9 @@ struct libcrun_context_s
   const char *notify_socket;
   const char *handler;
   int preserve_fds;
+  // For some use-cases we need differentiation between preserve_fds and listen_fds.
+  // Following context variable makes sure we get exact value of listen_fds irrespective of preserve_fds.
+  int listen_fds;
 
   crun_output_handler output_handler;
   void *output_handler_arg;

--- a/src/run.c
+++ b/src/run.c
@@ -125,6 +125,7 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
   cleanup_free char *config_file_cleanup = NULL;
 
   crun_context.preserve_fds = 0;
+  crun_context.listen_fds = 0;
   /* Check if global handler is configured and pass it down to crun context */
   crun_context.handler = global_args->handler;
 
@@ -171,7 +172,10 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
 
   crun_context.bundle = bundle;
   if (getenv ("LISTEN_FDS"))
-    crun_context.preserve_fds += strtoll (getenv ("LISTEN_FDS"), NULL, 10);
+    {
+      crun_context.listen_fds = strtoll (getenv ("LISTEN_FDS"), NULL, 10);
+      crun_context.preserve_fds += crun_context.listen_fds;
+    }
 
   return libcrun_container_run (&crun_context, container, 0, err);
 }

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -229,6 +229,22 @@ def test_empty_home():
         return -1
     return 0
 
+# Following test is for a special case where crun sets LISTEN_PID=1 when nothing is specified
+# to make sure that primary process is 1, this feature makes sure crun is in parity with runc.
+def test_listen_pid_env():
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'printenv', 'LISTEN_PID']
+    add_all_namespaces(conf)
+    env = dict(os.environ)
+    env["LISTEN_FDS"] = "1"
+    try:
+        out, cid = run_and_get_output(conf, env=env, command='run')
+        if "1" not in str(out):
+            return -1
+    except:
+        return -1
+    return 0
+
 all_tests = {
     "start" : test_start,
     "start-override-config" : test_start_override_config,
@@ -237,6 +253,7 @@ all_tests = {
     "sd-notify-file" : test_sd_notify_file,
     "sd-notify-env" : test_sd_notify_env,
     "sd-notify-proxy": test_sd_notify_proxy,
+    "listen_pid_env": test_listen_pid_env,
     "test-cwd-relative": test_cwd_relative,
     "test-cwd-relative-subdir": test_cwd_relative_subdir,
     "test-cwd-absolute": test_cwd_absolute,


### PR DESCRIPTION
Following PR adds a  default configuration of seting primary process to 1 via `LISTEN_PID`  if configuration is missing.
Following behavior is similar to runc.
