### PR TITLE
gha: simplify deps install

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,21 +76,10 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
 
-    - name: install latest stable docker
-      run: |
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-        sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
-        sudo apt-get update -q -y
-        sudo apt-get install docker-ce
-
     - name: install dependencies
       run: |
-        sudo apt-get update -q -y
-        sudo apt-get install -q -y software-properties-common
-
         sudo add-apt-repository -y ppa:criu/ppa
-        sudo apt-get update -q -y
-
+        # add-apt-repository runs apt-get update so we don't have to.
         sudo apt-get install -q -y criu automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev docker.io containerd runc libasan6 libprotobuf-c-dev
 
         sudo systemctl unmask docker

--- a/tests/podman/run-tests.sh
+++ b/tests/podman/run-tests.sh
@@ -32,8 +32,11 @@ export TMPDIR=/var/tmp
 # - podman run exit 12*|podman run exit code on failure to exec|failed to start
 #   assumption that "create" must fail if the executable is not found.  We must add lookup for the executable in $PATH to mimic the runc behavior.
 #   device-cgroup-rule|capabilities|network|overlay volume flag|prune removes a pod with a stopped container: not working on github actions
+#
+# - Podman run with specified static IPv6 has correct IP
+#   Does not work inside test environment.
 
 
-ginkgo --focus='.*' --skip='.*(selinux|notify_socket|systemd|podman run exit 12*|podman run exit code on failure to exec|failed to start|search|trust|inspect|logs|generate|import|mounted rw|inherit host devices|play kube|cgroups=disabled|privileged CapEff|device-cgroup-rule|capabilities|network|pull from docker|--add-host|removes a pod with a container|prune removes a pod with a stopped container|overlay volume flag|prune unused images|podman images filter|image list filter|create --pull|podman ps json format|using journald for container|image tree|--pull|shared layers|child images|cached images|flag with multiple mounts|overlay and used as workdir|image_copy_tmp_dir).*' \
+ginkgo --focus='.*' --skip='.*(selinux|notify_socket|systemd|podman run exit 12*|podman run exit code on failure to exec|failed to start|search|trust|inspect|logs|generate|import|mounted rw|inherit host devices|play kube|cgroups=disabled|privileged CapEff|device-cgroup-rule|capabilities|network|pull from docker|--add-host|removes a pod with a container|prune removes a pod with a stopped container|overlay volume flag|prune unused images|podman images filter|image list filter|create --pull|podman ps json format|using journald for container|image tree|--pull|shared layers|child images|cached images|flag with multiple mounts|overlay and used as workdir|image_copy_tmp_dir|Podman run with specified static IPv6 has correct IP).*' \
 	 -v -tags "seccomp ostree selinux varlink exclude_graphdriver_devicemapper" \
 	 -timeout=50m -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.


### PR DESCRIPTION
0. tests/podman: exclude --ip6 test case
    
    This test case was recently added by podman commit https://github.com/containers/podman/commit/c496001d03f9eac87dfd6f3.
    It fails in our test environment (probably because of IPv6) and does not
    test crun in any special way.


1. Use docker as bundled with Ubuntu (note that docker.io was already in
   the list of packages to install).

   In fact, the current code installs docker-ce and then replaces it with docker.io:
   ```
   The following packages will be REMOVED:
     containerd.io docker-ce docker-ce-cli
   ```
  
2. Do not install software-properties-common as it's already installed
   (it is needed for add-apt-repository script).

3. Do not run apt-get update as apt-add-repository does that already.