### PR TITLE
runc exec: refuze paused container/cgroup

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -1867,15 +1867,20 @@ libcrun_cgroup_enter (struct libcrun_cgroup_args *args, libcrun_error_t *err)
 }
 
 int
-libcrun_cgroup_is_container_paused (const char *cgroup_path, int cgroup_mode, bool *paused, libcrun_error_t *err)
+libcrun_cgroup_is_container_paused (const char *cgroup_path, bool *paused, libcrun_error_t *err)
 {
   cleanup_free char *content = NULL;
   cleanup_free char *path = NULL;
   const char *state;
+  int cgroup_mode;
   int ret;
 
   if (cgroup_path == NULL || cgroup_path[0] == '\0')
     return 0;
+
+  cgroup_mode = libcrun_get_cgroup_mode (err);
+  if (UNLIKELY (cgroup_mode < 0))
+    return cgroup_mode;
 
   if (cgroup_mode == CGROUP_MODE_UNIFIED)
     {

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -65,8 +65,7 @@ LIBCRUN_PUBLIC int libcrun_move_process_to_cgroup (pid_t pid, pid_t init_pid, ch
 LIBCRUN_PUBLIC int libcrun_update_cgroup_resources (int cgroup_mode,
                                                     runtime_spec_schema_config_linux_resources *resources, char *path,
                                                     libcrun_error_t *err);
-LIBCRUN_PUBLIC int libcrun_cgroup_is_container_paused (const char *cgroup_path, int cgroup_mode, bool *paused,
-                                                       libcrun_error_t *err);
+LIBCRUN_PUBLIC int libcrun_cgroup_is_container_paused (const char *cgroup_path, bool *paused, libcrun_error_t *err);
 LIBCRUN_PUBLIC int libcrun_cgroup_pause_unpause (const char *path, const bool pause, libcrun_error_t *err);
 LIBCRUN_PUBLIC int libcrun_cgroup_read_pids (const char *path, bool recurse, pid_t **pids, libcrun_error_t *err);
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3045,6 +3045,7 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
                         libcrun_error_t *err)
 {
   int container_status, ret;
+  bool container_paused;
   pid_t pid;
   libcrun_container_status_t status = {};
   const char *state_root = context->state_root;
@@ -3087,6 +3088,13 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
 
   if (container_status == 0)
     return crun_make_error (err, 0, "the container `%s` is not running.", id);
+
+  ret = libcrun_cgroup_is_container_paused (status.cgroup_path, &container_paused, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  if (UNLIKELY (container_paused))
+    return crun_make_error (err, 0, "the container `%s` is paused.", id);
 
   ret = block_signals (err);
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2893,13 +2893,7 @@ libcrun_get_container_state_string (const char *id, libcrun_container_status_t *
 
   if (*running && ! has_fifo)
     {
-      int cgroup_mode;
-
-      cgroup_mode = libcrun_get_cgroup_mode (err);
-      if (UNLIKELY (cgroup_mode < 0))
-        return cgroup_mode;
-
-      ret = libcrun_cgroup_is_container_paused (status->cgroup_path, cgroup_mode, &paused, err);
+      ret = libcrun_cgroup_is_container_paused (status->cgroup_path, &paused, err);
       if (UNLIKELY (ret < 0))
         {
           /*


### PR DESCRIPTION
In case the container is paused, crun exec is stuck without
any diagnostics, and this is hard to debug by end user.
    
Add a check, and refuse to exec in a paused container/cgroup.

Before:
```console
# crun exec xx34 echo yes
^C^Z^C
```
(crun exec stuck, it's unclear what is going on, and there is nothing we can do from this terminal)

After:
```console
# crun exec xx34 echo yes
2021-09-01T18:20:30.000549846Z: the container `xx34` is paused.
```