### PR TITLE
linux: create missing cwd

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2286,6 +2286,16 @@ libcrun_set_mounts (libcrun_container_t *container, const char *rootfs, set_moun
   if (UNLIKELY (ret < 0))
     return ret;
 
+  if (def->process && def->process->cwd)
+    {
+      libcrun_error_t tmp_err = NULL;
+      const char *rel_cwd = consume_slashes (def->process->cwd);
+      /* Ignore errors here and let it fail later.  */
+      (void) crun_safe_ensure_directory_at (rootfsfd, rootfs, strlen (rootfs),
+                                            rel_cwd, 0755, &tmp_err);
+      crun_error_release (&tmp_err);
+    }
+
   ret = do_masked_and_readonly_paths (container, err);
   if (UNLIKELY (ret < 0))
     return ret;

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -50,6 +50,17 @@ def test_cwd_relative_subdir():
         return -1
     return 0
 
+def test_cwd_not_exist():
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'true']
+    conf['process']['cwd'] = "/doesnotexist"
+    add_all_namespaces(conf)
+    try:
+        run_and_get_output(conf)
+    except:
+        return -1
+    return 0
+
 def test_cwd_absolute():
     conf = base_config()
     conf['process']['args'] = ['/init', 'echo', 'hello']
@@ -463,6 +474,7 @@ all_tests = {
     "cwd-relative": test_cwd_relative,
     "cwd-relative-subdir": test_cwd_relative_subdir,
     "cwd-absolute": test_cwd_absolute,
+    "cwd-not-exist" : test_cwd_not_exist,
     "empty-home": test_empty_home,
     "delete-in-created-state": test_delete_in_created_state,
     "run-rootless-netns-with-userns" : test_run_rootless_netns_with_userns,


### PR DESCRIPTION
attempt to create the specified working directory if it doesn't exist
already.

We had this logic to detect typos when launching Podman containers,
but since Podman now checks that the cwd exists, we do not need
anymore to keep the old behavior but follow what runc does.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>