### PR TITLE
cri-o: bump golang to `1.18.1` for `capnproto.org/go/capnp`

### DIFF
--- a/tests/cri-o/Dockerfile
+++ b/tests/cri-o/Dockerfile
@@ -10,8 +10,8 @@ RUN yum install -y python git gcc automake autoconf libcap-devel \
     dnf install -y 'dnf-command(builddep)' && dnf builddep -y podman && \
     dnf remove -y golang && \
     sudo dnf update -y && \
-    curl -LO https://go.dev/dl/go1.17.6.linux-amd64.tar.gz && \
-    sudo tar -C /usr/local -xzf go1.17.6.linux-amd64.tar.gz && \
+    curl -LO https://go.dev/dl/go1.18.1.linux-amd64.tar.gz && \
+    sudo tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz && \
     export GOPATH=$HOME/go && \
     export GOROOT=/usr/local/go && \
     export PATH=$GOPATH/bin:$GOROOT/bin:$PATH && \


### PR DESCRIPTION
`capnproto.org/go/capnp` needs atleast golang `1.18` now so bump golang
version for cri-o test to `1.18.1`