### PR TITLE
utils: drop check for invalid path

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -466,12 +466,6 @@ crun_safe_ensure_at (bool do_open, bool dir, int dirfd, const char *dirpath,
 
   npath = xstrdup (path);
 
-  it = npath + strlen (npath) - 1;
-  while (*it == '/' && it > npath && ((size_t) (it - npath)) > dirpath_len)
-    *it-- = '\0';
-  if (((size_t) (it - npath)) == dirpath_len)
-    return crun_make_error (err, 0, "invalid path `%s`", path);
-
   cwd = dirfd;
   cur = npath;
   it = strchr (npath, '/');


### PR DESCRIPTION
it has already caused an issue in the past and it doesn't add any
value, since each component in the path is validated again later on.

Closes: https://github.com/containers/crun/issues/842

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>