### PR TITLE
fix compile error unknown type name 'uint64_t'

### DIFF
--- a/tests/init.c
+++ b/tests/init.c
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <errno.h>
 #include <dirent.h>


### PR DESCRIPTION
'uint64_t' was declared in file <stdint.h> which did not included.