### PR TITLE
windows: use `mono` to run `.NET` based windows `exe` natively on linux.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,7 @@ libcrun_SOURCES = src/libcrun/utils.c \
 			src/libcrun/handlers/handler-utils.c \
 			src/libcrun/handlers/krun.c \
 			src/libcrun/handlers/wasmedge.c \
+			src/libcrun/handlers/mono.c \
 			src/libcrun/handlers/wasmer.c
 
 if HAVE_EMBEDDED_YAJL

--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,21 @@ AS_IF([test "x$enable_dl" != "xno"], [
 	AC_SEARCH_LIBS([dlopen], [dl], [AC_DEFINE([HAVE_DLOPEN], 1, [Define if DLOPEN is available])], [])
 ])
 
+AC_SUBST(MONO_CFLAGS)
+AC_SUBST(MONO_LIBS)
+dnl include support for mono (EXPERIMENTAL)
+AC_ARG_WITH([mono], AS_HELP_STRING([--with-mono], [build with mono support]))
+AS_IF([test "x$with_mono" = "xyes"], [
+	AC_CHECK_HEADERS([mono/metadata/environment.h], [], [AC_MSG_ERROR([*** Missing mono headers1])])
+	AS_IF([test "$ac_cv_header_mono_metadata_environment_h" = "yes"], [
+		AC_SEARCH_LIBS(mono_environment_exitcode_get, [mono-2.0], [AC_DEFINE([HAVE_MONO], 1, [Define if mono is available])], [AC_MSG_ERROR([*** Missing mono headers2])])
+		MONO_CFLAGS=`pkg-config --cflags mono-2`
+		MONO_LIBS=`pkg-config --libs mono-2`
+		CFLAGS="$CFLAGS `pkg-config --cflags mono-2`"
+		LIBS="$LIBS `pkg-config --libs mono-2`"
+	])
+])
+
 dnl include support for wasmer (EXPERIMENTAL)
 AC_ARG_WITH([wasmer], AS_HELP_STRING([--with-wasmer], [build with wasmer support]))
 AS_IF([test "x$with_wasmer" = "xyes"], AC_CHECK_HEADERS([wasmer.h], AC_DEFINE([HAVE_WASMER], 1, [Define if wasmer is available]), [AC_MSG_ERROR([*** Missing wasmer headers])]))

--- a/docs/mono-example.md
+++ b/docs/mono-example.md
@@ -1,0 +1,56 @@
+# mono windows dotnet handler
+* Make sure oci config contains handler for **mono** or image contains annotation **run.oci.handler=dotnet**.
+* Entrypoint must point to a valid **.exe** (windows .NET compatible executable).
+ ```json
+...
+"annotations": {
+  "run.oci.handler": "dotnet"
+},
+...
+```
+
+## Examples
+#### Compile and run `wasm` modules directly
+* Following example is using `mono` to compile a cross platform executable but you can also use visual studio or any other build tools on windows.
+* Add relevant function to `hello.cs` for this example we will be using a print.
+ ```c#
+  using System;
+  using System.Runtime.CompilerServices;
+
+  class MonoEmbed {
+	static int Main ()
+	{
+		System.Console.WriteLine("hello");
+		return 0;
+	}
+  }
+
+```
+* Compile a new `.exe` using `mcs -out:hello.exe hello.cs` if you have `mono` or you can `VisualStudio` or `dotnet build` as specified here: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-build
+* Create relevant image and use your container manager. But for this example we will be running directly using crun and plub config manually.
+```console
+$ crun run container-with-mono
+hello
+```
+
+#### Running OCI `mono` compat images with buildah and podman
+* Compile your `.exe` module using instructions from step one.
+* Prepare a `Containerfile` with your `.exe`.
+ ```Containerfile
+ FROM scratch
+COPY hello.exe /
+CMD ["/hello.exe"]
+ ```
+* Build wasm image using buildah with annotation `run.oci.handler=dotnet`
+```console
+$ buildah build --annotation "run.oci.handler=dotnet" -t my-windows-executable .
+```
+* Make sure your podman points to oci runtime `crun` build with `mono` support.
+* Run image using podman
+```console
+$ podman run --userns=keep-id my-windows-executable:latest
+hello
+```
+
+#### Known-Issues
+* Crun-mono containers needs user namespace for containers so with podman use `--userns=auto` or `--userns=keep-id`.

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -975,11 +975,11 @@ maybe_chown_std_streams (uid_t container_uid, gid_t container_gid,
   return 0;
 }
 
