### PR TITLE
linux: resolve symlinks in bind mounts

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -419,7 +419,7 @@ get_bind_mount (const char *src, libcrun_error_t *err)
   int ret;
 
   open_tree_fd = syscall_open_tree (-1, src,
-                                    AT_NO_AUTOMOUNT | AT_SYMLINK_NOFOLLOW | OPEN_TREE_CLOEXEC | OPEN_TREE_CLONE);
+                                    AT_NO_AUTOMOUNT | OPEN_TREE_CLOEXEC | OPEN_TREE_CLONE);
   if (UNLIKELY (open_tree_fd < 0))
     return crun_make_error (err, errno, "open `%s`", src);
 


### PR DESCRIPTION
when opening a bind mount from the host, resolve the symlink instead
of using the symlink itself as the source.

commit bb5bc67d97379293c0f425b6c7b15c276ccbbeec  introduced this regression.

issue reproducible with:

$ ls -l /usr/libexec/podman/catatonit
lrwxrwxrwx. 1 root root 32 Nov  8 15:35 /usr/libexec/podman/catatonit -> /usr/libexec/catatonit/catatonit
    
$ sudo podman run --rm --init --uidmap 0:100000:1024 centos true
Error: /usr/bin/crun: executable file `/dev/init` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>