### PR TITLE
linux: use $PATH for newgidmap and newguidmap

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2649,13 +2649,13 @@ uidgidmap_helper (char *helper, pid_t pid, char *map_file, libcrun_error_t *err)
 static int
 newgidmap (pid_t pid, char *map_file, libcrun_error_t *err)
 {
-  return uidgidmap_helper ("/usr/bin/newgidmap", pid, map_file, err);
+  return uidgidmap_helper ("newgidmap", pid, map_file, err);
 }
 
 static int
 newuidmap (pid_t pid, char *map_file, libcrun_error_t *err)
 {
-  return uidgidmap_helper ("/usr/bin/newuidmap", pid, map_file, err);
+  return uidgidmap_helper ("newuidmap", pid, map_file, err);
 }
 
 static int


### PR DESCRIPTION
There are distributions which do not have `newgidmap` or `newuidmap` in
`/usr/bin` but available in `$PATH`. To support that, we now have to use
the binary names directly rather than its full path.

Refers to https://github.com/NixOS/nixpkgs/pull/178458