-static inline int
-notify_handler (struct container_entrypoint_s *args,
-                enum handler_configure_phase phase,
-                libcrun_container_t *container, const char *rootfs,
-                libcrun_error_t *err)
+int
+libcrun_container_notify_handler (struct container_entrypoint_s *args,
+                                  enum handler_configure_phase phase,
+                                  libcrun_container_t *container, const char *rootfs,
+                                  libcrun_error_t *err)
 {
   struct custom_handler_s *h = args->custom_handler;
 
@@ -1055,16 +1055,16 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = notify_handler (entrypoint_args, HANDLER_CONFIGURE_BEFORE_MOUNTS, container, rootfs, err);
+  ret = libcrun_container_notify_handler (entrypoint_args, HANDLER_CONFIGURE_BEFORE_MOUNTS, container, rootfs, err);
   if (UNLIKELY (ret < 0))
     return ret;
 
   /* sync 2 and 3 are sent as part of libcrun_set_mounts.  */
-  ret = libcrun_set_mounts (container, rootfs, send_sync_cb, &sync_socket, err);
+  ret = libcrun_set_mounts (entrypoint_args, container, rootfs, send_sync_cb, &sync_socket, err);
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = notify_handler (entrypoint_args, HANDLER_CONFIGURE_AFTER_MOUNTS, container, rootfs, err);
+  ret = libcrun_container_notify_handler (entrypoint_args, HANDLER_CONFIGURE_AFTER_MOUNTS, container, rootfs, err);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -23,6 +23,13 @@
 #include <runtime_spec_schema_config_schema.h>
 #include "error.h"
 
+enum handler_configure_phase
+{
+  HANDLER_CONFIGURE_BEFORE_MOUNTS = 1,
+  HANDLER_CONFIGURE_AFTER_MOUNTS,
+  HANDLER_CONFIGURE_MOUNTS,
+};
+
 struct custom_handler_manager_s;
 
 struct libcrun_context_s
@@ -85,6 +92,8 @@ typedef struct libcrun_container_status_s libcrun_container_status_t;
 typedef struct libcrun_container_s libcrun_container_t;
 typedef struct libcrun_context_s libcrun_context_t;
 
+struct container_entrypoint_s;
+
 struct libcrun_checkpoint_restore_s
 {
   char *image_path;
@@ -127,6 +136,11 @@ LIBCRUN_PUBLIC int libcrun_container_start (libcrun_context_t *context, const ch
 
 LIBCRUN_PUBLIC int libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out,
                                             libcrun_error_t *err);
+
+int libcrun_container_notify_handler (struct container_entrypoint_s *args,
+                                      enum handler_configure_phase phase,
+                                      libcrun_container_t *container, const char *rootfs,
+                                      libcrun_error_t *err);
 
 LIBCRUN_PUBLIC int libcrun_get_container_state_string (const char *id, libcrun_container_status_t *status,
                                                        const char *state_root, const char **container_status,

--- a/src/libcrun/custom-handler.c
+++ b/src/libcrun/custom-handler.c
@@ -42,6 +42,9 @@ extern struct custom_handler_s handler_wasmedge;
 #if HAVE_DLOPEN && HAVE_WASMER
 extern struct custom_handler_s handler_wasmer;
 #endif
+#if HAVE_DLOPEN && HAVE_MONO
+extern struct custom_handler_s handler_mono;
+#endif
 
 static struct custom_handler_s *static_handlers[] = {
 #if HAVE_DLOPEN && HAVE_LIBKRUN
@@ -52,6 +55,9 @@ static struct custom_handler_s *static_handlers[] = {
 #endif
 #if HAVE_DLOPEN && HAVE_WASMER
   &handler_wasmer,
+#endif
+#if HAVE_DLOPEN && HAVE_MONO
+  &handler_mono,
 #endif
   NULL,
 };

--- a/src/libcrun/custom-handler.h
+++ b/src/libcrun/custom-handler.h
@@ -22,12 +22,6 @@
 #include "container.h"
 #include <stdio.h>
 
-enum handler_configure_phase
-{
-  HANDLER_CONFIGURE_BEFORE_MOUNTS = 1,
-  HANDLER_CONFIGURE_AFTER_MOUNTS,
-};
-
 struct custom_handler_s
 {
   const char *name;

--- a/src/libcrun/handlers/mono.c
+++ b/src/libcrun/handlers/mono.c
@@ -1,0 +1,154 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2017, 2018, 2019, 2020, 2021 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#define _GNU_SOURCE
+
+#include <config.h>
+#include "../custom-handler.h"
+#include "../container.h"
+#include "../utils.h"
+#include "../linux.h"
+#include <unistd.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sched.h>
+
+#ifdef HAVE_DLOPEN
+#  include <dlfcn.h>
+#endif
+
+#ifdef HAVE_MONO
+#  include <mono/metadata/environment.h>
+#  include <mono/utils/mono-publib.h>
+#  include <mono/metadata/mono-config.h>
+#  include <mono/jit/jit.h>
+#endif
+
+#if HAVE_DLOPEN && HAVE_MONO
+static int
+mono_exec (void *cookie, libcrun_container_t *container,
+           const char *pathname, char *const argv[])
+{
+  MonoDomain *domain;
+  char *path = (char *) pathname;
+  int argc = 2;
+  char *argv_mono[] = {
+    path,
+    path,
+    NULL
+  };
+  const char *file;
+  int retval;
+
+  file = argv_mono[1];
+
+  MonoAllocatorVTable mem_vtable = { MONO_ALLOCATOR_VTABLE_VERSION, xmalloc, NULL, NULL, NULL };
+  mono_set_allocator_vtable (&mem_vtable);
+
+  /*
+   * Load the default Mono configuration file, this is needed
+   * if you are planning on using the dllmaps defined on the
+   * system configuration
+   */
+  mono_config_parse (NULL);
+  /*
+   * mono_jit_init() creates a domain: each assembly is
+   * loaded and run in a MonoDomain.
+   */
+  domain = mono_jit_init (file);
+
+  /*
+   * We add our special internal call, so that C# code
+   * can call us back.
+   */
+
+  MonoAssembly *assembly;
+  assembly = mono_domain_assembly_open (domain, file);
+  if (! assembly)
+    exit (EXIT_FAILURE);
+  /*
+   * mono_jit_exec() will run the Main() method in the assembly.
+   * The return value needs to be looked up from
+   * System.Environment.ExitCode.
+   */
+  mono_jit_exec (domain, assembly, argc - 1, argv_mono + 1);
+  retval = mono_environment_exitcode_get ();
+  mono_jit_cleanup (domain);
+  return 0;
+}
+
+static int
+mono_load (void **cookie, libcrun_error_t *err arg_unused)
+{
+  void *handle;
+
+  handle = dlopen ("libmono-native.so", RTLD_NOW);
+  if (handle == NULL)
+    return crun_make_error (err, 0, "could not load `libmono-2.0.so`: %s", dlerror ());
+  *cookie = handle;
+
+  return 0;
+}
+
+static int
+mono_configure_container (void *cookie arg_unused, enum handler_configure_phase phase,
+                          libcrun_context_t *context, libcrun_container_t *container,
+                          const char *rootfs, libcrun_error_t *err)
+{
+  /* Any windows library mounts if neccessary */
+  return 0;
+}
+
+static int
+mono_unload (void *cookie, libcrun_error_t *err arg_unused)
+{
+  int r;
+
+  if (cookie)
+    {
+      r = dlclose (cookie);
+      if (UNLIKELY (r < 0))
+        return crun_make_error (err, 0, "could not unload handle: %s", dlerror ());
+    }
+  return 0;
+}
+
+static int
+mono_can_handle_container (libcrun_container_t *container, libcrun_error_t *err arg_unused)
+{
+  const char *annotation;
+
+  annotation = find_annotation (container, "run.oci.handler");
+  if (annotation)
+    return strcmp (annotation, "dotnet") == 0 ? 1 : 0;
+
+  return 0;
+}
+
+struct custom_handler_s handler_mono = {
+  .name = "dotnet",
+  .feature_string = ".NET:mono",
+  .load = mono_load,
+  .unload = mono_unload,
+  .exec_func = mono_exec,
+  .can_handle_container = mono_can_handle_container,
+  .configure_container = mono_configure_container,
+};
+
+#endif

--- a/src/libcrun/handlers/mono.c
+++ b/src/libcrun/handlers/mono.c
@@ -111,7 +111,29 @@ mono_configure_container (void *cookie arg_unused, enum handler_configure_phase 
                           libcrun_context_t *context, libcrun_container_t *container,
                           const char *rootfs, libcrun_error_t *err)
 {
-  /* Any windows library mounts if neccessary */
+  int ret;
+  if (phase != HANDLER_CONFIGURE_MOUNTS)
+    return 0;
+
+  char *options[] = {
+    "ro",
+    "rprivate",
+    "nosuid",
+    "nodev",
+    "rbind"
+  };
+
+  ret = libcrun_container_do_bind_mount (container, "/etc/mono", "/etc/mono", options, 5, err);
+  if (ret != 0)
+    return ret;
+
+  ret = libcrun_container_do_bind_mount (container, "/usr/lib/mono", "/usr/lib/mono", options, 5, err);
+  if (ret != 0)
+    return ret;
+
+  /* release any error if set since we are going to be returning from here */
+  crun_error_release (err);
+
   return 0;
 }
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2236,7 +2236,7 @@ make_parent_mount_private (const char *rootfs, libcrun_error_t *err)
 }
 
 int
-libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, set_mounts_cb_t cb, void *cb_data, libcrun_error_t *err)
+libcrun_set_mounts (struct container_entrypoint_s *entrypoint_args, libcrun_container_t *container, const char *rootfs, set_mounts_cb_t cb, void *cb_data, libcrun_error_t *err)
 {
   runtime_spec_schema_config_schema *def = container->container_def;
   cleanup_free char *unified_cgroup_path = NULL;
@@ -2285,6 +2285,11 @@ libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, set_moun
   get_private_data (container)->rootfs = rootfs;
   get_private_data (container)->rootfsfd = rootfsfd;
   get_private_data (container)->rootfs_len = rootfs ? strlen (rootfs) : 0;
+
+  // configure handler mounts
+  ret = libcrun_container_notify_handler (entrypoint_args, HANDLER_CONFIGURE_MOUNTS, container, rootfs, err);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "failed configuring mounts for handler");
 
   if (def->root->readonly)
     {

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -68,6 +68,7 @@ int libcrun_linux_container_update (libcrun_container_status_t *status, const ch
 int libcrun_create_keyring (const char *name, const char *label, libcrun_error_t *err);
 int libcrun_container_pause_linux (libcrun_container_status_t *status, libcrun_error_t *err);
 int libcrun_container_unpause_linux (libcrun_container_status_t *status, libcrun_error_t *err);
+int libcrun_container_do_bind_mount (libcrun_container_t *container, char *mount_source, char *mount_destination, char **mount_options, size_t mount_options_len, libcrun_error_t *err);
 int libcrun_container_enter_cgroup_ns (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_personality (runtime_spec_schema_defs_linux_personality *p, libcrun_error_t *err);
 int libcrun_configure_network (libcrun_container_t *container, libcrun_error_t *err);

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -46,7 +46,7 @@ pid_t libcrun_run_linux_container (libcrun_container_t *container, container_ent
                                    int *sync_socket_out, libcrun_error_t *err);
 int get_notify_fd (libcrun_context_t *context, libcrun_container_t *container, int *notify_socket_out,
                    libcrun_error_t *err);
-int libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, set_mounts_cb_t cb, void *cb_data, libcrun_error_t *err);
+int libcrun_set_mounts (struct container_entrypoint_s *args, libcrun_container_t *container, const char *rootfs, set_mounts_cb_t cb, void *cb_data, libcrun_error_t *err);
 int libcrun_init_caps (libcrun_error_t *err);
 int libcrun_do_pivot_root (libcrun_container_t *container, bool no_pivot, const char *rootfs, libcrun_error_t *err);
 int libcrun_reopen_dev_null (libcrun_error_t *err);


### PR DESCRIPTION
Allows `crun` to natively run `.net` based `exe` using `mono` as under the hood `.net` runtime.

When built using `mono` following extension allows crun to run scratch based images with windows portable 
executables based on `.NET`  natively on `linux`.

Allows `crun` to run on `linux`.
```Dockerfile
FROM scratch
# Windows compatible `.NET` based executable
COPY hello.exe .
CMD ["/hello.exe"]
```

    
Ref:
https://dotnetfoundation.org/projects/mono
https://wiki.winehq.org/Mono
https://www.mono-project.com/
https://en.wikipedia.org/wiki/Mono_(software)

-- Draft till --

- [ ] (Add docs)
- [ ] (Add tryout example)
- [ ] (`dlopen` alternative to load windows dll)

