### PR TITLE
status: check for owner before using it

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2977,8 +2977,11 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
   yajl_gen_string (gen, YAJL_STR ("created"), strlen ("created"));
   yajl_gen_string (gen, YAJL_STR (status.created), strlen (status.created));
 
-  yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));
-  yajl_gen_string (gen, YAJL_STR (status.owner), strlen (status.owner));
+  if (status.owner)
+    {
+      yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));
+      yajl_gen_string (gen, YAJL_STR (status.owner), strlen (status.owner));
+    }
 
   {
     size_t i;

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -269,13 +269,16 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   if (UNLIKELY (r != yajl_gen_status_ok))
     goto yajl_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  if (status->owner)
+    {
+      r = yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));
+      if (UNLIKELY (r != yajl_gen_status_ok))
+        goto yajl_error;
 
-  r = yajl_gen_string (gen, YAJL_STR (status->owner), strlen (status->owner));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+      r = yajl_gen_string (gen, YAJL_STR (status->owner), strlen (status->owner));
+      if (UNLIKELY (r != yajl_gen_status_ok))
+        goto yajl_error;
+    }
 
   r = yajl_gen_string (gen, YAJL_STR ("detached"), strlen ("detached"));
   if (UNLIKELY (r != yajl_gen_status_ok))


### PR DESCRIPTION
check that the owner string is set before using it.

commit 60de7677f4ea9db37ce48964e995c2b0536af886 introduced the issue.

Closes: https://github.com/containers/crun/issues/718

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>