### PR TITLE
linux: hooks inherit env if not specified

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,16 +11,20 @@ jobs:
       matrix:
         include:
           - arch: armv7
-            distro: ubuntu20.04
+            distro: ubuntu_latest
           - arch: aarch64
-            distro: ubuntu20.04
+            distro: ubuntu_latest
           - arch: s390x
-            distro: ubuntu20.04
+            distro: ubuntu_latest
           - arch: ppc64le
-            distro: ubuntu20.04
+            distro: ubuntu_latest
     steps:
-      - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: actions/checkout@v3.0.2
+        with:
+          submodules: true
+          set-safe-directory: true
+
+      - uses: uraimo/run-on-arch-action@v2.2.0
         name: Build
         id: build
         with:
@@ -34,6 +38,7 @@ jobs:
             apt-get install -q -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev libprotobuf-c-dev
 
           run: |
+            find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;
             ./autogen.sh
             ./configure CFLAGS='-Wall -Werror'
             make -j $(nproc) -C libocispec libocispec.la
@@ -87,6 +92,7 @@ jobs:
     - name: run autogen.sh
       run: |
         git clean -fdx .
+        find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;
         ./autogen.sh
 
     - name: run test
@@ -190,6 +196,7 @@ jobs:
       - uses: lumaxis/shellcheck-problem-matchers@v1
       - name: shellcheck
         run: |
+          find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;
           ./autogen.sh
           ./configure
           make shellcheck

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These dependencies are required for the build:
 
 ```console
 $ sudo dnf install -y make python git gcc automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel \
+    systemd-devel yajl-devel libseccomp-devel pkg-config \
     go-md2man glibc-static python3-libmount libtool
 ```
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -711,7 +711,12 @@ do_hooks (runtime_spec_schema_config_schema *def, pid_t pid, const char *id, boo
 
   for (i = 0; i < hooks_len; i++)
     {
-      ret = run_process_with_stdin_timeout_envp (hooks[i]->path, hooks[i]->args, cwd, hooks[i]->timeout, hooks[i]->env,
+      char **env = environ;
+
+      if (hooks[i]->env)
+        env = hooks[i]->env;
+
+      ret = run_process_with_stdin_timeout_envp (hooks[i]->path, hooks[i]->args, cwd, hooks[i]->timeout, env,
                                                  stdin, stdin_len, out_fd, err_fd, err);
       if (UNLIKELY (ret != 0))
         {

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with crun.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 from tests_utils import *
 
 def test_fail_prestart():
@@ -37,9 +38,40 @@ def test_success_prestart():
         return -1
     return 0
 
+def test_hook_env_inherit():
+    conf = base_config()
+    path = os.getenv("PATH")
+
+    hook = {"path" : "/bin/sh", "args" : ["/bin/sh", "-c", "test \"$PATH\" = %s" % path]}
+    conf['hooks'] = {"prestart" : [hook]}
+
+    add_all_namespaces(conf)
+    print(conf['hooks'])
+    try:
+        out, _ = run_and_get_output(conf)
+    except:
+        return -1
+    return 0
+
+def test_hook_env_no_inherit():
+    conf = base_config()
+
+    hook = {"path" : "/bin/sh", "env": ["PATH=/foo"], "args" : ["/bin/sh", "-c", "/bin/test \"$PATH\" == '/foo'"]}
+    conf['hooks'] = {"prestart" : [hook]}
+
+    add_all_namespaces(conf)
+    print(conf['hooks'])
+    try:
+        out, _ = run_and_get_output(conf)
+    except:
+        return -1
+    return 0
+
 all_tests = {
     "test-fail-prestart" : test_fail_prestart,
     "test-success-prestart" : test_success_prestart,
+    "test-hook-env-inherit" : test_hook_env_inherit,
+    "test-hook-env-no-inherit" : test_hook_env_no_inherit,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
if the hook doesn't specify an env block, then inherit it from the
current process.

Closes: https://github.com/containers/crun/issues/906

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>