### PR TITLE
wasmedge: The wasmedge.h is moved to wasmedge/wasmedge.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ AS_IF([test "x$with_wasmer" = "xyes"], AC_CHECK_HEADERS([wasmer.h], AC_DEFINE([H
 
 dnl include support for wasmedge (EXPERIMENTAL)
 AC_ARG_WITH([wasmedge], AS_HELP_STRING([--with-wasmedge], [build with WasmEdge support]))
-AS_IF([test "x$with_wasmedge" = "xyes"], AC_CHECK_HEADERS([wasmedge.h], AC_DEFINE([HAVE_WASMEDGE], 1, [Define if WasmEdge is available]), [AC_MSG_ERROR([*** Missing wasmedge headers])]))
+AS_IF([test "x$with_wasmedge" = "xyes"], AC_CHECK_HEADERS([wasmedge/wasmedge.h], AC_DEFINE([HAVE_WASMEDGE], 1, [Define if WasmEdge is available]), [AC_MSG_ERROR([*** Missing wasmedge headers])]))
 
 dnl include support for libkrun (EXPERIMENTAL)
 AC_ARG_WITH([libkrun], AS_HELP_STRING([--with-libkrun], [build with libkrun support]))

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -55,7 +55,7 @@
 #  include <wasmer.h>
 #endif
 #ifdef HAVE_WASMEDGE
-#  include <wasmedge.h>
+#  include <wasmedge/wasmedge.h>
 #endif
 
 #ifdef HAVE_SYSTEMD


### PR DESCRIPTION
Because WasmEdge has more headers after 0.9.0 release,
the origin header wasmedge.h is moved to wasmedge folder.

Signed-off-by: hydai <hydai@secondstate.io>