### PR TITLE
criu: fix save of external descriptors

### DIFF
--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -292,9 +292,28 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   if (UNLIKELY (r != yajl_gen_status_ok))
     goto yajl_error;
 
-  r = yajl_gen_string (gen, YAJL_STR (status->external_descriptors), strlen (status->external_descriptors));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  {
+    const char *it = status->external_descriptors;
+
+    r = yajl_gen_array_open (gen);
+    if (UNLIKELY (r != yajl_gen_status_ok))
+      goto yajl_error;
+
+    while (*it)
+      {
+        size_t len = strlen (it);
+
+        r = yajl_gen_string (gen, (unsigned char *) it, len);
+        if (UNLIKELY (r != yajl_gen_status_ok))
+          goto yajl_error;
+
+        it += len + 1;
+      }
+
+    r = yajl_gen_array_close (gen);
+    if (UNLIKELY (r != yajl_gen_status_ok))
+      goto yajl_error;
+  }
 
   r = yajl_gen_map_close (gen);
   if (UNLIKELY (r != yajl_gen_status_ok))

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -21,6 +21,7 @@ import os
 import os.path
 import threading
 import socket
+import json
 from tests_utils import *
 
 def test_cwd_relative():
@@ -80,6 +81,15 @@ def test_start():
         out, _ = proc.communicate()
         if "hello" not in str(out):
             return -1
+
+        # verify that the external_descriptors are stored correctly
+        path = os.path.join(get_tests_root_status(), cid, "status")
+        with open(path) as f:
+            status = json.load(f)
+            descriptors = status["external_descriptors"]
+            if len(descriptors) <= 1:
+                print("invalid length for external_descriptors")
+                return -1
     finally:
         if cid is not None:
             run_crun_command(["delete", "-f", cid])

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -185,6 +185,9 @@ def run_all_tests(all_tests, allowed_tests):
 def get_tests_root():
     return '%s/.testsuite-run-%d' % (os.getcwd(), os.getpid())
 
+def get_tests_root_status():
+    return os.path.join(get_tests_root(), "root")
+
 def get_crun_path():
     cwd = os.getcwd()
     return os.getenv("OCI_RUNTIME") or os.path.join(cwd, "crun")
@@ -243,7 +246,8 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
     pid_file_arg = ['--pid-file', pid_file] if pid_file else []
     relative_config_path = ['--config', relative_config_path] if relative_config_path else []
 
-    args = [crun, command] + relative_config_path + preserve_fds_arg + detach_arg + pid_file_arg + [id_container]
+    root = get_tests_root_status()
+    args = [crun, "--root", root, command] + relative_config_path + preserve_fds_arg + detach_arg + pid_file_arg + [id_container]
 
     stderr = subprocess.STDOUT
     if hide_stderr:
@@ -266,8 +270,9 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
         return subprocess.check_output(args, cwd=temp_dir, stderr=stderr, env=env, close_fds=False).decode(), id_container
 
 def run_crun_command(args):
+    root = get_tests_root_status()
     crun = get_crun_path()
-    args = [crun] + args
+    args = [crun, "--root", root] + args
     return subprocess.check_output(args, close_fds=False).decode()
 
 def tests_main(all_tests):


### PR DESCRIPTION
fix how external_descriptors are stored in the status file.  They were
previously stored as a string,e.g.:

"external_descriptors":"[\"/dev/null\",\"pipe:[5716690]\",\"pipe:[5716691]\"]"

and breaking the JSON parser.

Closes: https://github.com/containers/crun/issues/734

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>