### PR TITLE
copy_recursive_fd_to_fd(): copy the whole file

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1140,8 +1140,10 @@ copy_from_fd_to_fd (int src, int dst, int consume, libcrun_error_t *err)
       cleanup_free char *buffer = NULL;
       ssize_t remaining;
 
+#define BUFFER_SIZE 4096
+
 #ifdef HAVE_COPY_FILE_RANGE
-      nread = copy_file_range (src, NULL, dst, NULL, 0, 0);
+      nread = copy_file_range (src, NULL, dst, NULL, BUFFER_SIZE, 0);
       if (nread < 0 && (errno == EINVAL || errno == EXDEV))
         goto fallback;
       if (consume && nread < 0 && errno == EAGAIN)
@@ -1150,10 +1152,10 @@ copy_from_fd_to_fd (int src, int dst, int consume, libcrun_error_t *err)
         return 0;
       if (UNLIKELY (nread < 0))
         return crun_make_error (err, errno, "copy_file_range");
+      continue;
 
     fallback:
 #endif
-#define BUFFER_SIZE 4096
 
       buffer = xmalloc (BUFFER_SIZE);
       nread = TEMP_FAILURE_RETRY (read (src, buffer, BUFFER_SIZE));
@@ -1167,7 +1169,7 @@ copy_from_fd_to_fd (int src, int dst, int consume, libcrun_error_t *err)
       remaining = nread;
       while (remaining)
         {
-          ret = TEMP_FAILURE_RETRY (write (dst, buffer, nread));
+          ret = TEMP_FAILURE_RETRY (write (dst, buffer+nread-remaining, remaining));
           if (UNLIKELY (ret < 0))
             return crun_make_error (err, errno, "write");
           remaining -= ret;
@@ -1926,7 +1928,7 @@ copy_recursive_fd_to_fd (int srcdirfd, int dfd, const char *srcname, const char 
           if (UNLIKELY (destfd < 0))
             return crun_make_error (err, errno, "open `%s/%s`", destname, de->d_name);
 
-          ret = copy_from_fd_to_fd (srcfd, destfd, 0, err);
+          ret = copy_from_fd_to_fd (srcfd, destfd, 1, err);
           if (UNLIKELY (ret < 0))
             return ret;
 

--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -3,18 +3,16 @@ FROM fedora:latest
 ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
-RUN yum install -y golang python git gcc automake autoconf libcap-devel \
+RUN dnf install -y golang python git gcc automake autoconf libcap-devel \
     systemd-devel yajl-devel libseccomp-devel go-md2man \
-    glibc-static python3-libmount libtool make podman xz nmap-ncat && \
-    dnf install -y 'dnf-command(builddep)' && dnf builddep -y podman && \
-    go get github.com/onsi/ginkgo/ginkgo && \
-    go get github.com/onsi/gomega/... && \
-    mkdir -p /root/go/src/github.com/containers && \
+    glibc-static python3-libmount libtool make podman xz nmap-ncat \
+    containernetworking-plugins 'dnf-command(builddep)' && \
+    dnf builddep -y podman && \
     chmod 755 /root && \
-    (cd /root/go/src/github.com/containers && git clone -b main https://github.com/containers/podman && \
-     cd podman && \
-     make install.catatonit && \
-     make)
+    git clone https://github.com/containers/podman /root/go/src/github.com/containers/podman && \
+    cd /root/go/src/github.com/containers/podman && \
+    make .install.ginkgo install.catatonit && \
+    make
 
 ## Change default log driver to k8s-file for tests
 RUN sed -i 's/journald/k8s-file/g' /usr/share/containers/containers.conf


### PR DESCRIPTION
In `copy_recursive_fd_to_fd()`, copy the whole file by calling `copy_from_fd_to_fd()` with consume=1.

In `copy_from_fd_to_fd()`, pass a buffer length to `copy_file_range()`, don't bother calling `read()` and `write()` if it succeeds, and handle partial `write()`s correctly if we have to fall back to doing the copying ourselves by calling `read()` and `write()`.

Should fix https://github.com/containers/podman/issues/14243.