### PR TITLE
Change podman branch to fix CI

### DIFF
--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y golang python git gcc automake autoconf libcap-devel \
     go get github.com/onsi/gomega/... && \
     mkdir -p /root/go/src/github.com/containers && \
     chmod 755 /root && \
-    (cd /root/go/src/github.com/containers && git clone -b v3.4.2 https://github.com/containers/podman && \
+    (cd /root/go/src/github.com/containers && git clone -b main https://github.com/containers/podman && \
      cd podman && \
      make install.catatonit && \
      make)


### PR DESCRIPTION
Use podman main branch, which has a fix(containers/podman/pull/12343) to use fedora
34 image.

Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>