### PR TITLE
utils: write_file truncates existing files

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -111,7 +111,7 @@ xasprintf (char **str, const char *fmt, ...)
 int
 write_file_at (int dirfd, const char *name, const void *data, size_t len, libcrun_error_t *err)
 {
-  cleanup_close int fd = openat (dirfd, name, O_WRONLY | O_CREAT, 0700);
+  cleanup_close int fd = openat (dirfd, name, O_WRONLY | O_CREAT | O_TRUNC, 0700);
   int ret = 0;
   if (UNLIKELY (fd < 0))
     return crun_make_error (err, errno, "opening file `%s` for writing", name);
@@ -144,7 +144,7 @@ write_file_with_flags (const char *name, int flags, const void *data, size_t len
 int
 write_file (const char *name, const void *data, size_t len, libcrun_error_t *err)
 {
-  return write_file_with_flags (name, O_CREAT, data, len, err);
+  return write_file_with_flags (name, O_CREAT | O_TRUNC, data, len, err);
 }
 
 int


### PR DESCRIPTION
when opening the descriptors.json file, truncate the file if it is
already existing.

Closes: https://github.com/containers/crun/issues/787

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>