### PR TITLE
rpm/Makefile: install git-core in tarball-prep

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -2,6 +2,7 @@ CWD:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 .ONESHELL:
 tarball-prep:
+	sudo dnf -y install git-core
 	cd "$(CWD)/..";
 	git submodule update --recursive --init
 	git archive --prefix=crun-latest/ -o crun-latest.tar.gz HEAD


### PR DESCRIPTION
After PR #975, the triggered builds on `rhcontainerbot/podman-next`
copr are failing like so:

```
git submodule update --recursive --init
git archive --prefix=crun-latest/ -o crun-latest.tar.gz HEAD
/bin/sh: line 2: git: command not found
/bin/sh: line 3: git: command not found
make: *** [/mnt/workdir-3s_ozokd/crun/.copr/Makefile:5: tarball-prep] Error 127
```

Detailed log at:
https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/srpm-builds/04689814/builder-live.log.gz

The builds seem to occur in a mock environment with no prior git binary
installed.

This PR should fix that.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@giuseppe @flouthoc @rhatdan PTAL