### PR TITLE
src: export some symbols used by crun

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,14 @@ jobs:
             make -j $(nproc) libcrun.la
             make -j $(nproc) crun
 
+            make -j $(nproc) clean
+
+            ./configure CFLAGS='-Wall -Werror --enable-shared'
+            make -j $(nproc) -C libocispec libocispec.la
+            make git-version.h
+            make -j $(nproc) libcrun.la
+            make -j $(nproc) crun
+
   Test:
     runs-on: ubuntu-latest
     strategy:

--- a/src/crun.c
+++ b/src/crun.c
@@ -51,7 +51,7 @@ static struct crun_global_arguments arguments;
 static struct custom_handler_manager_s *handler_manager;
 
 static struct custom_handler_manager_s *
-get_handler_manager ()
+libcrun_get_handler_manager ()
 {
   if (handler_manager == NULL)
     {
@@ -59,17 +59,17 @@ get_handler_manager ()
       libcrun_error_t err;
       int ret;
 
-      handler_manager = handler_manager_create (&err);
+      handler_manager = libcrun_handler_manager_create (&err);
       if (UNLIKELY (handler_manager == NULL))
         libcrun_fail_with_error (err->status, "%s", err->msg);
 
-      ret = append_paths (&handlers_path, &err, CRUN_LIBDIR, "handlers", NULL);
+      ret = libcrun_append_paths (&handlers_path, &err, CRUN_LIBDIR, "handlers", NULL);
       if (UNLIKELY (ret < 0))
         libcrun_fail_with_error (err->status, "%s", err->msg);
 
       if (access (handlers_path, F_OK) == 0)
         {
-          ret = handler_manager_load_from_directory (handler_manager, handlers_path, &err);
+          ret = libcrun_handler_manager_load_directory (handler_manager, handlers_path, &err);
           if (UNLIKELY (ret < 0))
             libcrun_fail_with_error (err->status, "%s", err->msg);
         }
@@ -113,7 +113,7 @@ init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global
   if (con->config_file == NULL)
     con->config_file = "./config.json";
 
-  con->handler_manager = get_handler_manager ();
+  con->handler_manager = libcrun_get_handler_manager ();
 
   return 0;
 }
@@ -240,7 +240,7 @@ print_version (FILE *stream, struct argp_state *state arg_unused)
   fprintf (stream, "+CRIU ");
 #endif
 
-  handler_manager_print_feature_tags (get_handler_manager (), stream);
+  libcrun_handler_manager_print_feature_tags (libcrun_get_handler_manager (), stream);
 
   fprintf (stream, "+YAJL\n");
 }

