### PR TITLE
criu: add support for different manage cgroups modes

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -446,6 +446,11 @@ the pre-dump. It is important to use a relative path from the actual
 checkpoint directory specified via \fB--image-path\fP\&. It will fail
 if an absolute path is used.
 
+.PP
+\fB--manage-cgroups-mode\fP=\fIMODE\fP
+Specify which CRIU mange cgroup mode should be used. Permitted values are
+\fBsoft\fP, \fBignore\fP, \fBfull\fP or \fBstrict\fP\&. Default is \fBsoft\fP\&.
+
 .SH RESTORE OPTIONS
 .PP
 crun [global options] restore [options] CONTAINER
@@ -481,6 +486,11 @@ Detach from the container's process
 .PP
 \fB--pid-file\fP=\fIFILE\fP
 Where to write the PID of the container
+
+.PP
+\fB--manage-cgroups-mode\fP=\fIMODE\fP
+Specify which CRIU mange cgroup mode should be used. Permitted values are
+\fBsoft\fP, \fBignore\fP, \fBfull\fP or \fBstrict\fP\&. Default is \fBsoft\fP\&.
 
 
 .SH Extensions to OCI

--- a/crun.1.md
+++ b/crun.1.md
@@ -351,6 +351,10 @@ the pre-dump. It is important to use a relative path from the actual
 checkpoint directory specified via **--image-path**. It will fail
 if an absolute path is used.
 
+**--manage-cgroups-mode**=_MODE_
+Specify which CRIU manage cgroup mode should be used. Permitted values are
+**soft**, **ignore**, **full** or **strict**. Default is **soft**.
+
 ## RESTORE OPTIONS
 
 crun [global options] restore [options] CONTAINER
@@ -378,6 +382,10 @@ Detach from the container's process
 
 **--pid-file**=_FILE_
 Where to write the PID of the container
+
+**--manage-cgroups-mode**=_MODE_
+Specify which CRIU manage cgroup mode should be used. Permitted values are
+**soft**, **ignore**, **full** or **strict**. Default is **soft**.
 
 # Extensions to OCI
 

--- a/src/checkpoint.h
+++ b/src/checkpoint.h
@@ -20,6 +20,7 @@
 
 #include "crun.h"
 
+int crun_parse_manage_cgroups_mode (char *param);
 int crun_command_checkpoint (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *error);
 
 #endif

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -98,6 +98,7 @@ struct libcrun_checkpoint_restore_s
   const char *console_socket;
   char *parent_path;
   bool pre_dump;
+  int manage_cgroups_mode;
 };
 typedef struct libcrun_checkpoint_restore_s libcrun_checkpoint_restore_t;
 

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -488,6 +488,11 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   criu_set_tcp_established (cr_options->tcp_established);
   criu_set_file_locks (cr_options->file_locks);
   criu_set_orphan_pts_master (true);
+  if (cr_options->manage_cgroups_mode == -1)
+    /* Defaulting to CRIU_CG_MODE_SOFT just as runc */
+    criu_set_manage_cgroups_mode (CRIU_CG_MODE_SOFT);
+  else
+    criu_set_manage_cgroups_mode (cr_options->manage_cgroups_mode);
   criu_set_manage_cgroups (true);
 
   ret = criu_dump ();

--- a/src/restore.c
+++ b/src/restore.c
@@ -28,6 +28,7 @@
 #include <regex.h>
 
 #include "crun.h"
+#include "checkpoint.h"
 #include "libcrun/container.h"
 #include "libcrun/status.h"
 #include "libcrun/utils.h"
@@ -42,6 +43,7 @@ enum
   OPTION_PID_FILE,
   OPTION_CONSOLE_SOCKET,
   OPTION_FILE_LOCKS,
+  OPTION_MANAGE_CGROUPS_MODE,
 };
 
 static char doc[] = "OCI runtime";
@@ -64,6 +66,7 @@ static struct argp_option options[]
         { "console-socket", OPTION_CONSOLE_SOCKET, "SOCKET", 0,
           "path to a socket that will receive the master end of the tty", 0 },
         { "file-locks", OPTION_FILE_LOCKS, 0, 0, "allow file locks", 0 },
+        { "manage-cgroups-mode", OPTION_MANAGE_CGROUPS_MODE, "MODE", 0, "cgroups mode: 'soft' (default), 'ignore', 'full' and 'strict'", 0 },
         {
             0,
         } };
@@ -116,6 +119,10 @@ parse_opt (int key, char *arg arg_unused, struct argp_state *state arg_unused)
 
     case OPTION_PID_FILE:
       crun_context.pid_file = argp_mandatory_argument (arg, state);
+      break;
+
+    case OPTION_MANAGE_CGROUPS_MODE:
+      cr_options.manage_cgroups_mode = crun_parse_manage_cgroups_mode (argp_mandatory_argument (arg, state));
       break;
 
     default:


### PR DESCRIPTION
This is motivated by checkpoint errors of containers restored with a new ID in Podman.

Restoring a container with a new name and ID will result in a new cgroup assigned to the container. Unfortunately CRIU restores information about the original cgroup name. Now the container is running in one cgroup but partially has still old cgroup information tied to it.

This adds `--manage-cgroups-mode=ignore'` to crun which allows crun to tell CRIU to completely ignore anything concerning cgroups.

With this change it is possible to checkpoint and restore a container multiple times with changing names and IDs.