### PR TITLE
cgroup: change delegate cgroup after cgroupns creation

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -604,6 +604,10 @@ If the \fB\fCrun.oci.systemd.subgroup\fR annotation is specified, yet another
 sub-cgroup is created and the container process is moved here.
 
 .PP
+If a cgroup namespace is used, the cgroup namespace is created before
+moving the container to the delegated cgroup.
+
+.PP
 .RS
 
 .nf

--- a/crun.1.md
+++ b/crun.1.md
@@ -477,6 +477,9 @@ e.g.
 If the `run.oci.systemd.subgroup` annotation is specified, yet another
 sub-cgroup is created and the container process is moved here.
 
+If a cgroup namespace is used, the cgroup namespace is created before
+moving the container to the delegated cgroup.
+
 ```
 /sys/fs/cgroup/$PATH/$SUBGROUP/$DELEGATED-CGROUP
 ```

--- a/src/libcrun/cgroup-internal.h
+++ b/src/libcrun/cgroup-internal.h
@@ -49,7 +49,6 @@ struct libcrun_cgroup_manager
   int (*update_resources) (struct libcrun_cgroup_status *cgroup_status, runtime_spec_schema_config_linux_resources *resources, libcrun_error_t *err);
 };
 
-const char *find_delegate_cgroup (json_map_string_string *annotations);
 int move_process_to_cgroup (pid_t pid, const char *subsystem, const char *path, libcrun_error_t *err);
 int enter_cgroup_subsystem (pid_t pid, const char *subsystem, const char *path, bool create_if_missing,
                             libcrun_error_t *err);

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -360,6 +360,12 @@ success:
 }
 
 int
+libcrun_cgroup_enter_finalize (struct libcrun_cgroup_args *args, struct libcrun_cgroup_status *cgroup_status arg_unused, libcrun_error_t *err)
+{
+  return 0;
+}
+
+int
 libcrun_cgroup_has_oom (struct libcrun_cgroup_status *status, libcrun_error_t *err)
 {
   cleanup_free char *content = NULL;

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -82,7 +82,7 @@ get_cgroup_manager (int manager, struct libcrun_cgroup_manager **out, libcrun_er
   return crun_make_error (err, EINVAL, "unknown cgroup manager specified %d", manager);
 }
 
-const char *
+static const char *
 find_delegate_cgroup (json_map_string_string *annotations)
 {
   const char *annotation;
@@ -362,6 +362,64 @@ success:
 int
 libcrun_cgroup_enter_finalize (struct libcrun_cgroup_args *args, struct libcrun_cgroup_status *cgroup_status arg_unused, libcrun_error_t *err)
 {
+  cleanup_free char *target_cgroup = NULL;
+  cleanup_free char *cgroup_path = NULL;
+  cleanup_free char *content = NULL;
+  const char *delegate_cgroup;
+  cleanup_free char *dir = NULL;
+  char *current_cgroup, *to;
+  int cgroup_mode;
+  int ret;
+
+  delegate_cgroup = find_delegate_cgroup (args->annotations);
+  if (delegate_cgroup == NULL)
+    return 0;
+
+  cgroup_mode = libcrun_get_cgroup_mode (err);
+  if (UNLIKELY (cgroup_mode < 0))
+    return cgroup_mode;
+
+  if (cgroup_mode != CGROUP_MODE_UNIFIED)
+    return crun_make_error (err, 0, "delegate-cgroup not supported on cgroup v1");
+
+  xasprintf (&cgroup_path, "/proc/%d/cgroup", args->pid);
+  ret = read_all_file (cgroup_path, &content, NULL, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  current_cgroup = strstr (content, "0::");
+  if (UNLIKELY (current_cgroup == NULL))
+    return crun_make_error (err, 0, "cannot find cgroup2 for the current process");
+  current_cgroup += 3;
+  to = strchr (current_cgroup, '\n');
+  if (UNLIKELY (to == NULL))
+    return crun_make_error (err, 0, "cannot parse /proc/self/cgroup");
+  *to = '\0';
+
+  ret = append_paths (&target_cgroup, err, current_cgroup, delegate_cgroup, NULL);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = append_paths (&dir, err, CGROUP_ROOT, target_cgroup, NULL);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = crun_ensure_directory (dir, 0755, true, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = move_process_to_cgroup (args->pid, NULL, target_cgroup, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = enable_controllers (target_cgroup, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = chown_cgroups (target_cgroup, args->root_uid, args->root_gid, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   return 0;
 }
 

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -55,6 +55,7 @@ struct libcrun_cgroup_args
 
 /* cgroup life-cycle management.  */
 int libcrun_cgroup_enter (struct libcrun_cgroup_args *args, struct libcrun_cgroup_status **out, libcrun_error_t *err);
+int libcrun_cgroup_enter_finalize (struct libcrun_cgroup_args *args, struct libcrun_cgroup_status *cgroup_status, libcrun_error_t *err);
 int libcrun_cgroup_destroy (struct libcrun_cgroup_status *cgroup_status, libcrun_error_t *err);
 
 /* Handle the cgroup status.  */

--- a/tests/cri-o/run-tests.sh
+++ b/tests/cri-o/run-tests.sh
@@ -41,6 +41,7 @@ sed -i -e 's|@test "image volume ignore" {|@test "image volume ignore" {\nskip\n
 sed -i -e 's|@test "image volume bind" {|@test "image volume bind" {\nskip\n|g' test/*.bats
 sed -i -e 's|@test "image volume user mkdir" {|@test "image volume user mkdir" {\nskip\n|g' test/*.bats
 sed -i -e 's|@test "crio restore with missing config.json" {|@test "crio restore with missing config.json" {\nskip\n|g' test/*.bats
+sed -i -e 's|@test "crio restore upon exiting KUBENSMNT" {|@test "crio restore upon exiting KUBENSMNT" {\nskip\n|g' test/*.bats
 
 
 # remove useless tests


### PR DESCRIPTION
change the delegate cgroup semantic to be the cgroup that is created in the container payload after the cgroupns is created.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>