### PR TITLE
docs: fix dependencies on RHEL/CentOS 8 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ sudo dnf install -y make python git gcc automake autoconf libcap-devel \
 $ sudo yum --enablerepo='*' --disablerepo='media-*' install -y make automake \
     autoconf gettext \
     libtool gcc libcap-devel systemd-devel yajl-devel \
-    libseccomp-devel python36 git
+    glibc-static libseccomp-devel python36 git
 ```
 
 go-md2man is not available on RHEL/CentOS 8, so if you'd like to build


### PR DESCRIPTION
The glibc-static package is required by RHEL system, if not, it will hit
error like this 'exec container process (missing dynamic library?) `/init`:
No such file or directory\n' when running tests with make check-TESTS.

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>