### PR TITLE
libcrun: fix typo

### DIFF
--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -689,7 +689,7 @@ libcrun_status_write_exec_fifo (const char *state_root, const char *id, libcrun_
 
   ret = TEMP_FAILURE_RETRY (write (fd, buffer, 1));
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "read from exec.fifo");
+    return crun_make_error (err, errno, "write to exec.fifo");
 
   return strtoll (buffer, NULL, 10);
 }


### PR DESCRIPTION
I don't get the meaning of error message here.
I found when this line of code written, it was in a function called `libcrun_status_read_exec_fifo`, which really read from a fifo,
but now this function is writting data to `exec.fifo`. Should we update the message? 