### PR TITLE
crun: show if version is packaged and supports `wasm` with configured runtime.

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -207,6 +207,11 @@ print_version (FILE *stream, struct argp_state *state arg_unused)
 #ifdef HAVE_CRIU
   fprintf (stream, "+CRIU ");
 #endif
+#ifdef HAVE_WASMER
+  fprintf (stream, "+WASM:wasmer ");
+#elif defined HAVE_WASMEDGE
+  fprintf (stream, "+WASM:wasmedge ");
+#endif
 #ifdef HAVE_LIBKRUN
   fprintf (stream, "+LIBKRUN ");
 #endif

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1048,7 +1048,7 @@ wasmedge_do_exec (void *container, void *handle, const char *pathname, char *con
     {
       WasmEdge_VMDelete (vm);
       WasmEdge_ConfigureDelete (configure);
-      error (EXIT_FAILURE, 0, "could not set krun executable");
+      error (EXIT_FAILURE, 0, "could not get wasmedge result from VM");
     }
 
   WasmEdge_VMDelete (vm);


### PR DESCRIPTION
* End **users** and **container managers** should be able to check if their crun
is packaged with `wasm` support and which `wasm` runtime is it using.

```console
$ crun --version
crun version 1.3.12-e58e-dirty
commit: e58ec44d60c98eff1fd79727b4a2d81dbbf3ee35
spec: 1.0.0
+SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +WASM:wasmer +YAJL
```

* wasmedge: fix error message when fails to get valid result object from VM.