### PR TITLE
linux: fix creating devices in the rootfs

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1529,14 +1529,19 @@ libcrun_create_dev (libcrun_container_t *container, int devfd, struct device_s *
           *tmp = '\0';
           basename = tmp + 1;
 
-          dirfd = safe_openat (rootfsfd, rootfs, rootfs_len, dirname,
-                               O_DIRECTORY | O_PATH | O_CLOEXEC, 0, err);
-          if (dirfd < 0 && ensure_parent_dir)
+          if (dirname[0] == '\0')
+            dirfd = dup (rootfsfd);
+          else
             {
-              crun_error_release (err);
+              dirfd = safe_openat (rootfsfd, rootfs, rootfs_len, dirname,
+                                   O_DIRECTORY | O_PATH | O_CLOEXEC, 0, err);
+              if (dirfd < 0 && ensure_parent_dir)
+                {
+                  crun_error_release (err);
 
-              dirfd = crun_safe_create_and_open_ref_at (true, rootfsfd, rootfs,
-                                                        rootfs_len, dirname, 0755, err);
+                  dirfd = crun_safe_create_and_open_ref_at (true, rootfsfd, rootfs,
+                                                            rootfs_len, dirname, 0755, err);
+                }
             }
           if (UNLIKELY (dirfd < 0))
             return dirfd;

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -108,11 +108,27 @@ def test_allow_access():
         return -1
     return 0
 
+def test_mknod_device():
+    if is_rootless():
+        return 77
+
+    conf = base_config()
+    add_all_namespaces(conf)
+    conf['process']['args'] = ['/init', 'true']
+    conf['linux']['devices'] = [{"path": "/foo-dev", "type": "b", "major": 10, "minor": 229},
+                                {"path": "/subdir/foo-dev", "type": "b", "major": 10, "minor": 229},]
+    try:
+        run_and_get_output(conf)
+    except Exception as e:
+        return -1
+    return 0
+
 
 all_tests = {
     "deny-devices" : test_deny_devices,
     "allow-device" : test_allow_device,
     "allow-access" : test_allow_access,
+    "mknod-device" : test_mknod_device,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix the creation of devices nodes in the container rootfs.

commit d583bdcef7f7297c58ce65b69ccbda908e050548 introduced the regression.

Closes: https://github.com/containers/crun/issues/917

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>