### PR TITLE
artifacts, centos9-build: add `libprotobuf-c-devel` for protobuf headers

### DIFF
--- a/tests/centos9-build/Dockerfile
+++ b/tests/centos9-build/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream9
 
 RUN yum  --enablerepo='appstream'  --enablerepo='baseos' --enablerepo='crb' install -y make \
     automake autoconf gettext criu-devel libtool gcc libcap-devel systemd-devel yajl-devel \
-    libseccomp-devel python3 libtool git
+    libseccomp-devel python3 libtool git protobuf-c protobuf-c-devel
 
 COPY run-tests.sh /usr/local/bin
 


### PR DESCRIPTION
Add protobuf-devl to centos-9 build test.

Needed for: https://github.com/containers/crun/pull/933 and CI