### PR TITLE
build: fix bashism in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ case "${enableval}" in
 	*) AC_MSG_ERROR(bad value ${enableval} for --enable-embedded-yajl) ;;
 esac],[embedded_yajl=false])
 
-AM_CONDITIONAL([HAVE_EMBEDDED_YAJL], [test x"$embedded_yajl" == xtrue])
+AM_CONDITIONAL([HAVE_EMBEDDED_YAJL], [test x"$embedded_yajl" = xtrue])
 AM_COND_IF([HAVE_EMBEDDED_YAJL], [], [
 AC_SEARCH_LIBS(yajl_tree_get, [yajl], [AC_DEFINE([HAVE_YAJL], 1, [Define if libyajl is available])], [AC_MSG_ERROR([*** libyajl headers not found])])
 PKG_CHECK_MODULES([YAJL], [yajl >= 2.0.0])


### PR DESCRIPTION
configure scripts need to be usable with a POSIX-compliant /bin/sh
(like e.g. 'dash', which is the default provider of /bin/sh on Debian).

This has no effect on bash compatibility and will continue to work
with bash.

Signed-off-by: Sam James <sam@gentoo.org>