### PR TITLE
cgroup: use cgroup.kill if available

### DIFF
--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y golang python git gcc automake autoconf libcap-devel \
     go get github.com/onsi/gomega/... && \
     mkdir -p /root/go/src/github.com/containers && \
     chmod 755 /root && \
-    (cd /root/go/src/github.com/containers && git clone -b v3.0.0 https://github.com/containers/podman && \
+    (cd /root/go/src/github.com/containers && git clone -b v3.3.0 https://github.com/containers/podman && \
      cd podman && \
      make install.catatonit && \
      make)

--- a/tests/podman/run-tests.sh
+++ b/tests/podman/run-tests.sh
@@ -34,6 +34,6 @@ export TMPDIR=/var/tmp
 #   device-cgroup-rule|capabilities|network|overlay volume flag|prune removes a pod with a stopped container: not working on github actions
 
 
-ginkgo --focus='.*' --skip='.*(selinux|notify_socket|systemd|podman run exit 12*|podman run exit code on failure to exec|failed to start|search|trust|inspect|logs|generate|import|mounted rw|inherit host devices|play kube|cgroups=disabled|privileged CapEff|device-cgroup-rule|capabilities|network|pull from docker|--add-host|removes a pod with a container|prune removes a pod with a stopped container|overlay volume flag|prune unused images|podman images filter|image list filter|create --pull).*' \
+ginkgo --focus='.*' --skip='.*(selinux|notify_socket|systemd|podman run exit 12*|podman run exit code on failure to exec|failed to start|search|trust|inspect|logs|generate|import|mounted rw|inherit host devices|play kube|cgroups=disabled|privileged CapEff|device-cgroup-rule|capabilities|network|pull from docker|--add-host|removes a pod with a container|prune removes a pod with a stopped container|overlay volume flag|prune unused images|podman images filter|image list filter|create --pull|podman ps json format|using journald for container).*' \
 	 -v -tags "seccomp ostree selinux varlink exclude_graphdriver_devicemapper" \
 	 -timeout=50m -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.


### PR DESCRIPTION
Linux 5.14 supports the file "cgroup.kill" to kill all the processes
in a cgroup.  It avoids the cost of opening "cgroup.procs" and send
the kill signal to each process listed.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>