### PR TITLE
utils: fix path check

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -460,12 +460,16 @@ crun_safe_ensure_at (bool do_open, bool dir, int dirfd, const char *dirpath,
 
   path = consume_slashes (path);
 
+  /* Empty path, nothing to do.  */
+  if (*path == '\0')
+    return 0;
+
   npath = xstrdup (path);
 
   it = npath + strlen (npath) - 1;
-  while (*it == '/' && it > npath && ((size_t) (it - path)) > dirpath_len)
+  while (*it == '/' && it > npath && ((size_t) (it - npath)) > dirpath_len)
     *it-- = '\0';
-  if (((size_t) (it - path)) == dirpath_len)
+  if (((size_t) (it - npath)) == dirpath_len)
     return crun_make_error (err, 0, "invalid path `%s`", path);
 
   cwd = dirfd;


### PR DESCRIPTION
The check was erroneously using `path` instead of the freshly
allocated `npath`.

Since `it - path` could be any value, in some rare cases its value was
precisely `dirpath_len`, causing the error.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>