### PR TITLE
artifacts: add libprotobuf-c-dev for protobuf headers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - run: sudo apt-get update
 
-      - run: sudo apt-get install -y make git gcc build-essential pkgconf libtool libsystemd-dev libcap-dev libseccomp-dev libyajl-dev go-md2man libtool autoconf python3 automake
+      - run: sudo apt-get install -y make git gcc build-essential pkgconf libtool libsystemd-dev libcap-dev libseccomp-dev libyajl-dev go-md2man libtool autoconf python3 automake libprotobuf-c-dev
 
       - run: |
           set -ex

--- a/tests/clang-check/Dockerfile
+++ b/tests/clang-check/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 
-RUN yum install -y make clang-tools-extra clang python3-pip 'dnf-command(builddep)' && \
+RUN yum install -y protobuf-c protobuf-c-devel make clang-tools-extra clang python3-pip 'dnf-command(builddep)' && \
         dnf builddep -y crun && pip install scan-build
 
 COPY run-tests.sh /usr/local/bin


### PR DESCRIPTION
Following commit fixes regression for artifacts.
Add libprotobuf-c-dev to dependencies.
