### PR TITLE
CI: correctly check for the fuzzing tests result

### DIFF
--- a/src/libcrun/ebpf.c
+++ b/src/libcrun/ebpf.c
@@ -159,6 +159,9 @@ bpf_program_append_dev (struct bpf_program *program, const char *access, char ty
     BPF_EXIT_INSN (),
   };
 
+  if (access == NULL)
+    access = "";
+
   if (program->private & HAS_WILDCARD)
     return program;
 

--- a/tests/fuzzing/run-tests.sh
+++ b/tests/fuzzing/run-tests.sh
@@ -26,7 +26,9 @@ function run_test {
     export FUZZING_MODE=$1
     TEST_CASES=$2
 
-    honggfuzz --exit_upon_crash $VERBOSITY --run_time $SINGLE_RUN_TIME --timeout $TIMEOUT -T -i $TEST_CASES -- tests/tests_libcrun_fuzzer 2>&1 | tail -n 2
+    result=$(honggfuzz --exit_upon_crash $VERBOSITY --run_time $SINGLE_RUN_TIME --timeout $TIMEOUT -T -i $TEST_CASES -- tests/tests_libcrun_fuzzer 2>&1 | tail -n 2)
+    echo $result
+    echo $result | (grep -q crashes_count:0 || exit 1)
 }
 
 run_test 0 $CORPUS/config-json


### PR DESCRIPTION
and fix a potential crash when the access string is not provided.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>