### PR TITLE
podman, tests: change default `log-driver` to `k8s-file` instead of `journald`

### DIFF
--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -16,6 +16,8 @@ RUN yum install -y golang python git gcc automake autoconf libcap-devel \
      make install.catatonit && \
      make)
 
+## Change default log driver to k8s-file for tests
+RUN sed -i 's/journald/k8s-file/g' /usr/share/containers/containers.conf
 COPY run-tests.sh /usr/local/bin
 WORKDIR /root/go/src/github.com/containers/podman
 ENTRYPOINT /usr/local/bin/run-tests.sh


### PR DESCRIPTION
Change default log-driver in tests from `journald` to `k8s-file` since
crun tests does not directly exercises `journald` hence its easier to
maintain and run tests without `journald` setup inside container tests.