### PR TITLE
test: set `/crun` as safe directory on containers running the tests

### DIFF
--- a/tests/clang-check/run-tests.sh
+++ b/tests/clang-check/run-tests.sh
@@ -3,6 +3,7 @@
 set -e
 cd /crun
 
+git config --global --add safe.directory /crun
 git clean -fdx
 ./autogen.sh
 ./configure CFLAGS='-Wall -Wextra -Werror' CC=clang

--- a/tests/cri-o/run-tests.sh
+++ b/tests/cri-o/run-tests.sh
@@ -8,6 +8,7 @@ set -e
 
 (
 cd /crun
+git config --global --add safe.directory /crun
 git clean -fdx
 ./autogen.sh
 ./configure CFLAGS='-Wall -Wextra -Werror' --prefix=/usr

--- a/tests/fuzzing/run-tests.sh
+++ b/tests/fuzzing/run-tests.sh
@@ -12,6 +12,7 @@ SINGLE_RUN_TIME=$(( RUN_TIME / N_TESTS ))
 
 CORPUS=${CORPUS:=/testcases}
 
+git config --global --add safe.directory /crun
 git clean -fdx
 ./autogen.sh
 ./configure --enable-embedded-yajl HFUZZ_CC_UBSAN=1 HFUZZ_CC_ASAN=1 CC=hfuzz-clang CPPFLAGS="-D FUZZER" CFLAGS="-ggdb3 -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-div,indirect-calls"

--- a/tests/oci-validation/run-tests.sh
+++ b/tests/oci-validation/run-tests.sh
@@ -10,6 +10,7 @@ fi
 
 (
 cd /crun
+git config --global --add safe.directory /crun
 git clean -fdx
 ./autogen.sh
 ./configure

--- a/tests/podman/run-tests.sh
+++ b/tests/podman/run-tests.sh
@@ -8,6 +8,7 @@ fi
 set -e
 (
 cd /crun
+git config --global --add safe.directory /crun
 git clean -fdx
 ./autogen.sh
 ./configure CFLAGS='-Wall -Wextra -Werror' --prefix=/usr


### PR DESCRIPTION
Set `/crun` as safe directory on containers running the tests.

Last regression seen here: https://github.com/containers/crun/pull/841