### PR TITLE
utils: retry openat2 on EAGAIN

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -348,7 +348,7 @@ safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *path,
 
   if (openat2_supported)
     {
-      ret = syscall_openat2 (dirfd, path, flags, mode, RESOLVE_IN_ROOT);
+      ret = TEMP_FAILURE_RETRY (syscall_openat2 (dirfd, path, flags, mode, RESOLVE_IN_ROOT));
       if (ret < 0)
         {
           if (errno == ENOSYS)


### PR DESCRIPTION
From the man page:

EAGAIN how.resolve contains either RESOLVE_IN_ROOT or RESOLVE_BENEATH,
and the kernel could not ensure that a ".." component didn't
escape (due to a race condition or potential attack).  The caller may
choose to retry the openat2() call.

Closes: https://github.com/containers/crun/issues/725

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>