### PR TITLE
test: bump base to `focal` / go to `1.16` / containerd to `v1.5.7` for containerd tests

### DIFF
--- a/tests/containerd/Dockerfile
+++ b/tests/containerd/Dockerfile
@@ -1,23 +1,23 @@
-FROM ubuntu:groovy
+FROM ubuntu:focal
 
 ENV GOPATH=/root/go
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/go/bin
 
 RUN apt-get update \
     && apt-get -y upgrade \
-    && apt-get install -y bash golang-1.13 libbtrfs-dev libnl-3-dev libnet1-dev \
+    && apt-get install -y bash golang-1.16 libbtrfs-dev libnl-3-dev libnet1-dev \
             protobuf-c-compiler libcap-dev libaio-dev \
             curl libprotobuf-c-dev libprotobuf-dev socat libseccomp-dev \
             pigz lsof make git gcc build-essential pkgconf libtool \
             libsystemd-dev libcap-dev libyajl-dev \
             go-md2man libtool autoconf python3 automake sudo \
-    && update-alternatives --install /usr/bin/go go /usr/lib/go-1.13/bin/go 0 \
+    && update-alternatives --install /usr/bin/go go /usr/lib/go-1.16/bin/go 0 \
     && mkdir -p /root/go/src/github.com/containerd \
     && chmod 755 /root \
     && (cd /root/go/src/github.com/containerd \
         && git clone https://github.com/containerd/containerd \
         && cd containerd \
-        && git reset --hard v1.4.9 \
+        && git reset --hard v1.5.7 \
         && make \
         && make binaries \
         && make install \


### PR DESCRIPTION
It seems something got back-ported to CNI plugins which is using native functions introduced from go 1.16 onwards.

Fixes flakes seen in
* https://github.com/containers/crun/pull/752
* https://github.com/containers/crun/pull/742

