### PR TITLE
Remove ignored arguments

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -779,7 +779,7 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
 
               if (ret > 0)
                 {
-                  ret = mount ("/sys", real_target, "/sys", MS_BIND | MS_REC | MS_SLAVE, data);
+                  ret = mount ("/sys", real_target, NULL, MS_BIND | MS_REC, NULL);
                   if (LIKELY (ret == 0))
                     return 0;
                 }


### PR DESCRIPTION
According to man pages of `mount` syscall:
"If mountflags includes MS_BIND ... The filesystemtype and data arguments are ignored. ... The remaining bits (other than MS_REC, described below) in the mountflags argument are also ignored."
