### PR TITLE
linux: improve detection of /dev target

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1576,7 +1576,7 @@ do_mounts (libcrun_container_t *container, int rootfsfd, const char *rootfs, con
 
       if (flags & MS_BIND)
         {
-          if (strcmp (def->mounts[i]->destination, "/dev") == 0)
+          if (path_is_slash_dev (def->mounts[i]->destination))
             get_private_data (container)->mount_dev_from_host = true;
           /* It is used only for error messages.  */
           type = "bind";

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -205,6 +205,24 @@ consume_slashes (const char *t)
   return t;
 }
 
+static inline bool
+path_is_slash_dev (const char *path)
+{
+  path = consume_slashes (path);
+
+  if (strncmp (path, "dev", 3))
+    return false;
+
+  path += 3;
+
+  /* Check there are only '/' left.  */
+  for (; *path; path++)
+    if (*path != '/')
+      return false;
+
+  return true;
+}
+
 int xasprintf (char **str, const char *fmt, ...);
 
 int crun_path_exists (const char *path, libcrun_error_t *err);

--- a/tests/tests_libcrun_utils.c
+++ b/tests/tests_libcrun_utils.c
@@ -249,6 +249,36 @@ test_crun_path_exists ()
 }
 
 static int
+test_path_is_slash_dev ()
+{
+  if (! path_is_slash_dev ("/dev"))
+    return -1;
+  if (! path_is_slash_dev ("/dev//"))
+    return -1;
+  if (! path_is_slash_dev ("///dev///"))
+    return -1;
+  if (! path_is_slash_dev ("/dev/"))
+    return -1;
+  if (! path_is_slash_dev ("dev"))
+    return -1;
+  if (! path_is_slash_dev ("dev////"))
+    return -1;
+  if (path_is_slash_dev ("dev////foo"))
+    return -1;
+  if (path_is_slash_dev ("/dev/foo"))
+    return -1;
+  if (path_is_slash_dev ("/dev/foo/"))
+    return -1;
+  if (path_is_slash_dev ("/dev/foo/bar"))
+    return -1;
+  if (path_is_slash_dev ("///dev/foo//bar"))
+    return -1;
+  if (path_is_slash_dev ("///dev/foo/////"))
+    return -1;
+  return 0;
+}
+
+static int
 test_append_paths ()
 {
 #define PROLOGUE()               \
@@ -392,9 +422,9 @@ main ()
 {
   int id = 1;
 #ifdef HAVE_SYSTEMD
-  printf ("1..8\n");
+  printf ("1..9\n");
 #else
-  printf ("1..7\n");
+  printf ("1..8\n");
 #endif
   RUN_TEST (test_crun_path_exists);
   RUN_TEST (test_write_read_file);
@@ -403,6 +433,7 @@ main ()
   RUN_TEST (test_socket_pair);
   RUN_TEST (test_send_receive_fd);
   RUN_TEST (test_append_paths);
+  RUN_TEST (test_path_is_slash_dev);
 #ifdef HAVE_SYSTEMD
   RUN_TEST (test_parse_sd_array);
 #endif


### PR DESCRIPTION
improve the detection of /dev being used as a target.

There is already a check for "/dev" being used as a target, but it
fails when the bind mount is specified e.g., like "/dev/".

Improve its detection to accept any path like /*dev/*.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2021203

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>