### PR TITLE
handlers, wasm: add lost support for `run.oci.handler=wasm`

### DIFF
--- a/src/libcrun/custom-handler.c
+++ b/src/libcrun/custom-handler.c
@@ -263,13 +263,14 @@ libcrun_configure_handler (struct custom_handler_manager_s *manager,
         return crun_make_error (err, 0, "handler requested but no manager configured: `%s`", context->handler);
 
       *out = handler_by_name (manager, explicit_handler);
-      if (*out == NULL)
-        return crun_make_error (err, 0, "invalid handler specified `%s`", explicit_handler);
+      if (*out)
+        {
+          if ((*out)->load)
+            return (*out)->load (cookie, err);
+          return 0;
+        }
 
-      if ((*out)->load)
-        return (*out)->load (cookie, err);
-
-      return 0;
+      return find_handler_for_container (manager, container, out, cookie, err);
     }
 
   if (manager == NULL)

--- a/src/libcrun/handlers/wasmedge.c
+++ b/src/libcrun/handlers/wasmedge.c
@@ -170,11 +170,15 @@ wasmedge_can_handle_container (libcrun_container_t *container, libcrun_error_t *
 {
   const char *annotation;
 
-  annotation = find_annotation (container, "module.wasm.image/variant");
-  if (! annotation)
-    return 0;
+  annotation = find_annotation (container, "run.oci.handler");
+  if (annotation)
+    return strcmp (annotation, "wasm") == 0 ? 1 : 0;
 
-  return strcmp (annotation, "compat") == 0 ? 1 : 0;
+  annotation = find_annotation (container, "module.wasm.image/variant");
+  if (annotation)
+    return strcmp (annotation, "compat") == 0 ? 1 : 0;
+
+  return 0;
 }
 
 struct custom_handler_s handler_wasmedge = {

--- a/src/libcrun/handlers/wasmer.c
+++ b/src/libcrun/handlers/wasmer.c
@@ -276,11 +276,15 @@ libwasmer_can_handle_container (libcrun_container_t *container, libcrun_error_t 
 {
   const char *annotation;
 
-  annotation = find_annotation (container, "module.wasm.image/variant");
-  if (! annotation)
-    return 0;
+  annotation = find_annotation (container, "run.oci.handler");
+  if (annotation)
+    return strcmp (annotation, "wasm") == 0 ? 1 : 0;
 
-  return strcmp (annotation, "compat") == 0 ? 1 : 0;
+  annotation = find_annotation (container, "module.wasm.image/variant");
+  if (annotation)
+    return strcmp (annotation, "compat") == 0 ? 1 : 0;
+
+  return 0;
 }
 
 struct custom_handler_s handler_wasmer = {


### PR DESCRIPTION
Last refactor in https://github.com/containers/crun/pull/806 dropped
support for legacy annotation run.oci.handler=wasm for users.

Following PR adds alias to handlers so more intutive selection for
handlers can be done

Closes: https://github.com/containers/crun/issues/815
