### PR TITLE
wasm: allow wasi modules to read args from config

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -252,8 +252,8 @@ write_controller_file (const char *path, int controllers_to_enable, libcrun_erro
       crun_error_release (err);
 
       /* It seems the kernel can return EBUSY when a process was moved to a sub-cgroup
-	 and the controllers are enabled in its parent cgroup.  Retry a few times when
-	 it happens.  */
+         and the controllers are enabled in its parent cgroup.  Retry a few times when
+         it happens.  */
       for (attempts_left = 1000; attempts_left >= 0; attempts_left--)
         {
           int controllers_written;

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -2183,3 +2183,29 @@ has_suffix (const char *str, const char *suffix)
     return 0;
   return memcmp (str + lenstr - lensuffix, suffix, lensuffix) == 0;
 }
+
+char *
+str_join_array (int offset, size_t size, char *const array[], const char *joint)
+{
+  size_t jlen, lens[size];
+  size_t i, total_size = (size - 1) * (jlen = strlen (joint)) + 1;
+  char *result, *p;
+
+  for (i = 0; i < size; ++i)
+    {
+      total_size += (lens[i] = strlen (array[i]));
+    }
+  p = result = xmalloc (total_size);
+  for (i = offset; i < size; ++i)
+    {
+      memcpy (p, array[i], lens[i]);
+      p += lens[i];
+      if (i < size - 1)
+        {
+          memcpy (p, joint, jlen);
+          p += jlen;
+        }
+    }
+  *p = '\0';
+  return result;
+}

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -281,5 +281,6 @@ LIBCRUN_PUBLIC int libcrun_str2sig (const char *name);
 
 int base64_decode (const char *iptr, size_t isize, char *optr, size_t osize, size_t *nbytes);
 int has_suffix (const char *source, const char *suffix);
+char *str_join_array (int offset, size_t size, char *const array[], const char *joint);
 
 #endif

--- a/tests/clang-check/Dockerfile
+++ b/tests/clang-check/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:34
 
 RUN yum install -y protobuf-c protobuf-c-devel make clang-tools-extra clang python3-pip 'dnf-command(builddep)' && \
         dnf builddep -y crun && pip install scan-build

--- a/tests/clang-format/Dockerfile
+++ b/tests/clang-format/Dockerfile
@@ -1,3 +1,3 @@
-FROM fedora:latest
+FROM fedora:34
 
 RUN yum install -y make clang-tools-extra 'dnf-command(builddep)' && dnf builddep -y crun

--- a/tests/fuzzing/Dockerfile
+++ b/tests/fuzzing/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:34
 
 RUN yum install -y golang python git automake autoconf libcap-devel \
     systemd-devel yajl-devel libseccomp-devel go-md2man \

--- a/tests/oci-validation/Dockerfile
+++ b/tests/oci-validation/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora
+FROM fedora:34
 
 ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin

--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:34
 
 ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin


### PR DESCRIPTION
move #768 forward and fix CI

Wasm modules must accept and process if any arguments are specified in OCI spec.

Example OCI spec could contain args as
```json
...
"args": {
 "./module.wasm",
 "arg1",
 "arg2"
},
...