### PR TITLE
test, container-delete: ignore known `EBUSY` warning for cgroupv1 when process is `freezed`

### DIFF
--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -46,7 +46,21 @@ def test_simple_delete():
                 f.write(str(state['pid']))
             with open('/sys/fs/cgroup/freezer/frozen/freezer.state', 'w') as f:
                 f.write('FROZEN')
-        run_crun_command(["delete", "-f", container_id])
+        try:
+            output = run_crun_command_raw(["delete", "-f", container_id])
+        except subprocess.CalledProcessError as exc:
+            print("Status : FAIL", exc.returncode, exc.output)
+            return -1
+        else:
+            # this is expected for cgroup v1 so ignore
+            if not output or b'Device or resource busy' in output:
+                # if output is empty or expected error pass
+                pass
+            else:
+                # anything else is error
+                print(output)
+                return -1
+
         if freezerCreated:
             os.rmdir("/sys/fs/cgroup/freezer/frozen/")
     return 0

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -283,6 +283,13 @@ def run_crun_command(args):
     args = [crun, "--root", root] + args
     return subprocess.check_output(args, close_fds=False).decode()
 
+# Similar as run_crun_command but does not performs decode of output and relays error message for further matching
+def run_crun_command_raw(args):
+    root = get_tests_root_status()
+    crun = get_crun_path()
+    args = [crun, "--root", root] + args
+    return subprocess.check_output(args, close_fds=False, stderr=subprocess.STDOUT)
+
 def running_on_systemd():
     with open('/proc/1/comm') as f:
         return "systemd" in f.readline()


### PR DESCRIPTION
Its a feature of crun to throw warnings when cgroup cleanup fails, and
currently cgroup delete test is testing that feature however CI will
fail on error/warning so filter out known expected warning and only fail if error
is unknown.