### PR TITLE
container: attempt find_executable after setresuid                                                                                      

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -993,7 +993,7 @@ notify_handler (struct container_entrypoint_s *args,
    It is used by the container init process.  */
 static int
 container_init_setup (void *args, pid_t own_pid, char *notify_socket,
-                      int sync_socket, const char **exec_path, libcrun_error_t *err)
+                      int sync_socket, char **exec_path, libcrun_error_t *err)
 {
   struct container_entrypoint_s *entrypoint_args = args;
   libcrun_container_t *container = entrypoint_args->container;
@@ -1286,7 +1286,7 @@ container_init (void *args, char *notify_socket, int sync_socket, libcrun_error_
   struct container_entrypoint_s *entrypoint_args = args;
   int ret;
   runtime_spec_schema_config_schema *def = entrypoint_args->container->container_def;
-  cleanup_free const char *exec_path = NULL;
+  cleanup_free char *exec_path = NULL;
   __attribute__ ((unused)) cleanup_free char *notify_socket_cleanup = notify_socket;
   pid_t own_pid = 0;
 
@@ -3062,7 +3062,7 @@ exec_process_entrypoint (libcrun_context_t *context,
                          libcrun_error_t *err)
 {
   runtime_spec_schema_config_schema_process_capabilities *capabilities = NULL;
-  cleanup_free const char *exec_path = NULL;
+  cleanup_free char *exec_path = NULL;
   uid_t container_uid;
   gid_t container_gid;
   const char *cwd;

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1680,7 +1680,7 @@ check_access (const char *path)
   return 0;
 }
 
-const char *
+char *
 find_executable (const char *executable_path, const char *cwd)
 {
   cleanup_free char *cwd_executable_path = NULL;

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -310,7 +310,7 @@ int parse_json_file (yajl_val *out, const char *jsondata, struct parser_context 
 
 int has_prefix (const char *str, const char *prefix);
 
-const char *find_executable (const char *executable_path, const char *cwd);
+char *find_executable (const char *executable_path, const char *cwd);
 
 int copy_recursive_fd_to_fd (int srcfd, int destfd, const char *srcname, const char *destname, libcrun_error_t *err);
 


### PR DESCRIPTION
if the find_executable() call fails when running with EUID=0, ignore any error beside ENOENT and attempt again the lookup once the process switched to the final UID/GID used in the container.                                                                                    

This is visible on network file systems like NFS, where CAP_DAC_OVERRIDE is not honored and the EUID=0 cannot read a file if it is owned by the UID/GID in the container.                                                                                            

It is the same mechanism we already have in place for chdir() that might fail before the setresuid() call.                                                                                                 
                                                   
Closes: https://github.com/containers/crun/issues/852                                                               

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>