### PR TITLE
pre-dump support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,12 +133,20 @@ AC_ARG_ENABLE([criu], AS_HELP_STRING([--disable-criu], [Disable CRIU based check
 AS_IF([test "x$enable_criu" != "xno"], [
 	PKG_CHECK_MODULES([CRIU], [criu >= 3.15], [have_criu="yes"], [have_criu="no"
 		AC_MSG_NOTICE([CRIU headers not found, building without CRIU support])])
-	PKG_CHECK_MODULES([CRIU], [criu > 3.16], [have_criu_join_ns="yes"], [have_criu_join_ns="no"
-		AC_MSG_NOTICE([CRIU version doesn't support join-ns API])])
-		AS_IF([test "$have_criu" = "yes"], [
-			AC_DEFINE([HAVE_CRIU], 1, [Define if CRIU is available])
-			AC_SEARCH_LIBS(criu_init_opts, [criu])
-		])
+	PKG_CHECK_MODULES([CRIU_JOIN_NS], [criu > 3.16], [have_criu_join_ns="yes"], [have_criu_join_ns="no"
+	        AC_MSG_NOTICE([CRIU version doesn't support join-ns API])])
+	PKG_CHECK_MODULES([CRIU_PRE_DUMP], [criu > 3.16.1], [have_criu_pre_dump="yes"], [have_criu_pre_dump="no"
+	        AC_MSG_NOTICE([CRIU version doesn't support for pre-dumping])])
+	AS_IF([test "$have_criu" = "yes"], [
+		AC_DEFINE([HAVE_CRIU], 1, [Define if CRIU is available])
+		AC_SEARCH_LIBS(criu_init_opts, [criu])
+	])
+	AS_IF([test "$have_criu_join_ns" = "yes"], [
+		AC_DEFINE([CRIU_JOIN_NS_SUPPORT], 1, [Define if CRIU join NS support is available])
+	])
+	AS_IF([test "$have_criu_pre_dump" = "yes"], [
+		AC_DEFINE([CRIU_PRE_DUMP_SUPPORT], 1, [Define if CRIU pre-dump support is available])
+	])
 ], [AC_MSG_NOTICE([CRIU support disabled per user request])])
 
 FOUND_LIBS=$LIBS
@@ -183,7 +191,6 @@ AC_SEARCH_LIBS([argp_parse], [argp], [], [AC_MSG_ERROR([*** argp functions not f
 
 AM_CONDITIONAL([PYTHON_BINDINGS], [test "x$with_python_bindings" = "xyes"])
 AM_CONDITIONAL([CRIU_SUPPORT], [test "x$have_criu" = "xyes"])
-AM_CONDITIONAL([CRIU_JOIN_NS_SUPPORT], [test "x$have_criu_join_ns" = "xyes"])
 
 AC_CONFIG_FILES([Makefile rpm/crun.spec])
 

--- a/crun.1
+++ b/crun.1
@@ -429,6 +429,23 @@ Allow external UNIX sockets
 \fB--shell-job\fP
 Allow shell jobs
 
+.PP
+\fB--pre-dump\fP
+Only checkpoint the container's memory without stopping the container.
+It is not possible to restore a container from a pre-dump. A pre-dump
+always needs a final checkpoint (without \fB--pre-dump\fP). It is possible
+to make as many pre-dumps as necessary. For a second pre-dump or for
+a final checkpoint it is necessary to use \fB--parent-path\fP to point
+crun (and thus CRIU) to the pre-dump.
+
+.PP
+\fB--parent-path\fP=\fIDIR\fP
+Doing multiple pre-dumps or the final checkpoint after one or multiple
+pre-dumps requires that crun (and thus CRIU) knows the location of
+the pre-dump. It is important to use a relative path from the actual
+checkpoint directory specified via \fB--image-path\fP\&. It will fail
+if an absolute path is used.
+
 .SH RESTORE OPTIONS
 .PP
 crun [global options] restore [options] CONTAINER

--- a/crun.1.md
+++ b/crun.1.md
@@ -336,6 +336,21 @@ Allow external UNIX sockets
 **--shell-job**
 Allow shell jobs
 
+**--pre-dump**
+Only checkpoint the container's memory without stopping the container.
+It is not possible to restore a container from a pre-dump. A pre-dump
+always needs a final checkpoint (without **--pre-dump**). It is possible
+to make as many pre-dumps as necessary. For a second pre-dump or for
+a final checkpoint it is necessary to use **--parent-path** to point
+crun (and thus CRIU) to the pre-dump.
+
+**--parent-path**=_DIR_
+Doing multiple pre-dumps or the final checkpoint after one or multiple
+pre-dumps requires that crun (and thus CRIU) knows the location of
+the pre-dump. It is important to use a relative path from the actual
+checkpoint directory specified via **--image-path**. It will fail
+if an absolute path is used.
+
 ## RESTORE OPTIONS
 
 crun [global options] restore [options] CONTAINER

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -41,6 +41,8 @@ enum
   OPTION_SHELL_JOB,
   OPTION_EXT_UNIX_SK,
   OPTION_FILE_LOCKS,
+  OPTION_PARENT_PATH,
+  OPTION_PRE_DUMP,
 };
 
 static char doc[] = "OCI runtime";
@@ -55,6 +57,10 @@ static struct argp_option options[]
         { "ext-unix-sk", OPTION_EXT_UNIX_SK, 0, 0, "allow external unix sockets", 0 },
         { "shell-job", OPTION_SHELL_JOB, 0, 0, "allow shell jobs", 0 },
         { "file-locks", OPTION_FILE_LOCKS, 0, 0, "allow file locks", 0 },
+#ifdef CRIU_PRE_DUMP_SUPPORT
+        { "parent-path", OPTION_PARENT_PATH, "DIR", 0, "path for previous criu image files in pre-dump", 0 },
+        { "pre-dump", OPTION_PRE_DUMP, 0, 0, "dump container's memory information only, leave the container running after this", 0 },
+#endif
         {
             0,
         } };
@@ -75,6 +81,14 @@ parse_opt (int key, char *arg arg_unused, struct argp_state *state arg_unused)
 
     case OPTION_WORK_PATH:
       cr_options.work_path = argp_mandatory_argument (arg, state);
+      break;
+
+    case OPTION_PARENT_PATH:
+      cr_options.parent_path = argp_mandatory_argument (arg, state);
+      break;
+
+    case OPTION_PRE_DUMP:
+      cr_options.pre_dump = true;
       break;
 
     case OPTION_LEAVE_RUNNING:

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3563,7 +3563,7 @@ libcrun_container_checkpoint (libcrun_context_t *context, const char *id, libcru
   if (UNLIKELY (ret < 0))
     return ret;
 
-  if (! cr_options->leave_running)
+  if (! (cr_options->leave_running || cr_options->pre_dump))
     return container_delete_internal (context, NULL, id, true, true, err);
 
   return 0;

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -96,6 +96,8 @@ struct libcrun_checkpoint_restore_s
   bool detach;
   bool file_locks;
   const char *console_socket;
+  char *parent_path;
+  bool pre_dump;
 };
 typedef struct libcrun_checkpoint_restore_s libcrun_checkpoint_restore_t;
 

--- a/tests/centos8-build/Dockerfile
+++ b/tests/centos8-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream8
 
 RUN yum --enablerepo='*' --disablerepo='media-*' install -y make automake autoconf gettext \
-    libtool gcc libcap-devel systemd-devel yajl-devel \
+    criu-devel libtool gcc libcap-devel systemd-devel yajl-devel \
     libseccomp-devel python36 libtool git
 
 COPY run-tests.sh /usr/local/bin

--- a/tests/centos9-build/Dockerfile
+++ b/tests/centos9-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream9
 
 RUN yum --enablerepo='*' --disablerepo='nfv-*' install -y make automake autoconf gettext \
-    libtool gcc libcap-devel systemd-devel yajl-devel \
+    criu-devel libtool gcc libcap-devel systemd-devel yajl-devel \
     libseccomp-devel python3 libtool git
 
 COPY run-tests.sh /usr/local/bin

--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -18,7 +18,68 @@
 import time
 import json
 import os
+import subprocess
 from tests_utils import *
+
+criu_version = 0
+
+def _get_criu_version():
+    global criu_version
+    if criu_version != 0:
+        return criu_version
+
+    args = ["criu", "--version"]
+    version_output = subprocess.check_output(args, close_fds=False).decode().split('\n')
+
+    if len(version_output) < 1:
+        return 0
+
+    first_line = version_output[0].split(':')
+
+    if len(first_line) != 2:
+        return 0
+
+    version_string = first_line[1].split('.')
+
+    if len(version_string) < 2:
+        return 0
+
+    version = int(version_string[0]) * 10000
+    version += int(version_string[1]) * 100
+
+    if len(version_string) == 3:
+        version += int(version_string[2])
+
+    if len(version_output) > 1:
+        if version_output[1].startswith('GitID'):
+            version -= version % 100
+            version += 100
+
+    return version
+
+
+def _get_cmdline(cid, tests_root):
+    s = {}
+    for _ in range(50):
+        try:
+            if os.path.exists(os.path.join(tests_root, 'root/%s/status' % cid)):
+                s = json.loads(run_crun_command(["state", cid]))
+                break
+            else:
+                time.sleep(0.1)
+        except Exception as e:
+            time.sleep(0.1)
+
+    if len(s) == 0:
+        return ""
+
+    if s['status'] != "running":
+        return ""
+    if s['id'] != cid:
+        return ""
+    with open("/proc/%s/cmdline" % s['pid'], 'r') as cmdline_fd:
+        return cmdline_fd.read()
+    return ""
 
 
 def run_cr_test(conf):
@@ -31,19 +92,10 @@ def run_cr_test(conf):
             use_popen=True,
             detach=True
         )
-        for _ in range(50):
-            try:
-                s = json.loads(run_crun_command(["state", cid]))
-                break
-            except Exception as e:
-                time.sleep(0.1)
 
-        if s['status'] != "running":
+        first_cmdline = _get_cmdline(cid, get_tests_root())
+        if first_cmdline == "":
             return -1
-        if s['id'] != cid:
-            return -1
-        with open("/proc/%s/cmdline" % s['pid'], 'r') as cmdline_fd:
-            first_cmdline = cmdline_fd.read()
 
         run_crun_command(["checkpoint", "--image-path=%s" % cr_dir, cid])
 
@@ -60,15 +112,103 @@ def run_cr_test(conf):
             cid
         ])
 
-        s = json.loads(run_crun_command(["state", cid]))
-        if s['status'] != "running":
-            return -1
-        if s['id'] != cid:
-            return -1
-        with open("/proc/%s/cmdline" % s['pid'], 'r') as cmdline_fd:
-            second_cmdline = cmdline_fd.read()
+        second_cmdline = _get_cmdline(cid, get_tests_root())
         if first_cmdline != second_cmdline:
             return -1
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+    return 0
+
+
+def test_cr_pre_dump():
+    if is_rootless() or 'CRIU' not in get_crun_feature_string():
+        return 77
+
+    if _get_criu_version() < 31700:
+        return 77
+
+    has_pre_dump = False
+    for i in run_crun_command(["checkpoint", "--help"]).split('\n'):
+        if "pre-dump" in i:
+            has_pre_dump = True
+            break
+
+    if not has_pre_dump:
+        return 77
+
+    def _get_pre_dump_size(cr_dir):
+        size = 0
+        for f in os.listdir(cr_dir):
+            if os.path.isfile(os.path.join(cr_dir, f)):
+                size += os.path.getsize(os.path.join(cr_dir, f))
+        return size
+
+    conf = base_config()
+    conf['process']['args'] = [
+            '/init',
+            'memhog',
+            '10'
+    ]
+    add_all_namespaces(conf)
+
+    cid = None
+    cr_dir = os.path.join(get_tests_root(), 'pre-dump')
+    try:
+        _, cid = run_and_get_output(
+            conf,
+            all_dev_null=True,
+            use_popen=True,
+            detach=True
+        )
+
+        first_cmdline = _get_cmdline(cid, get_tests_root())
+        if first_cmdline == "":
+            return -1
+
+        # Let's do one pre-dump first
+        run_crun_command([
+            "checkpoint",
+            "--pre-dump",
+            "--image-path=%s" % cr_dir,
+            cid
+        ])
+
+        # Get the size of the pre-dump
+        pre_dump_size = _get_pre_dump_size(cr_dir)
+
+        # Do the final dump. This dump should be much smaller.
+        cr_dir = os.path.join(get_tests_root(), 'checkpoint')
+        run_crun_command([
+            "checkpoint",
+            "--parent-path=../pre-dump",
+            "--image-path=%s" % cr_dir,
+            cid
+        ])
+
+        final_dump_size = _get_pre_dump_size(cr_dir)
+        if (final_dump_size > pre_dump_size):
+            # If the final dump is not smaller than the pre-dump
+            # something was not working as expected.
+            return -1
+
+        bundle = os.path.join(
+            get_tests_root(),
+            cid.split('-')[1]
+        )
+
+        run_crun_command([
+            "restore",
+            "-d",
+            "--image-path=%s" % cr_dir,
+            "--bundle=%s" % bundle,
+            cid
+        ])
+
+        second_cmdline = _get_cmdline(cid, get_tests_root())
+        if first_cmdline != second_cmdline:
+            return -1
+
     finally:
         if cid is not None:
             run_crun_command(["delete", "-f", cid])
@@ -87,6 +227,9 @@ def test_cr():
 
 def test_cr_with_ext_ns():
     if is_rootless() or 'CRIU' not in get_crun_feature_string():
+        return 77
+
+    if _get_criu_version() < 31601:
         return 77
 
     conf = base_config()
@@ -112,6 +255,7 @@ def test_cr_with_ext_ns():
 all_tests = {
     "checkpoint-restore": test_cr,
     "checkpoint-restore-ext-ns": test_cr_with_ext_ns,
+    "checkpoint-restore-pre-dump": test_cr_pre_dump,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
CRIU supports the concept of pre-copy migration. Instead of creating a
complete checkpoint of a process it is possible to only write the memory
of the process to disk while the process keeps on running. The first
memory only checkpoint can then be transferred to the migration
destination. During the transfer time it is possible take a second
checkpoint which will only write the memory pages to disk that have
changed since the previous checkpoint. This way it can be possible that
the second checkpoint is much smaller while the process keeps on running
which also means that the amount of data which needs to be transferred
to the migration destination might be smaller and thus the migration
downtime can be reduced. This only makes sense if the number of memory
pages which are changing is rather small. There is no limit on the
number pre-copy iterations.

This commit takes the interface as implemented in runc and implements it
for crun. Podman already uses the pre-dump as implemented by runc.

This commit also makes sure that the underlying software stack supports
the pre-dump mechanism. CRIU uses the kernel's dirty page tracking and
it is not available on all architectures (aarch64 does not implement it)
or might not be enabled in the kernel. If the user wants to use pre-dump
on a system without dirty page tracking crun will fail early and inform
the user.

This crun pre-dump implementation relies on libcriu interfaces which are
not yet part of the latest release (3.16.1). So at least 3.16.2 or 3.17
is required to use pre-dump in combination with crun.