### PR TITLE
wasm: adds support to natively build and run wasm workload and wasm containers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,15 @@ AS_IF([test "x$enable_dl" != "xno"], [
         AC_SEARCH_LIBS([dlopen], [dl], [AC_DEFINE([HAVE_DLOPEN], 1, [Define if DLOPEN is available])], [])
 ])
 
+dnl include support for wasmer (EXPERIMENTAL)
+AC_ARG_WITH([wasmer], AS_HELP_STRING([--with-wasmer], [build with wasmer support]))
+AS_IF([test "x$with_wasmer" = "xyes"], [
+	AC_CHECK_HEADERS([wasmer.h], [], [AC_MSG_ERROR([*** Missing wasmer headers])])
+	AS_IF([test "$ac_cv_header_wasmer_h" = "yes"], [
+		AC_SEARCH_LIBS(wasm_engine_new, [wasmer], [AC_DEFINE([HAVE_WASMER], 1, [Define if wasmer is available])], [AC_MSG_ERROR([*** Missing wasmer headers])])
+	])
+])
+
 dnl include support for libkrun (EXPERIMENTAL)
 AC_ARG_WITH([libkrun], AS_HELP_STRING([--with-libkrun], [build with libkrun support]))
 AS_IF([test "x$with_libkrun" = "xyes"], AC_CHECK_HEADERS([libkrun.h], AC_DEFINE([HAVE_LIBKRUN], 1, [Define if libkrun is available]), [AC_MSG_ERROR([*** Missing libkrun headers])]))


### PR DESCRIPTION
Following PR initiates and adds support for crun to be able to build and
run wasm workload in a native manner. With recent development in wasm and
amalgation of OCI, crun should be able to build and run wasm workload in
an isolated environment.

Ref:
https://github.com/engineerd/wasm-to-oci
https://www.solo.io/blog/announcing-the-webassembly-wasm-oci-image-spec/