### PR TITLE
krun, handler: move notifer for phase `HANDLER_CONFIGURE_AFTER_MOUNTS` just after finalizing mounts

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1064,10 +1064,6 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = libcrun_container_notify_handler (entrypoint_args, HANDLER_CONFIGURE_AFTER_MOUNTS, container, rootfs, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
-
   if (def->hooks && def->hooks->create_container_len)
     {
       ret = do_hooks (def, 0, container->context->id, false, NULL, "created", (hook **) def->hooks->create_container,

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2399,7 +2399,7 @@ libcrun_set_mounts (struct container_entrypoint_s *entrypoint_args, libcrun_cont
   // configure handler mounts
   ret = libcrun_container_notify_handler (entrypoint_args, HANDLER_CONFIGURE_MOUNTS, container, rootfs, err);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "failed configuring mounts for handler");
+    return crun_make_error (err, errno, "failed configuring mounts for handler at phase: HANDLER_CONFIGURE_MOUNTS");
 
   if (def->root->readonly)
     {
@@ -2482,6 +2482,11 @@ libcrun_set_mounts (struct container_entrypoint_s *entrypoint_args, libcrun_cont
   ret = finalize_mounts (container, err);
   if (UNLIKELY (ret < 0))
     return ret;
+
+  // configure handler mounts for phase: HANDLER_CONFIGURE_AFTER_MOUNTS
+  ret = libcrun_container_notify_handler (entrypoint_args, HANDLER_CONFIGURE_AFTER_MOUNTS, container, rootfs, err);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "failed configuring mounts for handler at phase: HANDLER_CONFIGURE_AFTER_MOUNTS");
 
   get_private_data (container)->rootfsfd = -1;
 


### PR DESCRIPTION
Move notification for `HANDLER_CONFIGURE_AFTER_MOUNTS` just after we finalize
mounts as certain handlers need to perform mounts just after we are done
 with container mounts and before we reset `rootfsfd`.

Closes: https://github.com/containers/crun/issues/945