--- a/src/libcrun/cgroup-cgroupfs.c
+++ b/src/libcrun/cgroup-cgroupfs.c
@@ -72,7 +72,7 @@ libcrun_cgroup_enter_cgroupfs (struct libcrun_cgroup_args *args, struct libcrun_
     process_target_cgroup = out->path;
   else
     {
-      ret = append_paths (&target_cgroup_cleanup, err, out->path, delegate_cgroup, NULL);
+      ret = libcrun_append_paths (&target_cgroup_cleanup, err, out->path, delegate_cgroup, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 

--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -922,7 +922,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       cleanup_close int dirfd_blkio = -1;
       runtime_spec_schema_config_linux_resources_block_io *blkio = resources->block_io;
 
-      ret = append_paths (&path_to_blkio, err, CGROUP_ROOT "/blkio", path, NULL);
+      ret = libcrun_append_paths (&path_to_blkio, err, CGROUP_ROOT "/blkio", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -943,11 +943,11 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       cleanup_close int dirfd_netprio = -1;
       runtime_spec_schema_config_linux_resources_network *network = resources->network;
 
-      ret = append_paths (&path_to_netclass, err, CGROUP_ROOT "/net_cls", path, NULL);
+      ret = libcrun_append_paths (&path_to_netclass, err, CGROUP_ROOT "/net_cls", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
-      ret = append_paths (&path_to_netprio, err, CGROUP_ROOT "/net_prio", path, NULL);
+      ret = libcrun_append_paths (&path_to_netprio, err, CGROUP_ROOT "/net_prio", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -969,7 +969,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       cleanup_free char *path_to_htlb = NULL;
       cleanup_close int dirfd_htlb = -1;
 
-      ret = append_paths (&path_to_htlb, err, CGROUP_ROOT "/hugetlb", path, NULL);
+      ret = libcrun_append_paths (&path_to_htlb, err, CGROUP_ROOT "/hugetlb", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
       dirfd_htlb = open (path_to_htlb, O_DIRECTORY | O_RDONLY);
@@ -987,7 +987,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       cleanup_free char *path_to_devs = NULL;
       cleanup_close int dirfd_devs = -1;
 
-      ret = append_paths (&path_to_devs, err, CGROUP_ROOT "/devices", path, NULL);
+      ret = libcrun_append_paths (&path_to_devs, err, CGROUP_ROOT "/devices", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -1005,7 +1005,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       cleanup_free char *path_to_mem = NULL;
       cleanup_close int dirfd_mem = -1;
 
-      ret = append_paths (&path_to_mem, err, CGROUP_ROOT "/memory", path, NULL);
+      ret = libcrun_append_paths (&path_to_mem, err, CGROUP_ROOT "/memory", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -1023,7 +1023,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       cleanup_free char *path_to_pid = NULL;
       cleanup_close int dirfd_pid = -1;
 
-      ret = append_paths (&path_to_pid, err, CGROUP_ROOT "/pids", path, NULL);
+      ret = libcrun_append_paths (&path_to_pid, err, CGROUP_ROOT "/pids", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -1043,7 +1043,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       cleanup_free char *path_to_cpuset = NULL;
       cleanup_close int dirfd_cpuset = -1;
 
-      ret = append_paths (&path_to_cpu, err, CGROUP_ROOT "/cpu", path, NULL);
+      ret = libcrun_append_paths (&path_to_cpu, err, CGROUP_ROOT "/cpu", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -1057,7 +1057,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       if (resources->cpu->cpus == NULL && resources->cpu->mems == NULL)
         return 0;
 
-      ret = append_paths (&path_to_cpuset, err, CGROUP_ROOT "/cpuset", path, NULL);
+      ret = libcrun_append_paths (&path_to_cpuset, err, CGROUP_ROOT "/cpuset", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -1109,7 +1109,7 @@ update_cgroup_v2_resources (runtime_spec_schema_config_linux_resources *resource
   if (resources->network)
     return crun_make_error (err, 0, "network limits not supported on cgroupv2");
 
-  ret = append_paths (&cgroup_path, err, CGROUP_ROOT, path, NULL);
+  ret = libcrun_append_paths (&cgroup_path, err, CGROUP_ROOT, path, NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/cgroup-setup.c
+++ b/src/libcrun/cgroup-setup.c
@@ -161,7 +161,7 @@ enter_cgroup_subsystem (pid_t pid, const char *subsystem, const char *path, bool
   cleanup_free char *cgroup_path = NULL;
   int ret;
 
-  ret = append_paths (&cgroup_path, err, CGROUP_ROOT, subsystem ? subsystem : "", path ? path : "", NULL);
+  ret = libcrun_append_paths (&cgroup_path, err, CGROUP_ROOT, subsystem ? subsystem : "", path ? path : "", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -360,7 +360,7 @@ enter_cgroup_v2 (pid_t pid, pid_t init_pid, const char *path, bool create_if_mis
 
   sprintf (pid_str, "%d", pid);
 
-  ret = append_paths (&cgroup_path, err, CGROUP_ROOT, path, NULL);
+  ret = libcrun_append_paths (&cgroup_path, err, CGROUP_ROOT, path, NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -371,7 +371,7 @@ enter_cgroup_v2 (pid_t pid, pid_t init_pid, const char *path, bool create_if_mis
         return ret;
     }
 
-  ret = append_paths (&cgroup_path_procs, err, cgroup_path, "cgroup.procs", NULL);
+  ret = libcrun_append_paths (&cgroup_path_procs, err, cgroup_path, "cgroup.procs", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -413,7 +413,7 @@ enter_cgroup_v2 (pid_t pid, pid_t init_pid, const char *path, bool create_if_mis
       if (cgroup_crun_exec_path == NULL)
         xasprintf (&cgroup_crun_exec_path, "%s/crun-exec", path);
 
-      ret = append_paths (&cgroup_sub_path_procs, err, CGROUP_ROOT, cgroup_crun_exec_path, "cgroup.procs", NULL);
+      ret = libcrun_append_paths (&cgroup_sub_path_procs, err, CGROUP_ROOT, cgroup_crun_exec_path, "cgroup.procs", NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -115,7 +115,7 @@ systemd_finalize (struct libcrun_cgroup_args *args, char **path_out,
         path = xstrdup (from);
       else
         {
-          ret = append_paths (&path, err, from, suffix, NULL);
+          ret = libcrun_append_paths (&path, err, from, suffix, NULL);
           if (UNLIKELY (ret < 0))
             return ret;
         }
@@ -175,13 +175,13 @@ systemd_finalize (struct libcrun_cgroup_args *args, char **path_out,
           path = xstrdup (from);
         else
           {
-            ret = append_paths (&path, err, from, suffix, NULL);
+            ret = libcrun_append_paths (&path, err, from, suffix, NULL);
             if (UNLIKELY (ret < 0))
               return ret;
           }
         *to = '\n';
 
-        ret = append_paths (&dir, err, CGROUP_ROOT, path, delegate_cgroup, NULL);
+        ret = libcrun_append_paths (&dir, err, CGROUP_ROOT, path, delegate_cgroup, NULL);
         if (UNLIKELY (ret < 0))
           return ret;
 
@@ -202,7 +202,7 @@ systemd_finalize (struct libcrun_cgroup_args *args, char **path_out,
           process_target_cgroup = path;
         else
           {
-            ret = append_paths (&target_cgroup_cleanup, err, path, delegate_cgroup, NULL);
+            ret = libcrun_append_paths (&target_cgroup_cleanup, err, path, delegate_cgroup, NULL);
             if (UNLIKELY (ret < 0))
               return ret;
 

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -78,8 +78,8 @@ move_process_to_cgroup (pid_t pid, const char *subsystem, const char *path, libc
   char pid_str[16];
   int ret;
 
-  ret = append_paths (&cgroup_path_procs, err, CGROUP_ROOT, subsystem ? subsystem : "", path ? path : "",
-                      "cgroup.procs", NULL);
+  ret = libcrun_append_paths (&cgroup_path_procs, err, CGROUP_ROOT, subsystem ? subsystem : "", path ? path : "",
+                              "cgroup.procs", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -110,7 +110,7 @@ libcrun_get_current_unified_cgroup (char **path, libcrun_error_t *err)
     return crun_make_error (err, 0, "cannot parse /proc/self/cgroup");
   *to = '\0';
 
-  return append_paths (path, err, CGROUP_ROOT, from, NULL);
+  return libcrun_append_paths (path, err, CGROUP_ROOT, from, NULL);
 }
 
 #ifndef CGROUP2_SUPER_MAGIC
@@ -326,14 +326,14 @@ libcrun_cgroup_read_pids_from_path (const char *path, bool recurse, pid_t **pids
   switch (mode)
     {
     case CGROUP_MODE_UNIFIED:
-      ret = append_paths (&cgroup_path, err, CGROUP_ROOT, path, NULL);
+      ret = libcrun_append_paths (&cgroup_path, err, CGROUP_ROOT, path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
       break;
 
     case CGROUP_MODE_HYBRID:
     case CGROUP_MODE_LEGACY:
-      ret = append_paths (&cgroup_path, err, CGROUP_ROOT "/memory", path, NULL);
+      ret = libcrun_append_paths (&cgroup_path, err, CGROUP_ROOT "/memory", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
       break;
@@ -398,7 +398,7 @@ destroy_cgroup_path (const char *path, int mode, libcrun_error_t *err)
         {
           cleanup_free char *cgroup_path = NULL;
 
-          ret = append_paths (&cgroup_path, err, CGROUP_ROOT, path, NULL);
+          ret = libcrun_append_paths (&cgroup_path, err, CGROUP_ROOT, path, NULL);
           if (UNLIKELY (ret < 0))
             return ret;
           ret = rmdir (cgroup_path);
@@ -441,7 +441,7 @@ destroy_cgroup_path (const char *path, int mode, libcrun_error_t *err)
               if (mode == CGROUP_MODE_LEGACY && strcmp (subsystem, "unified") == 0)
                 continue;
 
-              ret = append_paths (&cgroup_path, err, CGROUP_ROOT, subsystem, path, NULL);
+              ret = libcrun_append_paths (&cgroup_path, err, CGROUP_ROOT, subsystem, path, NULL);
               if (UNLIKELY (ret < 0))
                 return ret;
 
@@ -484,7 +484,7 @@ chown_cgroups (const char *path, uid_t uid, gid_t gid, libcrun_error_t *err)
   char *name;
   int ret;
 
-  ret = append_paths (&cgroup_path, err, CGROUP_ROOT, path, NULL);
+  ret = libcrun_append_paths (&cgroup_path, err, CGROUP_ROOT, path, NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -534,14 +534,14 @@ libcrun_cgroup_pause_unpause_with_mode (const char *cgroup_path, int cgroup_mode
   if (cgroup_mode == CGROUP_MODE_UNIFIED)
     {
       state = pause ? "1" : "0";
-      ret = append_paths (&path, err, CGROUP_ROOT, cgroup_path, "cgroup.freeze", NULL);
+      ret = libcrun_append_paths (&path, err, CGROUP_ROOT, cgroup_path, "cgroup.freeze", NULL);
       if (UNLIKELY (ret < 0))
         return ret;
     }
   else
     {
       state = pause ? "FROZEN" : "THAWED";
-      ret = append_paths (&path, err, CGROUP_ROOT "/freezer", cgroup_path, "freezer.state", NULL);
+      ret = libcrun_append_paths (&path, err, CGROUP_ROOT "/freezer", cgroup_path, "freezer.state", NULL);
       if (UNLIKELY (ret < 0))
         return ret;
     }
@@ -579,7 +579,7 @@ cgroup_killall_path (const char *path, int signal, libcrun_error_t *err)
     {
       cleanup_free char *kill_file = NULL;
 
-      ret = append_paths (&kill_file, err, CGROUP_ROOT, path, "cgroup.kill", NULL);
+      ret = libcrun_append_paths (&kill_file, err, CGROUP_ROOT, path, "cgroup.kill", NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -798,7 +798,7 @@ enable_controllers (const char *path, libcrun_error_t *err)
 
       *it = '\0';
 
-      ret = append_paths (&cgroup_path, err, CGROUP_ROOT, tmp_path, NULL);
+      ret = libcrun_append_paths (&cgroup_path, err, CGROUP_ROOT, tmp_path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -853,7 +853,7 @@ libcrun_get_cgroup_dirfd (struct libcrun_cgroup_status *status, const char *sub_
   if (is_empty_string (status->path))
     return crun_make_error (err, 0, "no cgroup path specified");
 
-  ret = append_paths (&path_to_cgroup, err, CGROUP_ROOT, status->path, sub_cgroup, NULL);
+  ret = libcrun_append_paths (&path_to_cgroup, err, CGROUP_ROOT, status->path, sub_cgroup, NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -156,7 +156,7 @@ libcrun_cgroup_is_container_paused (struct libcrun_cgroup_status *status, bool *
     {
       state = "1";
 
-      ret = append_paths (&path, err, CGROUP_ROOT, cgroup_path, "cgroup.freeze", NULL);
+      ret = libcrun_append_paths (&path, err, CGROUP_ROOT, cgroup_path, "cgroup.freeze", NULL);
       if (UNLIKELY (ret < 0))
         return ret;
     }
@@ -164,7 +164,7 @@ libcrun_cgroup_is_container_paused (struct libcrun_cgroup_status *status, bool *
     {
       state = "FROZEN";
 
-      ret = append_paths (&path, err, CGROUP_ROOT "/freezer", cgroup_path, "freezer.state", NULL);
+      ret = libcrun_append_paths (&path, err, CGROUP_ROOT "/freezer", cgroup_path, "freezer.state", NULL);
       if (UNLIKELY (ret < 0))
         return ret;
     }
@@ -391,7 +391,7 @@ libcrun_cgroup_has_oom (struct libcrun_cgroup_status *status, libcrun_error_t *e
         cleanup_free char *events_path = NULL;
         int ret;
 
-        ret = append_paths (&events_path, err, CGROUP_ROOT, path, "memory.events", NULL);
+        ret = libcrun_append_paths (&events_path, err, CGROUP_ROOT, path, "memory.events", NULL);
         if (UNLIKELY (ret < 0))
           return ret;
 
@@ -409,7 +409,7 @@ libcrun_cgroup_has_oom (struct libcrun_cgroup_status *status, libcrun_error_t *e
         cleanup_free char *oom_control_path = NULL;
         int ret;
 
-        ret = append_paths (&oom_control_path, err, CGROUP_ROOT, "memory", path, "memory.oom_control", NULL);
+        ret = libcrun_append_paths (&oom_control_path, err, CGROUP_ROOT, "memory", path, "memory.oom_control", NULL);
         if (UNLIKELY (ret < 0))
           return ret;
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1443,7 +1443,7 @@ read_container_config_from_state (libcrun_container_t **container, const char *s
   if (UNLIKELY (dir == NULL))
     return crun_make_error (err, 0, "cannot get state directory from `%s`", state_root);
 
-  ret = append_paths (&config_file, err, dir, "config.json", NULL);
+  ret = libcrun_append_paths (&config_file, err, dir, "config.json", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -1832,7 +1832,7 @@ wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
       if (UNLIKELY (state_root == NULL))
         return crun_make_error (err, 0, "cannot get state directory");
 
-      ret = append_paths (&oci_config_path, err, state_root, "config.json", NULL);
+      ret = libcrun_append_paths (&oci_config_path, err, state_root, "config.json", NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -2038,7 +2038,7 @@ open_seccomp_output (const char *id, int *fd, bool readonly, const char *state_r
   if (UNLIKELY (dir == NULL))
     return crun_make_error (err, 0, "cannot get state directory");
 
-  ret = append_paths (&dest_path, err, dir, "seccomp.bpf", NULL);
+  ret = libcrun_append_paths (&dest_path, err, dir, "seccomp.bpf", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -2485,7 +2485,7 @@ libcrun_copy_config_file (const char *id, const char *state_root, const char *co
   if (UNLIKELY (dir == NULL))
     return crun_make_error (err, 0, "cannot get state directory");
 
-  ret = append_paths (&dest_path, err, dir, "config.json", NULL);
+  ret = libcrun_append_paths (&dest_path, err, dir, "config.json", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -2960,7 +2960,7 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
         goto exit;
       }
 
-    ret = append_paths (&config_file, err, dir, "config.json", NULL);
+    ret = libcrun_append_paths (&config_file, err, dir, "config.json", NULL);
     if (UNLIKELY (ret < 0))
       return ret;
 
@@ -3253,7 +3253,7 @@ libcrun_container_exec_with_options (libcrun_context_t *context, const char *id,
   if (UNLIKELY (dir == NULL))
     return crun_make_error (err, 0, "cannot get state directory");
 
-  ret = append_paths (&config_file, err, dir, "config.json", NULL);
+  ret = libcrun_append_paths (&config_file, err, dir, "config.json", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -137,11 +137,11 @@ restore_cgroup_v1_mount (runtime_spec_schema_config_schema *def, libcrun_error_t
       if (strcmp (subsystem, "cpuacct,cpu") == 0)
         subsystem = "cpu,cpuacct";
 
-      ret = append_paths (&source, err, CGROUP_ROOT, subsystem, NULL);
+      ret = libcrun_append_paths (&source, err, CGROUP_ROOT, subsystem, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
-      ret = append_paths (&destination, err, source, subpath, NULL);
+      ret = libcrun_append_paths (&destination, err, source, subpath, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -204,7 +204,7 @@ checkpoint_cgroup_v1_mount (runtime_spec_schema_config_schema *def, libcrun_erro
       if (strcmp (subsystem, "cpuacct,cpu") == 0)
         subsystem = "cpu,cpuacct";
 
-      ret = append_paths (&source_path, err, CGROUP_ROOT, subsystem, NULL);
+      ret = libcrun_append_paths (&source_path, err, CGROUP_ROOT, subsystem, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -267,7 +267,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
 
   /* descriptors.json is needed during restore to correctly
    * reconnect stdin, stdout, stderr. */
-  ret = append_paths (&descriptors_path, err, cr_options->image_path, DESCRIPTORS_FILENAME, NULL);
+  ret = libcrun_append_paths (&descriptors_path, err, cr_options->image_path, DESCRIPTORS_FILENAME, NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -296,7 +296,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
    * and all of its children. */
   criu_set_pid (status->pid);
 
-  ret = append_paths (&path, err, status->bundle, status->rootfs, NULL);
+  ret = libcrun_append_paths (&path, err, status->bundle, status->rootfs, NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -389,13 +389,13 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   if (cgroup_mode == CGROUP_MODE_UNIFIED)
     {
       /* This needs CRIU 3.14. */
-      ret = append_paths (&freezer_path, err, CGROUP_ROOT, status->cgroup_path, NULL);
+      ret = libcrun_append_paths (&freezer_path, err, CGROUP_ROOT, status->cgroup_path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
     }
   else
     {
-      ret = append_paths (&freezer_path, err, CGROUP_ROOT "/freezer", status->cgroup_path, NULL);
+      ret = libcrun_append_paths (&freezer_path, err, CGROUP_ROOT "/freezer", status->cgroup_path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
     }
@@ -537,7 +537,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
     char err_buffer[256];
     yajl_val tree;
 
-    ret = append_paths (&descriptors_path, err, cr_options->image_path, DESCRIPTORS_FILENAME, NULL);
+    ret = libcrun_append_paths (&descriptors_path, err, cr_options->image_path, DESCRIPTORS_FILENAME, NULL);
     if (UNLIKELY (ret < 0))
       return ret;
 
@@ -616,7 +616,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
     }
 
   /* Mount the container rootfs for CRIU. */
-  ret = append_paths (&root, err, status->bundle, "criu-root", NULL);
+  ret = libcrun_append_paths (&root, err, status->bundle, "criu-root", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/custom-handler.c
+++ b/src/libcrun/custom-handler.c
@@ -64,7 +64,7 @@ struct custom_handler_manager_s
 };
 
 struct custom_handler_manager_s *
-handler_manager_create (libcrun_error_t *err arg_unused)
+libcrun_handler_manager_create (libcrun_error_t *err arg_unused)
 {
   struct custom_handler_s **handlers = NULL;
   void **handles = NULL;
@@ -135,7 +135,7 @@ handler_manager_add_so (struct custom_handler_manager_s *manager, void *handle, 
 #endif
 
 int
-handler_manager_load_from_directory (struct custom_handler_manager_s *manager, const char *path, libcrun_error_t *err)
+libcrun_handler_manager_load_directory (struct custom_handler_manager_s *manager, const char *path, libcrun_error_t *err)
 {
 #ifdef HAVE_DLOPEN
   cleanup_dir DIR *dir = NULL;
@@ -156,7 +156,7 @@ handler_manager_load_from_directory (struct custom_handler_manager_s *manager, c
       if (name[0] == '.')
         continue;
 
-      ret = append_paths (&fpath, err, path, name, NULL);
+      ret = libcrun_append_paths (&fpath, err, path, name, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -189,7 +189,7 @@ handler_by_name (struct custom_handler_manager_s *manager, const char *name)
 }
 
 void
-handler_manager_print_feature_tags (struct custom_handler_manager_s *manager, FILE *out)
+libcrun_handler_manager_print_feature_tags (struct custom_handler_manager_s *manager, FILE *out)
 {
   size_t i;
 

--- a/src/libcrun/custom-handler.h
+++ b/src/libcrun/custom-handler.h
@@ -48,18 +48,18 @@ struct custom_handler_s
 
 struct custom_handler_manager_s;
 
-struct custom_handler_manager_s *handler_manager_create (libcrun_error_t *err);
-int handler_manager_load_from_directory (struct custom_handler_manager_s *manager, const char *path, libcrun_error_t *err);
-void handler_manager_free (struct custom_handler_manager_s *manager);
+LIBCRUN_PUBLIC struct custom_handler_manager_s *libcrun_handler_manager_create (libcrun_error_t *err);
+LIBCRUN_PUBLIC int libcrun_handler_manager_load_directory (struct custom_handler_manager_s *manager, const char *path, libcrun_error_t *err);
+LIBCRUN_PUBLIC void handler_manager_free (struct custom_handler_manager_s *manager);
 
-struct custom_handler_s *handler_by_name (struct custom_handler_manager_s *manager, const char *name);
-void handler_manager_print_feature_tags (struct custom_handler_manager_s *manager, FILE *out);
+LIBCRUN_PUBLIC struct custom_handler_s *handler_by_name (struct custom_handler_manager_s *manager, const char *name);
+LIBCRUN_PUBLIC void libcrun_handler_manager_print_feature_tags (struct custom_handler_manager_s *manager, FILE *out);
 
-int libcrun_configure_handler (struct custom_handler_manager_s *manager,
-                               libcrun_context_t *context,
-                               libcrun_container_t *container,
-                               struct custom_handler_s **out,
-                               void **cookie, libcrun_error_t *err);
+LIBCRUN_PUBLIC int libcrun_configure_handler (struct custom_handler_manager_s *manager,
+                                              libcrun_context_t *context,
+                                              libcrun_container_t *container,
+                                              struct custom_handler_s **out,
+                                              void **cookie, libcrun_error_t *err);
 
 typedef struct custom_handler_s *(*run_oci_get_handler_cb) ();
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -967,7 +967,7 @@ do_mount_cgroup_systemd_v1 (libcrun_container_t *container, const char *source, 
   if (UNLIKELY (fd < 0))
     return crun_make_error (err, errno, "open `%s`", subsystem_path);
 
-  ret = append_paths (&subsystem_path, err, target, subsystem, NULL);
+  ret = libcrun_append_paths (&subsystem_path, err, target, subsystem, NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -1033,7 +1033,7 @@ do_mount_cgroup_v1 (libcrun_container_t *container, const char *source, int targ
       if (strcmp (subsystem, "cpuacct,cpu") == 0)
         subsystem = "cpu,cpuacct";
 
-      ret = append_paths (&source_subsystem, err, CGROUP_ROOT, subsystem, NULL);
+      ret = libcrun_append_paths (&source_subsystem, err, CGROUP_ROOT, subsystem, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -1041,11 +1041,11 @@ do_mount_cgroup_v1 (libcrun_container_t *container, const char *source, int targ
       if (has_mount_for (container, source_subsystem))
         continue;
 
-      ret = append_paths (&source_path, err, source_subsystem, subpath, NULL);
+      ret = libcrun_append_paths (&source_path, err, source_subsystem, subpath, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
-      ret = append_paths (&subsystem_path, err, target, subsystem, NULL);
+      ret = libcrun_append_paths (&subsystem_path, err, target, subsystem, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -1777,7 +1777,7 @@ get_notify_fd (libcrun_context_t *context, libcrun_container_t *container, int *
 
       parent_dir = get_private_data (container)->host_notify_socket_path;
 
-      ret = append_paths (&host_notify_socket_path, err, parent_dir, "notify", NULL);
+      ret = libcrun_append_paths (&host_notify_socket_path, err, parent_dir, "notify", NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -1790,7 +1790,7 @@ get_notify_fd (libcrun_context_t *context, libcrun_container_t *container, int *
     {
       state_dir = libcrun_get_state_directory (context->state_root, context->id);
 
-      ret = append_paths (&host_notify_socket_path, err, state_dir, "notify/notify", NULL);
+      ret = libcrun_append_paths (&host_notify_socket_path, err, state_dir, "notify/notify", NULL);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -1840,11 +1840,11 @@ do_notify_socket (libcrun_container_t *container, const char *rootfs, libcrun_er
   if (notify_socket == NULL)
     return 0;
 
-  ret = append_paths (&container_notify_socket_path, err, rootfs, notify_socket, "notify", NULL);
+  ret = libcrun_append_paths (&container_notify_socket_path, err, rootfs, notify_socket, "notify", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = append_paths (&host_notify_socket_path, err, state_dir, "notify", NULL);
+  ret = libcrun_append_paths (&host_notify_socket_path, err, state_dir, "notify", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -3880,7 +3880,7 @@ join_process_parent_helper (pid_t child_pid, int sync_socket_fd,
         {
           cleanup_free char *final_cgroup = NULL;
 
-          ret = append_paths (&final_cgroup, err, status->cgroup_path, sub_cgroup, NULL);
+          ret = libcrun_append_paths (&final_cgroup, err, status->cgroup_path, sub_cgroup, NULL);
           if (UNLIKELY (ret < 0))
             return ret;
 

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -51,7 +51,7 @@ get_run_directory (const char *state_root)
       const char *runtime_dir = getenv ("XDG_RUNTIME_DIR");
       if (runtime_dir && runtime_dir[0] != '\0')
         {
-          ret = append_paths (&root, &err, runtime_dir, "crun", NULL);
+          ret = libcrun_append_paths (&root, &err, runtime_dir, "crun", NULL);
           if (UNLIKELY (ret < 0))
             {
               crun_error_release (&err);
@@ -76,7 +76,7 @@ libcrun_get_state_directory (const char *state_root, const char *id)
   libcrun_error_t *err = NULL;
   cleanup_free char *root = get_run_directory (state_root);
 
-  ret = append_paths (&path, err, root, id, NULL);
+  ret = libcrun_append_paths (&path, err, root, id, NULL);
   if (UNLIKELY (ret < 0))
     {
       crun_error_release (err);
@@ -94,7 +94,7 @@ get_state_directory_status_file (const char *state_root, const char *id)
   char *path = NULL;
   int ret;
 
-  ret = append_paths (&path, err, root, id, "status", NULL);
+  ret = libcrun_append_paths (&path, err, root, id, "status", NULL);
   if (UNLIKELY (ret < 0))
     {
       crun_error_release (err);
@@ -564,7 +564,7 @@ libcrun_get_containers_list (libcrun_container_list_t **ret, const char *state_r
       if (next->d_name[0] == '.')
         continue;
 
-      r = append_paths (&status_file, err, path, next->d_name, "status", NULL);
+      r = libcrun_append_paths (&status_file, err, path, next->d_name, "status", NULL);
       if (UNLIKELY (r < 0))
         return r;
 
@@ -649,7 +649,7 @@ libcrun_status_create_exec_fifo (const char *state_root, const char *id, libcrun
   cleanup_free char *fifo_path = NULL;
   int ret, fd = -1;
 
-  ret = append_paths (&fifo_path, err, state_dir, "exec.fifo", NULL);
+  ret = libcrun_append_paths (&fifo_path, err, state_dir, "exec.fifo", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -675,7 +675,7 @@ libcrun_status_write_exec_fifo (const char *state_root, const char *id, libcrun_
   cleanup_close int fd = -1;
   int ret;
 
-  ret = append_paths (&fifo_path, err, state_dir, "exec.fifo", NULL);
+  ret = libcrun_append_paths (&fifo_path, err, state_dir, "exec.fifo", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -701,7 +701,7 @@ libcrun_status_has_read_exec_fifo (const char *state_root, const char *id, libcr
   cleanup_free char *fifo_path = NULL;
   int ret;
 
-  ret = append_paths (&fifo_path, err, state_dir, "exec.fifo", NULL);
+  ret = libcrun_append_paths (&fifo_path, err, state_dir, "exec.fifo", NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -2071,7 +2071,7 @@ safe_write (int fd, const void *buf, ssize_t count)
 }
 
 int
-append_paths (char **out, libcrun_error_t *err, ...)
+libcrun_append_paths (char **out, libcrun_error_t *err, ...)
 {
   const size_t MAX_PARTS = 32;
   const char *parts[MAX_PARTS];

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -336,7 +336,7 @@ int safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *p
 
 ssize_t safe_write (int fd, const void *buf, ssize_t count);
 
-int append_paths (char **out, libcrun_error_t *err, ...);
+LIBCRUN_PUBLIC int libcrun_append_paths (char **out, libcrun_error_t *err, ...);
 
 LIBCRUN_PUBLIC int libcrun_str2sig (const char *name);
 

--- a/tests/tests_libcrun_utils.c
+++ b/tests/tests_libcrun_utils.c
@@ -280,7 +280,7 @@ test_path_is_slash_dev ()
 }
 
 static int
-test_append_paths ()
+test_libcrun_append_paths ()
 {
 #define PROLOGUE()               \
   cleanup_free char *out = NULL; \
@@ -299,54 +299,54 @@ test_append_paths ()
   }
   {
     PROLOGUE ();
-    ret = append_paths (&out, &err, "/sys/fs/cgroup/", "memory", "some/path", NULL);
+    ret = libcrun_append_paths (&out, &err, "/sys/fs/cgroup/", "memory", "some/path", NULL);
     EXPECT_STRING ("/sys/fs/cgroup/memory/some/path");
   }
   {
     PROLOGUE ();
-    ret = append_paths (&out, &err, "/sys/fs/cgroup", "memory", "some/path", NULL);
+    ret = libcrun_append_paths (&out, &err, "/sys/fs/cgroup", "memory", "some/path", NULL);
     EXPECT_STRING ("/sys/fs/cgroup/memory/some/path");
   }
   {
     PROLOGUE ();
-    ret = append_paths (&out, &err, "/sys/fs/cgroup////////", "memory////////", "some/path//////", NULL);
+    ret = libcrun_append_paths (&out, &err, "/sys/fs/cgroup////////", "memory////////", "some/path//////", NULL);
     EXPECT_STRING ("/sys/fs/cgroup/memory/some/path");
   }
   {
     PROLOGUE ();
-    ret = append_paths (&out, &err, "/sys/fs/cgroup////////", "memory////////", "///////some/path//////", NULL);
+    ret = libcrun_append_paths (&out, &err, "/sys/fs/cgroup////////", "memory////////", "///////some/path//////", NULL);
     EXPECT_STRING ("/sys/fs/cgroup/memory/some/path");
   }
   {
     PROLOGUE ();
-    ret = append_paths (&out, &err, "", "//", "", "", "", NULL);
+    ret = libcrun_append_paths (&out, &err, "", "//", "", "", "", NULL);
     EXPECT_STRING ("/");
   }
   {
     PROLOGUE ();
-    ret = append_paths (&out, &err, "///", "/", "", "///", "a", NULL);
+    ret = libcrun_append_paths (&out, &err, "///", "/", "", "///", "a", NULL);
     EXPECT_STRING ("/a");
   }
   {
     PROLOGUE ();
-    ret = append_paths (&out, &err, "////", "/////", "///", "", "", NULL);
+    ret = libcrun_append_paths (&out, &err, "////", "/////", "///", "", "", NULL);
     EXPECT_STRING ("/");
   }
   {
     PROLOGUE ();
-    ret = append_paths (&out, &err, "", "", "", "", "", NULL);
+    ret = libcrun_append_paths (&out, &err, "", "", "", "", "", NULL);
     EXPECT_STRING ("");
   }
   {
     PROLOGUE ();
-    ret = append_paths (&out, &err, "", "///sys/fs/cgroup////////", "", "some/path", NULL);
+    ret = libcrun_append_paths (&out, &err, "", "///sys/fs/cgroup////////", "", "some/path", NULL);
     EXPECT_STRING ("/sys/fs/cgroup/some/path");
   }
   {
     PROLOGUE ();
-    ret = append_paths (&out, &err, "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d",
-                        "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d",
-                        "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d", NULL);
+    ret = libcrun_append_paths (&out, &err, "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d",
+                                "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d",
+                                "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d", NULL);
     if (ret == 0)
       return -1;
     crun_error_release (&err);
@@ -433,7 +433,7 @@ main ()
   RUN_TEST (test_dir_p);
   RUN_TEST (test_socket_pair);
   RUN_TEST (test_send_receive_fd);
-  RUN_TEST (test_append_paths);
+  RUN_TEST (test_libcrun_append_paths);
   RUN_TEST (test_path_is_slash_dev);
 #ifdef HAVE_SYSTEMD
   RUN_TEST (test_parse_sd_array);


### PR DESCRIPTION
make public some symbols that are used by crun when compiled with
`--enable-shared`.

Closes: https://github.com/containers/crun/issues/821

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>