### PR TITLE
cgroup, systemd: set CPUShares/CPUWeight on the systemd scope

### DIFF
--- a/src/libcrun/cgroup-internal.h
+++ b/src/libcrun/cgroup-internal.h
@@ -71,4 +71,11 @@ is_rootless (libcrun_error_t *err)
 
 int libcrun_cgroup_pause_unpause_path (const char *cgroup_path, const bool pause, libcrun_error_t *err);
 
+static inline uint64_t
+convert_shares_to_weight (uint64_t shares)
+{
+  /* convert linearly from 2-262144 to 1-10000.  */
+  return (1 + ((shares - 2) * 9999) / 262142);
+}
+
 #endif

--- a/src/libcrun/cgroup-internal.h
+++ b/src/libcrun/cgroup-internal.h
@@ -45,6 +45,8 @@ struct libcrun_cgroup_manager
   int (*create_cgroup) (struct libcrun_cgroup_args *args, struct libcrun_cgroup_status *out, libcrun_error_t *err);
   /* Destroy the cgroup and kill any process if needed.  */
   int (*destroy_cgroup) (struct libcrun_cgroup_status *cgroup_status, libcrun_error_t *err);
+  /* Additional resources configuration specific to this manager.  */
+  int (*update_resources) (struct libcrun_cgroup_status *cgroup_status, runtime_spec_schema_config_linux_resources *resources, libcrun_error_t *err);
 };
 
 const char *find_delegate_cgroup (json_map_string_string *annotations);

--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -816,15 +816,12 @@ write_cpu_resources (int dirfd_cpu, bool cgroup2, runtime_spec_schema_config_lin
   int64_t period = -1;
   int64_t quota = -1;
 
-  /* convert linearly from 2-262144 to 1-10000.  */
-#define CONVERT_SHARES_TO_CGROUPS_V2(x) (1 + (((x) -2) * 9999) / 262142)
-
   if (cpu->shares)
     {
       uint32_t val = cpu->shares;
 
       if (cgroup2)
-        val = CONVERT_SHARES_TO_CGROUPS_V2 (val);
+        val = convert_shares_to_weight (val);
 
       len = sprintf (fmt_buf, "%u", val);
 

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -564,8 +564,84 @@ open_sd_bus_connection (sd_bus **bus, libcrun_error_t *err)
   return 0;
 }
 
+static inline int
+get_weight (runtime_spec_schema_config_linux_resources *resources, uint64_t *weight, libcrun_error_t *err)
+{
+  if (resources->cpu && resources->cpu->shares_present)
+    {
+      *weight = convert_shares_to_weight (resources->cpu->shares);
+      return 1;
+    }
+
+  if (resources->unified)
+    {
+      size_t i;
+
+      for (i = 0; i < resources->unified->len; i++)
+        if (strcmp (resources->unified->keys[i], "cpu.weight") == 0)
+          {
+            errno = 0;
+            *weight = (uint64_t) strtoll (resources->unified->values[i], NULL, 10);
+            if (UNLIKELY (errno))
+              return crun_make_error (err, errno, "invalid value for `cpu.weight`: %s",
+                                      resources->unified->values[i]);
+            return 1;
+          }
+    }
+  return 0;
+}
+
+static int
+append_resources (sd_bus_message *m,
+                  runtime_spec_schema_config_linux_resources *resources,
+                  int cgroup_mode,
+                  libcrun_error_t *err)
+{
+  int sd_err;
+
+  if (resources == NULL)
+    return 0;
+
+  switch (cgroup_mode)
+    {
+    case CGROUP_MODE_UNIFIED:
+      {
+        uint64_t weight;
+        int ret;
+
+        ret = get_weight (resources, &weight, err);
+        if (UNLIKELY (ret < 0))
+          return ret;
+
+        if (ret)
+          {
+            sd_err = sd_bus_message_append (m, "(sv)", "CPUWeight", "t", weight);
+            if (UNLIKELY (sd_err < 0))
+              return crun_make_error (err, -sd_err, "sd-bus message append CPUWeight");
+          }
+      }
+      break;
+
+    case CGROUP_MODE_LEGACY:
+    case CGROUP_MODE_HYBRID:
+      if (resources->cpu && resources->cpu->shares_present)
+        {
+          sd_err = sd_bus_message_append (m, "(sv)", "CPUShares", "t", resources->cpu->shares);
+          if (UNLIKELY (sd_err < 0))
+            return crun_make_error (err, -sd_err, "sd-bus message append CPUShares");
+        }
+      break;
+
+    default:
+      return crun_make_error (err, 0, "invalid cgroup mode %d", cgroup_mode);
+    }
+
+  return 0;
+}
+
 static int
 enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *resources,
+                            int cgroup_mode,
                             json_map_string_string *annotations,
                             const char *scope, const char *slice,
                             pid_t pid, libcrun_error_t *err)
@@ -684,6 +760,10 @@ enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *resource
           goto exit;
         }
     }
