### PR TITLE
criu: Add support for external PID namespace

### DIFF
--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -17,10 +17,7 @@
 
 import time
 import json
-import subprocess
 import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_cr1():

--- a/tests/test_cwd.py
+++ b/tests/test_cwd.py
@@ -15,12 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
-import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_cwd():

--- a/tests/test_detach.py
+++ b/tests/test_detach.py
@@ -15,12 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import json
-import subprocess
-import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_detach():

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -15,12 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
 import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_deny_devices():

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -15,12 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import json
-import subprocess
 import os
 import shutil
-import sys
 import tempfile
 from tests_utils import *
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -15,12 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
-import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_fail_prestart():

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -15,12 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
-import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_hostname():

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -15,12 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
-import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_limit_pid_0():

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -15,11 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
-import os
-import shutil
 import sys
 from tests_utils import *
 import tempfile

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -15,12 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
-import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_readonly_paths():

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -15,12 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
-import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_pid():

--- a/tests/test_pid_file.py
+++ b/tests/test_pid_file.py
@@ -15,12 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
 import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_pid_file():

--- a/tests/test_preserve_fds.py
+++ b/tests/test_preserve_fds.py
@@ -15,12 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
 import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_preserve_fds_0():

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -15,11 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
 import subprocess
-import os
-import shutil
 import sys
 from tests_utils import *
 

--- a/tests/test_rlimits.py
+++ b/tests/test_rlimits.py
@@ -15,11 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
-import os
-import shutil
 import sys
 from tests_utils import *
 

--- a/tests/test_seccomp.py
+++ b/tests/test_seccomp.py
@@ -15,12 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import json
 import subprocess
 import os
 import socket
-import shutil
 import sys
 import array
 from tests_utils import *

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -16,12 +16,9 @@
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import json
 import subprocess
 import os
 import os.path
-import shutil
-import sys
 import threading
 import socket
 from tests_utils import *

--- a/tests/test_tty.py
+++ b/tests/test_tty.py
@@ -15,12 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
 import os
-import shutil
-import sys
 from tests_utils import *
 
 def tty_helper(fd):

--- a/tests/test_uid_gid.py
+++ b/tests/test_uid_gid.py
@@ -15,12 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
 import os
-import shutil
-import sys
 from tests_utils import *
 
 def test_userns_full_mapping():

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -15,12 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import json
-import subprocess
 import os
 import shutil
-import sys
 from tests_utils import *
 
 def test_update():

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -21,7 +21,6 @@ import sys
 import os
 import tempfile
 import subprocess
-import time
 
 base_conf = """
 {

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -266,7 +266,6 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
         return subprocess.check_output(args, cwd=temp_dir, stderr=stderr, env=env, close_fds=False).decode(), id_container
 
 def run_crun_command(args):
-    cwd = os.getcwd()
     crun = get_crun_path()
     args = [crun] + args
     return subprocess.check_output(args, close_fds=False).decode()


### PR DESCRIPTION
When creating a checkpoint of a container with external PID namespace
crun fails with:

    Error (criu/namespaces.c:1081): Can't dump a pid namespace without the process init

This PR allows crun to set PID namespace as external  during checkpoint/restore when "path" has been specified in config.json.
This is similar to https://github.com/opencontainers/runc/pull/2525/commits/09e103b01e34a7dda321781ec7f05939c9fe4adb