### PR TITLE
cgroup: remove tun/tap from the default allow list

### DIFF
--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -417,7 +417,6 @@ write_devices_resources_v1 (int dirfd, runtime_spec_schema_defs_linux_device_cgr
     "c 5:1 rwm",
     "c 136:* rwm",
     "c 5:2 rwm",
-    "c 10:200 rwm",
     NULL
   };
 
@@ -495,7 +494,6 @@ write_devices_resources_v2_internal (int dirfd, runtime_spec_schema_defs_linux_d
     { 'c', 5, 1, "rwm" },
     { 'c', 136, -1, "rwm" },
     { 'c', 5, 2, "rwm" },
-    { 'c', 10, 200, "rwm" },
   };
 
   program = bpf_program_new (2048);


### PR DESCRIPTION
For some reason, access to /dev/net/tun was enabled by the default
built-in ruleset in runc since its very inception.

Obviously, a container should not have access to tun/tap device, unless
it is explicitly specified in configuration.

Now, removing this might create a compatibility issue, but I see no
other choice.

Similar PR for runc: https://github.com/opencontainers/runc/pull/3468
(I guess it makes sense to wait until that one is merged).