### PR TITLE
cgroup-destroy: terminate destroy loop and relay error back to caller

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -141,6 +141,7 @@ TESTS = tests/test_capabilities.py \
 	tests/test_hooks.py \
 	tests/test_update.py \
 	tests/test_detach.py \
+	tests/test_delete.py \
 	tests/test_resources.py \
 	tests/test_start.py \
 	tests/test_exec.py \

--- a/src/libcrun/cgroup-cgroupfs.c
+++ b/src/libcrun/cgroup-cgroupfs.c
@@ -106,11 +106,7 @@ libcrun_destroy_cgroup_cgroupfs (struct libcrun_cgroup_status *cgroup_status,
   if (UNLIKELY (ret < 0))
     crun_error_release (err);
 
-  ret = destroy_cgroup_path (cgroup_status->path, mode, err);
-  if (UNLIKELY (ret < 0))
-    crun_error_release (err);
-
-  return 0;
+  return destroy_cgroup_path (cgroup_status->path, mode, err);
 }
 
 struct libcrun_cgroup_manager cgroup_manager_cgroupfs = {

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -950,11 +950,7 @@ libcrun_destroy_cgroup_systemd (struct libcrun_cgroup_status *cgroup_status,
   if (UNLIKELY (ret < 0))
     crun_error_release (err);
 
-  ret = destroy_cgroup_path (cgroup_status->path, mode, err);
-  if (UNLIKELY (ret < 0))
-    crun_error_release (err);
-
-  return 0;
+  return destroy_cgroup_path (cgroup_status->path, mode, err);
 }
 
 static int

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -459,7 +459,7 @@ destroy_cgroup_path (const char *path, int mode, libcrun_error_t *err)
         {
           struct timespec req = {
             .tv_sec = 0,
-            .tv_nsec = 100000,
+            .tv_nsec = 10000000,
           };
 
           nanosleep (&req, NULL);

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -241,7 +241,10 @@ rmdir_all_fd (int dfd)
 
   dir = fdopendir (dfd);
   if (dir == NULL)
-    return -1;
+    {
+      TEMP_FAILURE_RETRY (close (dfd));
+      return -1;
+    }
 
   dfd = dirfd (dir);
 
@@ -265,6 +268,7 @@ rmdir_all_fd (int dfd)
           libcrun_error_t tmp_err = NULL;
           size_t i, n_pids = 0, allocated = 0;
           cleanup_close int child_dfd = -1;
+          int tmp;
           int child_dfd_clone;
 
           child_dfd = openat (dfd, name, O_DIRECTORY | O_CLOEXEC);
@@ -286,7 +290,9 @@ rmdir_all_fd (int dfd)
           for (i = 0; i < n_pids; i++)
             kill (pids[i], SIGKILL);
 
-          return rmdir_all_fd (child_dfd);
+          tmp = child_dfd;
+          child_dfd = -1;
+          return rmdir_all_fd (tmp);
         }
     }
   return 0;
@@ -296,7 +302,7 @@ static int
 rmdir_all (const char *path)
 {
   int ret;
-  cleanup_close int dfd = open (path, O_DIRECTORY | O_CLOEXEC);
+  int dfd = open (path, O_DIRECTORY | O_CLOEXEC);
   if (UNLIKELY (dfd < 0))
     return dfd;
 

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -199,11 +199,7 @@ libcrun_cgroup_destroy (struct libcrun_cgroup_status *cgroup_status, libcrun_err
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = cgroup_manager->destroy_cgroup (cgroup_status, err);
-  if (UNLIKELY (ret < 0))
-    crun_error_release (err);
-
-  return 0;
+  return cgroup_manager->destroy_cgroup (cgroup_status, err);
 }
 
 int

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,60 @@
+#!/bin/env python3
+# crun - OCI runtime written in C
+#
+# Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+# crun is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# crun is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with crun.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import subprocess
+import os
+from tests_utils import *
+
+def test_simple_delete():
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'pause']
+    add_all_namespaces(conf)
+
+    out, container_id = run_and_get_output(conf, detach=True, hide_stderr=True)
+    if out != "":
+        return -1
+    try:
+        state = json.loads(run_crun_command(["state", container_id]))
+        if state['status'] != "running":
+            return -1
+        if state['id'] != container_id:
+            return -1
+    finally:
+        freezerCreated=False
+        if not os.path.exists("/sys/fs/cgroup/cgroup.controllers") and os.access('/sys/fs/cgroup/freezer/', os.W_OK):
+            # cgroupv1 freezer can easily simulate stuck or breaking `crun delete -f <cid>`
+            # this should be only done on cgroupv1 systems
+            if not os.path.exists("/sys/fs/cgroup/freezer/frozen/"):
+                freezerCreated=True
+                os.makedirs("/sys/fs/cgroup/freezer/frozen/")
+            with open('/sys/fs/cgroup/freezer/frozen/tasks', 'w') as f:
+                f.write(str(state['pid']))
+            with open('/sys/fs/cgroup/freezer/frozen/freezer.state', 'w') as f:
+                f.write('FROZEN')
+        run_crun_command(["delete", "-f", container_id])
+        if freezerCreated:
+            os.rmdir("/sys/fs/cgroup/freezer/frozen/")
+    return 0
+
+all_tests = {
+    "test_simple_delete" : test_simple_delete,
+}
+
+if __name__ == "__main__":
+    tests_main(all_tests)
+


### PR DESCRIPTION
Following commit makes sure that we terminate the destroy cgroup loop if in
case we ever fail to destroy the cgroup for N number of times and relay
a error back to caller function.

Closes: https://github.com/containers/crun/issues/868