### PR TITLE
krun: use library soname in dlopen

### DIFF
--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -162,9 +162,9 @@ libkrun_load (void **cookie, libcrun_error_t *err arg_unused)
 {
   void *handle;
 
-  handle = dlopen ("libkrun.so", RTLD_NOW);
+  handle = dlopen ("libkrun.so.1", RTLD_NOW);
   if (handle == NULL)
-    return crun_make_error (err, 0, "could not load `libkrun.so`: %s", dlerror ());
+    return crun_make_error (err, 0, "could not load `libkrun.so.1`: %s", dlerror ());
 
   *cookie = handle;
 


### PR DESCRIPTION
Since libkrun implemented library versioning via in "df698976", use
the library's soname ("libkrun.so.1") instead of just "libkrun.so" to
ensure we're pinned to a compatible ABI version.

This is also convenient because some distros, such as Fedora, only
ship the "libkrun.so" symbolic link in the "-devel" package.

Signed-off-by: Sergio Lopez <slp@redhat.com>