### PR TITLE
linux: create_missing_devs creates /dev/console

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -614,10 +614,8 @@ crun_ensure_file_at (int dirfd, const char *path, int mode, bool nofollow, libcr
       if (UNLIKELY (ret < 0))
         return ret;
       *it = '/';
-
-      return create_file_if_missing_at (dirfd, tmp, err);
     }
-  return 0;
+  return create_file_if_missing_at (dirfd, tmp, err);
 }
 
 int


### PR DESCRIPTION
move the creation of /dev/console to create_missing_devs so that it is performed before setting /dev read-only if configured in the OCI spec file.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
