### PR TITLE
linux: fix fix-test-mount-symlink-not-existing test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,17 +95,18 @@ jobs:
                 make
             ;;
             check)
-                ./configure --disable-dl CFLAGS='-fsanitize=address -fsanitize=undefined -fsanitize=null -fsanitize=return -fsanitize=bounds -fsanitize=bool  -fsanitize=enum -fsanitize=builtin'
+                ./configure --disable-dl
                 make
                 make syntax-check
                 echo run tests as root
-                sudo make check ASAN_OPTIONS=detect_leaks=false || cat test-suite.log
-                echo run tests as rootless
-                mkdir /tmp/runroot && make check XDG_RUNTIME_DIR=/tmp/runroot ASAN_OPTIONS=detect_leaks=false || cat test-suite.log
-                echo run tests as rootless in a user namespace
-                mkdir /tmp/runroot && unshare -r make check XDG_RUNTIME_DIR=/tmp/runroot ASAN_OPTIONS=detect_leaks=false || cat test-suite.log
                 # check that the working dir is clean
                 git describe --broken --dirty --all | grep -qv dirty
+
+                sudo make check ASAN_OPTIONS=detect_leaks=false || cat test-suite.log
+                echo run tests as rootless
+                make check ASAN_OPTIONS=detect_leaks=false || (cat test-suite.log; exit 1)
+                echo run tests as rootless in a user namespace
+                unshare -r make check ASAN_OPTIONS=detect_leaks=false || (cat test-suite.log; exit 1)
             ;;
             podman)
                 sudo docker build -t crun-podman tests/podman

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -126,18 +126,28 @@ def test_some_caps_permitted():
     return helper_test_some_caps(0, ["permitted"], 'CapPrm')
 
 def test_some_caps_effective_non_root():
+    if is_rootless():
+        return 77
     return helper_test_some_caps(1000, ["effective", "permitted", "inheritable", "ambient"], 'CapEff')
 
 def test_some_caps_bounding_non_root():
+    if is_rootless():
+        return 77
     return helper_test_some_caps(1000, ["bounding"], 'CapBnd')
 
 def test_some_caps_inheritable_non_root():
+    if is_rootless():
+        return 77
     return helper_test_some_caps(1000, ["inheritable"], 'CapInh')
 
 def test_some_caps_ambient_non_root():
+    if is_rootless():
+        return 77
     return helper_test_some_caps(1000, ["ambient", "permitted", "inheritable"], 'CapAmb')
 
 def test_some_caps_permitted_non_root():
+    if is_rootless():
+        return 77
     return helper_test_some_caps(1000, ["ambient", "permitted", "inheritable"], 'CapPrm')
 
 

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -62,6 +62,8 @@ def test_exec_detach_not_exists():
     return test_exec_not_exists_helper(False)
 
 def test_exec_additional_gids():
+    if is_rootless():
+        return 77
     conf = base_config()
     conf['process']['args'] = ['/init', 'pause']
     add_all_namespaces(conf)

--- a/tests/tests_libcrun_utils.c
+++ b/tests/tests_libcrun_utils.c
@@ -387,7 +387,11 @@ int
 main ()
 {
   int id = 1;
+#ifdef HAVE_SYSTEMD
+  printf ("1..8\n");
+#else
   printf ("1..7\n");
+#endif
   RUN_TEST (test_crun_path_exists);
   RUN_TEST (test_write_read_file);
   RUN_TEST (test_run_process);


### PR DESCRIPTION
commit ee3531124a134df9cb92679001c599f9d0979749 introduced the regression.  It also caused the e2e CRI-O tests to fail.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
