### PR TITLE
fix status.h compile error in C++

### DIFF
--- a/src/libcrun/status.h
+++ b/src/libcrun/status.h
@@ -68,7 +68,7 @@ int libcrun_check_pid_valid (libcrun_container_status_t *status, libcrun_error_t
 static inline void
 libcrun_free_container_listp (void *p)
 {
-  libcrun_container_list_t **l = p;
+  libcrun_container_list_t **l = (libcrun_container_list_t **) p;
   if (*l != NULL)
     libcrun_free_containers_list (*l);
 }


### PR DESCRIPTION
add explicit type conversion to fix C++ build error `libcrun_container_list_t **l = p;` 
"invalid conversion from ‘void*’ to ‘libcrun_container_list_t**’ {aka ‘libcrun_container_list_s**’} [-fpermissive]"