### PR TITLE
nix: lock `nixos/nix` version to last working release i.e `2.3.12`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
           set -ex
           sudo mkdir -p .cache
           sudo mv .cache /nix
-          if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
+          if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix:2.3.12 cp -rfT /nix /mnt/nix; fi
           sudo RUNTIME=docker SKIP_CHECKS=1 SKIP_GPG=1 build-aux/release.sh
           sudo mv /nix .cache
           sudo chown -Rf $(whoami) .cache

--- a/build-aux/release.sh
+++ b/build-aux/release.sh
@@ -40,25 +40,25 @@ RUNTIME=${RUNTIME:-podman}
 
 mkdir -p /nix
 
-$RUNTIME run --rm --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix \
+$RUNTIME run --rm --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix:2.3.12 \
     nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
 cp ./result/bin/crun $OUTDIR/crun-$VERSION-linux-amd64
 
 rm -rf result
 
-$RUNTIME run --rm --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix \
+$RUNTIME run --rm --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix:2.3.12 \
     nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/ --arg enableSystemd false
 cp ./result/bin/crun $OUTDIR/crun-$VERSION-linux-amd64-disable-systemd
 
 rm -rf result
 
-$RUNTIME run --rm --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix \
+$RUNTIME run --rm --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix:2.3.12 \
     nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/default-arm64.nix
 cp ./result/bin/crun $OUTDIR/crun-$VERSION-linux-arm64
 
 rm -rf result
 
-$RUNTIME run --rm --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix \
+$RUNTIME run --rm --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix:2.3.12 \
     nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/default-arm64.nix --arg enableSystemd false
 cp ./result/bin/crun $OUTDIR/crun-$VERSION-linux-arm64-disable-systemd
 


### PR DESCRIPTION
It seems `nixos/nix:latest` expects `nixbld` user to added and specified in
`build-users-group` but this should be only needed for `multi-user`
mode.

Hence I suspect latest push has a regression. Lock the `nix` to last working
image.

Following PR fixes regression for artifacts in CI