### PR TITLE
tests/fuzzing/run-tests.sh: fix flaking

### DIFF
--- a/tests/fuzzing/run-tests.sh
+++ b/tests/fuzzing/run-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -xeuo pipefail
+set -xeu
 
 TIMEOUT=${TIMEOUT:=10}
 RUN_TIME=${RUN_TIME:=600}


### PR DESCRIPTION
This (hopefully) fixes a flake seen in https://github.com/containers/crun/pull/843.

Recent commit ff3e33b95eba65f5cea89e9070ca1677a0a953d7 removed subshell
from grep invocation, but overlooked the fact that pipefail option is
also set. As a result, we get an occasional exit code 141 (i.e. SIGPIPE)
from the script (which was prevented by having a subshell).

Since this grep is the only pipe in the script, and we're looking at the
exit code from grep, remove "-o pipefail" from it.