### PR TITLE
Fix build error on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ export PATH=$PATH:$GOPATH/bin
 
 ```console
 $ sudo apt-get install -y make git gcc build-essential pkgconf libtool \
-   libsystemd-dev libcap-dev libseccomp-dev libyajl-dev \
+   libsystemd-dev libprotobuf-c-dev libcap-dev libseccomp-dev libyajl-dev \
    go-md2man libtool autoconf python3 automake
 ```
 


### PR DESCRIPTION
When compile on ubuntu, I met this error: 

```
In file included from /usr/include/criu/criu.h:25,
                 from src/libcrun/criu.c:26:
/usr/include/criu/rpc.pb-c.h:7:10: fatal error: protobuf-c/protobuf-c.h: No such file or directory
    7 | #include <protobuf-c/protobuf-c.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Add `libprotobuf-c-dev` as dependency will solve it. 
I didn't tested other OS, I guess we have similar issue.