### PR TITLE
handler: add support for running handlers on `kubernetes` with `containerd`

### DIFF
--- a/src/libcrun/custom-handler.c
+++ b/src/libcrun/custom-handler.c
@@ -248,6 +248,14 @@ libcrun_configure_handler (struct custom_handler_manager_s *manager,
   *out = NULL;
   *cookie = NULL;
 
+  // Kubernetes sandbox containers must be executed as regular process
+  // Example sandbox container can contain pause process
+  // See: https://github.com/containers/crun/issues/798
+  // before invoking handler check if this is not a kubernetes sandbox
+  annotation = find_annotation (container, "io.kubernetes.cri.container-type");
+  if (annotation && (strcmp (annotation, "sandbox") == 0))
+    return 0;
+
   annotation = find_annotation (container, "run.oci.handler");
 
   /* Fail with EACCESS if global handler is already configured and there was a attempt to override it via spec.  */


### PR DESCRIPTION
Some shims and manager like **containerd** on kubernetes still expect process image to be changed
with given executable in spec and invoked by `shim` hence perform a blank `execv` to change process
image and ignore the output since we only want to care about `exec_func`
See: https://github.com/containers/crun/issues/798

If process image is not changed containerd would fail as `Error: sandbox
container idxxxxxxx is not running`

-----
Everything above can be ignored. New fix is

We need to treat `pause` containers as regular containers spawned by containerd.