### PR TITLE
linux: use sd_notify_barrier if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,7 @@ AS_IF([test "x$enable_systemd" != "xno"], [
 	AC_CHECK_HEADERS([systemd/sd-bus.h], [], [AC_MSG_ERROR([*** Missing libsystemd headers])])
 	AS_IF([test "$ac_cv_header_systemd_sd_bus_h" = "yes"], [
 		AC_SEARCH_LIBS(sd_bus_match_signal_async, [systemd], [AC_DEFINE([HAVE_SYSTEMD], 1, [Define if libsystemd is available])], [AC_MSG_ERROR([*** Failed to find libsystemd])])
+		AC_CHECK_FUNCS(sd_notify_barrier)
 	])
 ])
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2185,6 +2185,11 @@ handle_notify_socket (int notify_socketfd, libcrun_error_t *err)
       if (UNLIKELY (ret < 0))
         return crun_make_error (err, -ret, "sd_notify");
 
+#  if HAVE_SD_NOTIFY_BARRIER
+      /* Hard-code a 30 seconds timeout.  Ignore errors.  */
+      sd_notify_barrier (0, 30 * 1000000);
+#  endif
+
       return 1;
     }
   return 0;


### PR DESCRIPTION
If the sd_notify_barrier function is available, use it to synchronize
systemd notify notifications and make sure they were processed by
systemd.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>