### PR TITLE
NEWS: tag 1.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,22 @@
+* crun-1.5
+
+- add mono based native .NET handler
+- new Wasmtime backend for running WebAssembly
+- add support for wasmedge 0.10 and dropping support for wasmedge 0.9.x
+- dropping support for experimental `WasmEdgeProcess` from wasmedge handler
+- honor process user's uid when setting the HOME environment variable
+- create the current working directory if it is missing in the container
+- fallback to using a tmpfs mount if umount of /sys and /proc fails
+- fallback to netlink to setup lo device
+- fix creating devices in the rootfs
+- fallback to using io.weight if io.bfq.weight doesn't exist
+- remove tun/tap from the default allow list
+- linux: devices mounts have noexec and nosuid
+- fix copyup of files from the container to the tmpfs
+- honor $PATH for newgidmap and newguidmap
+- krun: limit the number of vCPUs to 8
+- cgroup: add support for cpu.idle
+
 * crun-1.4.5
 
 - CRIU: add support for different manage cgroups modes.

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "ebb592a04c5282f316d60cd4aba066f6e5d74b65",
-  "date": "2021-07-28T11:14:35+00:00",
-  "path": "/nix/store/q1n55r3l0p6d8hl45vahdmpl5bi9xljc-nixpkgs",
-  "sha256": "1zrza6g09sa7jgsda8z0yknf6p91vh75z8vjsa86si9i3m0c9dhl",
+  "rev": "4d76a8a81f1a918ae273225692eef5d684ea02ca",
+  "date": "2022-07-20T02:11:28-05:00",
+  "path": "/nix/store/nnw6a319s2q7m9qfhqd4crgf0wk11kyc-nixpkgs",
+  "sha256": "1jhgpdpv2761ky9djagrdjxcp24khvqp7xkcbq4j5srlkbaf2hrk",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
- add mono based native .NET handler
- new Wasmtime backend for running WebAssembly
- add support for wasmedge 0.10 and dropping support for wasmedge 0.9.x
- dropping support for experimental `WasmEdgeProcess` from wasmedge handler
- honor process user's uid when setting the HOME environment variable
- create the current working directory if it is missing in the container
- fallback to using a tmpfs mount if umount of /sys and /proc fails
- fallback to netlink to setup lo device
- fix creating devices in the rootfs
- fallback to using io.weight if io.bfq.weight doesn't exist.
- remove tun/tap from the default allow list
- linux: devices mounts have noexec and nosuid
- fix copyup of files from the container to the tmpfs
- honor $PATH for newgidmap and newguidmap
- krun: limit the number of vCPUs to 8
- cgroup: add support for cpu.idle

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

