### PR TITLE
src/libcrun/linux.c:425:77: error: 'OPEN_TREE_CLOEXEC' undeclared (first use in this function); did you mean 'OPEN_TREE_CLONE'?

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -71,6 +71,10 @@
 #  define OPEN_TREE_CLONE 1
 #endif
 
+#ifndef OPEN_TREE_CLOEXEC
+#  define OPEN_TREE_CLOEXEC O_CLOEXEC
+#endif
+
 #ifndef MOVE_MOUNT_F_EMPTY_PATH
 #  define MOVE_MOUNT_F_EMPTY_PATH 0x00000004
 #endif


### PR DESCRIPTION
The new code from 1.4 didn't define the `OPEN_TREE_CLOEXEC` (which we have that for OPEN_TREE_CLONE).

In case of Ubuntu 18.04, compile crun 1.4 comming with following error message:

    gcc -DHAVE_CONFIG_H -I.   -Wdate-time -D_FORTIFY_SOURCE=2 -I /usr/src/packages/BUILD/libocispec/src -I /usr/src/packages/BUILD/libocispec/src -fvisibility=default -g -O2 -fdebug-prefix-map=/usr/src/packages/BUILD=. -fstack-protector-strong -Wformat -Werror=format-security -c -o src/libcrun/libcrun_testing_a-linux.o `test -f 'src/libcrun/linux.c' || echo './'`src/libcrun/linux.c
    src/libcrun/linux.c: In function 'get_idmapped_mount':
    src/libcrun/linux.c:425:77: error: 'OPEN_TREE_CLOEXEC' undeclared (first use in this function); did you mean 'OPEN_TREE_CLONE'?
                                         AT_NO_AUTOMOUNT | AT_SYMLINK_NOFOLLOW | OPEN_TREE_CLOEXEC | OPEN_TREE_CLONE);
                                                                                 ^~~~~~~~~~~~~~~~~
                                                                                 OPEN_TREE_CLONE
    src/libcrun/linux.c:425:77: note: each undeclared identifier is reported only once for each function it appears in

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>