+
+  ret = append_resources (m, resources, cgroup_mode, err);
+  if (UNLIKELY (ret < 0))
+    goto exit;
 
   sd_err = sd_bus_message_close_container (m);
   if (UNLIKELY (sd_err < 0))
@@ -830,7 +910,7 @@ libcrun_cgroup_enter_systemd (struct libcrun_cgroup_args *args,
 
   get_systemd_scope_and_slice (id, cgroup_path, &scope, &slice);
 
-  ret = enter_systemd_cgroup_scope (resources, args->annotations, scope, slice, pid, err);
+  ret = enter_systemd_cgroup_scope (resources, cgroup_mode, args->annotations, scope, slice, pid, err);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -192,7 +192,7 @@ libcrun_cgroup_killall (struct libcrun_cgroup_status *cgroup_status, int signal,
 int
 libcrun_cgroup_destroy (struct libcrun_cgroup_status *cgroup_status, libcrun_error_t *err)
 {
-  struct libcrun_cgroup_manager *cgroup_manager;
+  struct libcrun_cgroup_manager *cgroup_manager = NULL;
   int ret;
 
   ret = get_cgroup_manager (cgroup_status->manager, &cgroup_manager, err);
@@ -207,11 +207,24 @@ libcrun_cgroup_destroy (struct libcrun_cgroup_status *cgroup_status, libcrun_err
 }
 
 int
-libcrun_update_cgroup_resources (struct libcrun_cgroup_status *status,
+libcrun_update_cgroup_resources (struct libcrun_cgroup_status *cgroup_status,
                                  runtime_spec_schema_config_linux_resources *resources,
                                  libcrun_error_t *err)
 {
-  return update_cgroup_resources (status->path, resources, err);
+  struct libcrun_cgroup_manager *cgroup_manager = NULL;
+  int ret;
+
+  ret = get_cgroup_manager (cgroup_status->manager, &cgroup_manager, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  if (cgroup_manager->update_resources)
+    {
+      ret = cgroup_manager->update_resources (cgroup_status, resources, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+    }
+  return update_cgroup_resources (cgroup_status->path, resources, err);
 }
 
 static int

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2935,6 +2935,12 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
   yajl_gen_string (gen, YAJL_STR ("created"), strlen ("created"));
   yajl_gen_string (gen, YAJL_STR (status.created), strlen (status.created));
 
+  if (status.scope)
+    {
+      yajl_gen_string (gen, YAJL_STR ("systemd-scope"), strlen ("systemd-scope"));
+      yajl_gen_string (gen, YAJL_STR (status.scope), strlen (status.scope));
+    }
+
   if (status.owner)
     {
       yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));

--- a/src/update.c
+++ b/src/update.c
@@ -73,7 +73,7 @@ static struct description_s descriptors[] = { { BLKIO_WEIGHT, 0, "weight", 1 },
 
                                               { CPU_PERIOD, 1, "period", 1 },
                                               { CPU_QUOTA, 1, "quota", 1 },
-                                              { CPU_SHARE, 1, "share", 1 },
+                                              { CPU_SHARE, 1, "shares", 1 },
                                               { CPU_RT_PERIOD, 1, "realtimePeriod", 1 },
                                               { CPU_RT_RUNTIME, 1, "realtimeRuntime", 1 },
                                               { CPUSET_CPUS, 1, "cpus", 0 },

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -193,7 +193,7 @@ def get_crun_path():
     return os.getenv("OCI_RUNTIME") or os.path.join(cwd, "crun")
 
 def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
-                       command='run', env=None, use_popen=False, hide_stderr=False,
+                       command='run', env=None, use_popen=False, hide_stderr=False, cgroup_manager='cgroupfs',
                        all_dev_null=False, id_container=None, relative_config_path="config.json",
                        chown_rootfs_to=None):
 
@@ -247,7 +247,7 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
     relative_config_path = ['--config', relative_config_path] if relative_config_path else []
 
     root = get_tests_root_status()
-    args = [crun, "--root", root, command] + relative_config_path + preserve_fds_arg + detach_arg + pid_file_arg + [id_container]
+    args = [crun, "--cgroup-manager", cgroup_manager, "--root", root, command] + relative_config_path + preserve_fds_arg + detach_arg + pid_file_arg + [id_container]
 
     stderr = subprocess.STDOUT
     if hide_stderr:

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -275,6 +275,10 @@ def run_crun_command(args):
     args = [crun, "--root", root] + args
     return subprocess.check_output(args, close_fds=False).decode()
 
+def running_on_systemd():
+    with open('/proc/1/comm') as f:
+        return "systemd" in f.readline()
+
 def tests_main(all_tests):
     os.environ["LANG"] = "C"
     tests_root = get_tests_root()


### PR DESCRIPTION
CPUWeight/CPUShares affect the cgroup priority in relation to the sibling cgroups.  Since the expectation is that it affects other
containers at the same cgroup level, it is necessary to set it on the systemd scope.

It adds the infrastructure for setting values on the systemd scope similarly to what runc does.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

@mrunalp FYI