### PR TITLE
Fix compilation error with seccomp

### DIFF
--- a/tests/init.c
+++ b/tests/init.c
@@ -49,6 +49,10 @@
 #    define SECCOMP_SET_MODE_FILTER 1
 #  endif
 
+#ifndef __NR_seccomp
+#  define __NR_seccomp 0xffff // seccomp syscall number unknown for this architecture
+#endif
+
 #endif
 
 #ifdef HAVE_ERROR_H


### PR DESCRIPTION
On some kernels the seccomp syscall version is not known. Add missing define for this value in the tests (already exists elsewhere in the code)