### PR TITLE
python: unset LIBCRUN_RUN_OPTIONS_PREFORK for run

### DIFF
--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -163,7 +163,7 @@ container_run (PyObject *self, PyObject *args)
     return NULL;
 
   Py_BEGIN_ALLOW_THREADS;
-  ret = libcrun_container_run (ctx, ctr, LIBCRUN_RUN_OPTIONS_PREFORK, &err);
+  ret = libcrun_container_run (ctx, ctr, 0, &err);
   Py_END_ALLOW_THREADS;
   if (ret < 0)
     return set_error (&err);

--- a/src/create.c
+++ b/src/create.c
@@ -72,7 +72,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
       break;
 
     case 'f':
-      config_file = crun_context.config_file = argp_mandatory_argument (arg, state);
+      config_file = argp_mandatory_argument (arg, state);
       break;
 
     case OPTION_CONSOLE_SOCKET:
@@ -137,7 +137,6 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
           if (config_file_cleanup == NULL)
             libcrun_fail_with_error (errno, "realpath `%s` failed", config_file);
           config_file = config_file_cleanup;
-          crun_context.config_file = config_file;
         }
     }
 

--- a/src/crun.c
+++ b/src/crun.c
@@ -110,9 +110,6 @@ init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global
   if (con->bundle == NULL)
     con->bundle = ".";
 
-  if (con->config_file == NULL)
-    con->config_file = "./config.json";
-
   con->handler_manager = libcrun_get_handler_manager ();
 
   return 0;

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -37,8 +37,6 @@ struct libcrun_context_s
   const char *state_root;
   const char *id;
   const char *bundle;
-  const char *config_file;
-  const char *config_file_content;
   const char *console_socket;
   const char *pid_file;
   const char *notify_socket;
@@ -78,6 +76,9 @@ struct libcrun_container_s
 
   uid_t container_uid;
   gid_t container_gid;
+
+  char *config_file;
+  char *config_file_content;
 
   bool use_intermediate_userns;
 

--- a/src/run.c
+++ b/src/run.c
@@ -73,7 +73,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
       break;
 
     case 'f':
-      config_file = crun_context.config_file = argp_mandatory_argument (arg, state);
+      config_file = argp_mandatory_argument (arg, state);
       break;
 
     case 'b':
@@ -141,7 +141,6 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
           if (config_file_cleanup == NULL)
             libcrun_fail_with_error (errno, "realpath `%s` failed", config_file);
           config_file = config_file_cleanup;
-          crun_context.config_file = config_file;
         }
     }
 

--- a/tests/tests_libcrun_fuzzer.c
+++ b/tests/tests_libcrun_fuzzer.c
@@ -330,7 +330,6 @@ run_one_container (uint8_t *buf, size_t len, bool detach)
   ctx.id = id;
   ctx.bundle = "rootfs";
   ctx.detach = detach;
-  ctx.config_file_content = conf;
   ctx.fifo_exec_wait_fd = -1;
 
   libcrun_container_run (&ctx, container, LIBCRUN_RUN_OPTIONS_PREFORK, &err);


### PR DESCRIPTION
do not create a new process for each run.

Closes: https://github.com/containers/crun/issues/948

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
