### PR TITLE
criu: save the new descriptors after restore

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2700,8 +2700,8 @@ libcrun_get_external_descriptors (libcrun_container_t *container)
   return get_private_data (container)->external_descriptors;
 }
 
-static int
-save_external_descriptors (libcrun_container_t *container, pid_t pid, libcrun_error_t *err)
+int
+libcrun_save_external_descriptors (libcrun_container_t *container, pid_t pid, libcrun_error_t *err)
 {
   const unsigned char *buf = NULL;
   yajl_gen gen = NULL;
@@ -3458,7 +3458,7 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
     {
       cleanup_pid pid_t pid_to_clean = pid;
 
-      ret = save_external_descriptors (container, pid, err);
+      ret = libcrun_save_external_descriptors (container, pid, err);
       if (UNLIKELY (ret < 0))
         return ret;
 

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -76,4 +76,5 @@ int libcrun_container_setgroups (libcrun_container_t *container,
 int libcrun_kill_linux (libcrun_container_status_t *status, int signal, libcrun_error_t *err);
 int libcrun_create_final_userns (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_create_kvm_device (libcrun_container_t *container, libcrun_error_t *err);
+int libcrun_save_external_descriptors (libcrun_container_t *container, pid_t pid, libcrun_error_t *err);
 #endif


### PR DESCRIPTION
after a restore, save the new descriptors instead of re-using the old
ones.

Closes: https://github.com/containers/crun/issues/756

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>