### PR TITLE
cgroup: add fallback to io.weight

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -879,6 +879,12 @@ l l l l .
 \fB\fCOCI (x)\fR	\fB\fCcgroup 2 value (y)\fR	\fB\fCconversion\fR	\fB\fCcomment\fR
 weight	io.bfq.weight	y = x	
 weight_device	io.bfq.weight	y = x	
+weight	io.weight (fallback)	y = 1 + (x-10)*9999/990	T{
+convert linearly from [10-1000] to [1-10000]
+T}
+weight_device	io.weight (fallback)	y = 1 + (x-10)*9999/990	T{
+convert linearly from [10-1000] to [1-10000]
+T}
 rbps	io.max	y=x	
 wbps	io.max	y=x	
 riops	io.max	y=x	

--- a/crun.1.md
+++ b/crun.1.md
@@ -676,6 +676,8 @@ they are converted when needed from the cgroup v1 configuration.
 |---|---|---|---|
 | weight | io.bfq.weight | y = x ||
 | weight_device | io.bfq.weight | y = x ||
+| weight | io.weight (fallback) | y = 1 + (x-10)*9999/990 | convert linearly from [10-1000] to [1-10000] |
+| weight_device | io.weight (fallback) | y = 1 + (x-10)*9999/990 | convert linearly from [10-1000] to [1-10000] |
 | rbps | io.max | y=x ||
 | wbps | io.max | y=x ||
 | riops | io.max |y=x ||


### PR DESCRIPTION
copy the same fallback runc has.

If io.bfq.weight doesn't exist, then fallback to using io.weight with
a conversion.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>