### PR TITLE
linux: devices mounts should have NOEXEC and NOSUID

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1476,7 +1476,7 @@ libcrun_create_dev (libcrun_container_t *container, int devfd, struct device_s *
             return fd;
         }
 
-      ret = do_mount (container, fullname, fd, device->path, NULL, MS_BIND | MS_PRIVATE, NULL, LABEL_MOUNT, err);
+      ret = do_mount (container, fullname, fd, device->path, NULL, MS_BIND | MS_PRIVATE | MS_NOEXEC | MS_NOSUID, NULL, LABEL_MOUNT, err);
       if (UNLIKELY (ret < 0))
         return ret;
     }


### PR DESCRIPTION
As in linux we cannot execute device we can safely add `MS_NOEXEC` flag to the device mount. Also as it will not be executed the flag `MS_NOSUID` can be added too. Reasoning: on some platforms those flags were added either way but on some they are missing. If it doesn't make sense to exec then we should disallow it inside the mount just as a precaution.