### PR TITLE
git-version-gen: fix version comparison

### DIFF
--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Print a version string.
-scriptversion=2018-03-07.03; # UTC
+scriptversion=2022-03-25.09; # UTC
 
 # Copyright (C) 2007-2019 Free Software Foundation, Inc.
 #
@@ -186,7 +186,9 @@ then
 
     # Change the penultimate "-" to ".", for version-comparing tools.
     # Remove the "g" to save a byte.
-    v=`echo "$v" | sed 's/-\([^-]*\)-g\([^-]*\)$/.\1-\2/'`;
+    # Prepend a bunch of '.0', so that the version comparison doesn't
+    # conflict with a released version.
+    v=`echo "$v" | sed 's/-\([^-]*\)-g\([^-]*\)$/.0.0.0.\1-\2/'`;
     v_from_git=1
 elif test "x$fallback" = x || git --version >/dev/null 2>&1; then
     v=UNKNOWN


### PR DESCRIPTION
prepend a bunch of .0 when creating a version string for the current
git working tree, so that it doesn't conflict with a future release.

e.g. now it generates "1.4.4.0.0.0.4-9421" instead of "1.4.4.4-9421"
so it will compare <= than a future release 1.4.4.4.

Closes: https://github.com/containers/crun/issues/864

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>