### PR TITLE
ci: re-enable and fix clang-format

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1169,7 +1169,7 @@ copy_from_fd_to_fd (int src, int dst, int consume, libcrun_error_t *err)
       remaining = nread;
       while (remaining)
         {
-          ret = TEMP_FAILURE_RETRY (write (dst, buffer+nread-remaining, remaining));
+          ret = TEMP_FAILURE_RETRY (write (dst, buffer + nread - remaining, remaining));
           if (UNLIKELY (ret < 0))
             return crun_make_error (err, errno, "write");
           remaining -= ret;

--- a/tests/clang-format/Dockerfile
+++ b/tests/clang-format/Dockerfile
@@ -1,3 +1,6 @@
 FROM fedora:latest
 
-RUN yum install -y make clang-tools-extra 'dnf-command(builddep)' && dnf builddep -y crun
+RUN dnf install -y git make clang-tools-extra 'dnf-command(builddep)' && dnf builddep -y crun
+
+COPY run-tests.sh /usr/local/bin
+ENTRYPOINT /usr/local/bin/run-tests.sh

--- a/tests/clang-format/run-tests.sh
+++ b/tests/clang-format/run-tests.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-set -e
+set -e -x
+
+cd /crun
+
+# Recent git complains that the directory is owned by someone else,
+# which happens if we run it via a Dockefile with a volume mounted.
+git config --global --add safe.directory "$(pwd)"
 
 ./configure
 make clang-format
-git diff --exit-code src
+git diff --ignore-submodules --exit-code

--- a/tests/init.c
+++ b/tests/init.c
@@ -434,7 +434,7 @@ main (int argc, char **argv)
     {
       int ret;
 
-      ret = printf ("%d:%d", getuid(), getgid());
+      ret = printf ("%d:%d", getuid (), getgid ());
       if (ret < 0)
         error (EXIT_FAILURE, errno, "printf");
       return 0;


### PR DESCRIPTION
1. The check was a no-op since commit a51137c91ad which neglected to add
   the ENTRYPOINT in Dockerfile.

2. The above commit also forgot to install git. While at it, s/yum/dnf/.

3. Since a recent git release, any git operation working on files not
   belonging to a current use complains like this:

        fatal: unsafe repository ('/crun' is owned by someone else)

   To workaround that, add git config --add safe.directory.

4. Differences in tests subdirectory were not caught because commit
   4b184254 neglected to add tests to git diff --exit-code arguments.
   Replace the list of directories to check with --ignore-submodules,
   so we don't have to keep the list of directories in Makefile's
   clang-format git ls-files with the one in run-tests.sh here.