### PR TITLE
Add file-locks checkpoint/restore option

### DIFF
--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -39,7 +39,8 @@ enum
   OPTION_LEAVE_RUNNING,
   OPTION_TCP_ESTABLISHED,
   OPTION_SHELL_JOB,
-  OPTION_EXT_UNIX_SK
+  OPTION_EXT_UNIX_SK,
+  OPTION_FILE_LOCKS,
 };
 
 static char doc[] = "OCI runtime";
@@ -53,6 +54,7 @@ static struct argp_option options[]
         { "tcp-established", OPTION_TCP_ESTABLISHED, 0, 0, "allow open tcp connections", 0 },
         { "ext-unix-sk", OPTION_EXT_UNIX_SK, 0, 0, "allow external unix sockets", 0 },
         { "shell-job", OPTION_SHELL_JOB, 0, 0, "allow shell jobs", 0 },
+        { "file-locks", OPTION_FILE_LOCKS, 0, 0, "allow file locks", 0 },
         {
             0,
         } };
@@ -89,6 +91,10 @@ parse_opt (int key, char *arg arg_unused, struct argp_state *state arg_unused)
 
     case OPTION_SHELL_JOB:
       cr_options.shell_job = true;
+      break;
+
+    case OPTION_FILE_LOCKS:
+      cr_options.file_locks = true;
       break;
 
     default:

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -93,6 +93,7 @@ struct libcrun_checkpoint_restore_s
   bool shell_job;
   bool ext_unix_sk;
   bool detach;
+  bool file_locks;
   const char *console_socket;
 };
 typedef struct libcrun_checkpoint_restore_s libcrun_checkpoint_restore_t;

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -408,6 +408,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   criu_set_ext_unix_sk (cr_options->ext_unix_sk);
   criu_set_shell_job (cr_options->shell_job);
   criu_set_tcp_established (cr_options->tcp_established);
+  criu_set_file_locks (cr_options->file_locks);
   criu_set_orphan_pts_master (true);
   criu_set_manage_cgroups (true);
 
@@ -725,6 +726,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
   criu_set_ext_unix_sk (cr_options->ext_unix_sk);
   criu_set_shell_job (cr_options->shell_job);
   criu_set_tcp_established (cr_options->tcp_established);
+  criu_set_file_locks (cr_options->file_locks);
   criu_set_orphan_pts_master (true);
   criu_set_manage_cgroups (true);
 

--- a/src/restore.c
+++ b/src/restore.c
@@ -41,6 +41,7 @@ enum
   OPTION_EXT_UNIX_SK,
   OPTION_PID_FILE,
   OPTION_CONSOLE_SOCKET,
+  OPTION_FILE_LOCKS,
 };
 
 static char doc[] = "OCI runtime";
@@ -62,6 +63,7 @@ static struct argp_option options[]
         { "pid-file", OPTION_PID_FILE, "FILE", 0, "where to write the PID of the container", 0 },
         { "console-socket", OPTION_CONSOLE_SOCKET, "SOCKET", 0,
           "path to a socket that will receive the master end of the tty", 0 },
+        { "file-locks", OPTION_FILE_LOCKS, 0, 0, "allow file locks", 0 },
         {
             0,
         } };
@@ -98,6 +100,10 @@ parse_opt (int key, char *arg arg_unused, struct argp_state *state arg_unused)
 
     case OPTION_SHELL_JOB:
       cr_options.shell_job = true;
+      break;
+
+    case OPTION_FILE_LOCKS:
+      cr_options.file_locks = true;
       break;
 
     case 'd':


### PR DESCRIPTION
CRIU supports checkpoint/restore of file locks. However, it requires this feature to be explicitly enabled with the file-locks option.

The file-locks option has been introduced in runc with https://github.com/opencontainers/runc/pull/55

This option is required to checkpoint/restore application containers such as MySQL.