### PR TITLE
Revert "oci-validation: checkout last working commit for runtime-tools"

### DIFF
--- a/tests/oci-validation/run-tests.sh
+++ b/tests/oci-validation/run-tests.sh
@@ -26,7 +26,6 @@ export TMPDIR=/var/tmp
 export XDG_RUNTIME_DIR=/run
 
 cd "$GOPATH/src/github.com/opencontainers/runtime-tools"
-make -j "$(nproc)"
 
 # Skip:
 # cgroup tests as they require special configurations on the host
@@ -39,4 +38,7 @@ VALIDATION_TESTS=$(make print-validation-tests | tr ' ' '\n' | grep -Ev "(hooks_
 export VALIDATION_TESTS
 export RUNTIME="/crun/crun"
 
+# Build test binaries
+make -j "$(nproc)" runtimetest validation-executables
+# Run tests
 make localvalidation

--- a/tests/oci-validation/run-tests.sh
+++ b/tests/oci-validation/run-tests.sh
@@ -26,8 +26,6 @@ export TMPDIR=/var/tmp
 export XDG_RUNTIME_DIR=/run
 
 cd "$GOPATH/src/github.com/opencontainers/runtime-tools"
-# TODO: remove this `git magic` once runtime-tools is fixed in upstream
-git reset --hard 98b2d351ae7dd64da7cf6c89cb3f22497863513d
 make -j "$(nproc)"
 
 # Skip:


### PR DESCRIPTION
Since https://github.com/opencontainers/runtime-tools/pull/741 and https://github.com/opencontainers/runtime-tools/pull/742 this is no longer needed.

This reverts commit 6d046d6c4f0e4111e74c2281606863e1c4e1c40d (PR #762).

~~Currently a draft, pending https://github.com/opencontainers/runtime-tools/pull/742 merge.~~