### PR TITLE
exec: fix containers being wrongly reported as paused

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3045,7 +3045,7 @@ libcrun_container_exec (libcrun_context_t *context, const char *id, runtime_spec
                         libcrun_error_t *err)
 {
   int container_status, ret;
-  bool container_paused;
+  bool container_paused = false;
   pid_t pid;
   libcrun_container_status_t status = {};
   const char *state_root = context->state_root;


### PR DESCRIPTION
Fixes #746.

container_paused was uninitialized which resulted in containers being
wrongly reported as paused when libcrun_cgroup_is_container_paused was
called with a NULL or empty cgroup_path.