### PR TITLE
rpm/Makefile: install all dependencies on mock environments

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,6 +68,7 @@ jobs:
           - test: containerd
           - test: oci-validation
           - test: alpine-build
+          - test: fedora-rawhide-mockbuild
           - test: centos8-build
           - test: centos9-build
           - test: clang-format
@@ -140,6 +141,10 @@ jobs:
               alpine-build)
                   sudo docker build -t crun-alpine-build tests/alpine-build
                   sudo docker run --privileged --rm -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave -v ${PWD}:/crun crun-alpine-build
+              ;;
+              fedora-rawhide-mockbuild)
+                  sudo docker build -t crun-fedora-rawhide-mockbuild tests/fedora-rawhide-mockbuild
+                  sudo docker run --privileged --rm -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave -v ${PWD}:/crun crun-fedora-rawhide-mockbuild
               ;;
               centos8-build)
                   sudo docker build -t crun-centos8-build tests/centos8-build

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -2,7 +2,7 @@ CWD:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 .ONESHELL:
 tarball-prep:
-	sudo dnf -y install git-core
+	dnf -y install autoconf automake git-core libcap-devel libkrun-devel libseccomp-devel libtool m4 systemd-devel yajl-devel &> /dev/null
 	cd "$(CWD)/..";
 	git submodule update --recursive --init
 	git archive --prefix=crun-latest/ -o crun-latest.tar.gz HEAD
@@ -14,4 +14,5 @@ setup: tarball-prep
 	./configure --disable-silent-rules --with-libkrun
 
 srpm: setup
+	make -C ../libocispec
 	make -C .. srpm

--- a/rpm/crun.spec.in
+++ b/rpm/crun.spec.in
@@ -9,12 +9,11 @@ Source0: %{name}-latest.tar.gz
 License: GPLv2+
 URL: https://github.com/containers/%{name}
 
-# We always run autogen.sh
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: gcc
 BuildRequires: python
-BuildRequires: git
+BuildRequires: git-core
 BuildRequires: libcap-devel
 BuildRequires: libkrun-devel
 BuildRequires: systemd-devel

--- a/tests/fedora-rawhide-mockbuild/Dockerfile
+++ b/tests/fedora-rawhide-mockbuild/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.fedoraproject.org/fedora:rawhide
+
+RUN dnf install -y git-core make rpm-build
+
+COPY run-mockbuild.sh /usr/local/bin
+
+ENTRYPOINT /usr/local/bin/run-mockbuild.sh

--- a/tests/fedora-rawhide-mockbuild/run-mockbuild.sh
+++ b/tests/fedora-rawhide-mockbuild/run-mockbuild.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+cd /crun
+
+# needed to silence ambiguous directory ownership error
+git config --global --add safe.directory /crun
+git clean -fdx
+git submodule foreach --recursive git clean -fdx
+
+cd .copr
+make srpm


### PR DESCRIPTION
The mock environment needs all dependencies installed before running
autogen.sh and configure.

This PR will also enable fedora-rawhide-mockbuild test in CI.

Follow-up to PR #977.


Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@giuseppe @flouthoc @rhatdan PTAL. This time I've tested locally on a mock fedora rawhide environment, so I'm quite certain we'll be good to after this PR. Thanks.

sudo is not present by default on mock environments, so I got rid of that from the dnf step.
