### PR TITLE
oci-validation: checkout last working commit for runtime-tools

### DIFF
--- a/tests/oci-validation/oci-runtime-validation
+++ b/tests/oci-validation/oci-runtime-validation
@@ -20,6 +20,8 @@ export TMPDIR=/var/tmp
 export XDG_RUNTIME_DIR=/run
 
 cd $GOPATH/src/github.com/opencontainers/runtime-tools
+# TODO: remove this `git magic` once runtime-tools is fixed in upstream
+git reset --hard 98b2d351ae7dd64da7cf6c89cb3f22497863513d
 make -j $(nproc)
 
 # Skip:


### PR DESCRIPTION
Upstream opencontainers/runtime-tools have a ongoing open issues
check more details here

* https://github.com/containers/crun/pull/760
* https://github.com/opencontainers/runtime-tools/pull/735

Revert when https://github.com/opencontainers/runtime-tools/pull/735 or
equivalent is merged.
