### PR TITLE
rpm/Makefile: Fix copr build (follow-up on #979)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,16 +3,28 @@ SUBDIRS = libocispec
 ACLOCAL_AMFLAGS = -I m4
 
 WD := $(shell pwd)
+# outdir is needed by the make_srpm build type on Fedora copr
+# https://docs.pagure.org/copr.copr/user_documentation.html#make-srpm
+outdir ?= $(WD)
 
-rpm: dist-gzip rpm/crun.spec
-	echo $(VERSION)
-	$(MAKE) -C $(WD) dist-gzip
-	rpmbuild -ba --define "_sourcedir $(WD)" --define "_specdir $(WD)" --define "_builddir $(WD)" --define "_srcrpmdir $(WD)" --define "_rpmdir $(WD)" --define "_buildrootdir $(WD)/.build" rpm/crun.spec
+RPM_OPTS ?= --define "_sourcedir $(WD)" --define "_specdir $(WD)" --define "_builddir $(WD)" --define "_srcrpmdir $(outdir)" --define "_rpmdir $(outdir)" --define "_buildrootdir $(WD)/.build" rpm/crun.spec
 
-srpm: dist-gzip rpm/crun.spec
+# Clean any safe.directory values added to global gitconfig because of srpm and
+# rpm target runs
+clean-global-gitconfig:
+	$(shell git config --global --unset-all safe.directory $(shell pwd)/libocispec)
+	$(shell git config --global --unset-all safe.directory $(shell pwd)/rpm)
+	$(shell git config --global --unset-all safe.directory /crun)
+
+srpm:
 	echo $(VERSION)
-	$(MAKE) -C $(WD) dist-gzip
-	rpmbuild -bs --define "_sourcedir $(WD)" --define "_specdir $(WD)" --define "_builddir $(WD)" --define "_srcrpmdir $(WD)" --define "_rpmdir $(WD)" --define "_buildrootdir $(WD)/.build" rpm/crun.spec
+	$(MAKE) -C rpm tarball-prep
+	rpmbuild -bs $(RPM_OPTS) rpm/crun.spec
+	$(MAKE) clean-global-gitconfig
+
+rpm: srpm
+	rpmbuild -ba $(RPM_OPTS) rpm/crun.spec
+	$(MAKE) clean-global-gitconfig
 
 CLEANFILES = crun.spec
 

--- a/configure.ac
+++ b/configure.ac
@@ -209,7 +209,10 @@ AC_SUBST([CRUN_LIBDIR], [$libdir/crun])
 
 [RPM_VERSION=$(echo $VERSION | sed -e's,^\([^-]*\).*$,\1,g')]
 
+[GIT_COMMIT_ID=$(git rev-parse --short HEAD)]
+
 AC_SUBST([RPM_VERSION])
+AC_SUBST([GIT_COMMIT_ID])
 
 AC_CHECK_TOOL(GPERF, gperf)
 if test -z "$GPERF"; then

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,18 +1,44 @@
 CWD:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
+FEDORA_VERSION=$(shell rpm --eval %{?fedora})
+
+# libkrun only available on Fedora 37/Rawhide
+ifeq ($(FEDORA_VERSION), 37)
+KRUN_SUPPORT := 1
+else
+KRUN_SUPPORT := 0
+endif
+
 .ONESHELL:
 tarball-prep:
-	dnf -y install autoconf automake git-core libcap-devel libkrun-devel libseccomp-devel libtool m4 systemd-devel yajl-devel &> /dev/null
+	dnf -y install autoconf automake git git-archive-all libcap-devel libseccomp-devel libtool m4 rpm-build systemd-devel yajl-devel
+ifeq ($(KRUN_SUPPORT), 1)
+	dnf -y install libkrun-devel
+endif
 	cd "$(CWD)/..";
-	git submodule update --recursive --init
-	git archive --prefix=crun-latest/ -o crun-latest.tar.gz HEAD
+	git config --global --add safe.directory /crun
+	git config --global --add safe.directory /crun/libocispec
+	git config --global --add safe.directory /crun/libocispec/image-spec
+	git config --global --add safe.directory /crun/libocispec/runtime-spec
+	git config --global --add safe.directory /crun/libocispec/yajl
+	git config --global --add safe.directory $(shell pwd)/libocispec
+	git config --global --add safe.directory $(shell pwd)/libocispec/image-spec
+	git config --global --add safe.directory $(shell pwd)/libocispec/runtime-spec
+	git config --global --add safe.directory $(shell pwd)/libocispec/yajl
+	git-archive-all --prefix=crun-HEAD/ --force-submodules crun-HEAD.tar.gz
 
 .ONESHELL:
 setup: tarball-prep
 	cd "$(CWD)/..";
 	./autogen.sh
+ifeq ($(KRUN_SUPPORT), 1)
 	./configure --disable-silent-rules --with-libkrun
+else
+	./configure --disable-silent-rules
+endif
 
+.ONESHELL:
 srpm: setup
-	make -C ../libocispec
-	make -C .. srpm
+	cd "$(CWD)/..";
+	make libocispec
+	make srpm

--- a/rpm/crun.spec.in
+++ b/rpm/crun.spec.in
@@ -1,11 +1,21 @@
+%if 0%{?fedora} >= 37
+%ifarch aarch64,x86_64
+%global krun_support enabled
+%endif
+%else
+%global krun_support disabled
+%endif
+
 Summary: OCI runtime written in C
 Name: crun
 Epoch: 101
-Version: @RPM_VERSION@
+#FIXME: copr build env replaces this with a strange version number
+#Version: @RPM_VERSION@
+Version: 0.0
 %define build_timestamp %{lua: print(os.date("%Y%m%d%H%M%S"))}
-Release: %{build_timestamp}%{?dist}
+Release: %{build_timestamp}.@GIT_COMMIT_ID@%{?dist}
 # `make tarball-prep` will generate this from HEAD commit in the repo root dir
-Source0: %{name}-latest.tar.gz
+Source0: %{name}-HEAD.tar.gz
 License: GPLv2+
 URL: https://github.com/containers/%{name}
 
@@ -15,47 +25,67 @@ BuildRequires: gcc
 BuildRequires: python
 BuildRequires: git-core
 BuildRequires: libcap-devel
+%if "%{krun_support}" == "enabled"
 BuildRequires: libkrun-devel
+%endif
 BuildRequires: systemd-devel
 BuildRequires: yajl-devel
 BuildRequires: libseccomp-devel
 BuildRequires: python3-libmount
 BuildRequires: libtool
 BuildRequires: go-md2man
+Provides: oci-runtime
 
 %description
 %{name} is a OCI runtime
 
+%if "%{krun_support}" == "enabled"
 %package -n krun
 Summary: %{name} with libkrun support
 Requires: libkrun
 
 %description -n krun
 krun is a symlink to the crun binary, with libkrun as an additional dependency.
+%endif
 
 %prep
-%autosetup -n %{name}-@VERSION@
+%autosetup -Sgit -n %{name}-HEAD
 
 %build
-# autogen.sh and configure are run via Makefile
+./autogen.sh
+
+%if "%{krun_support}" == "enabled"
+./configure --disable-silent-rules --with-libkrun
+%else
+./configure --disable-silent-rules
+%endif
+
 %make_build
 
 %install
-%make_install
+# FIXME: make_install no longer finds files as expected,
+# so need to run install steps explicitly
+#%%make_install
+install -dp %{buildroot}%{_bindir}
+install -Dp -m0755 %{name} %{buildroot}%{_bindir}
+install -dp %{buildroot}%{_mandir}/man1
+install -Dp -m0644 %{name}.1 %{buildroot}%{_mandir}/man1
 rm -rf %{buildroot}%{_usr}/lib*
 
+%if "%{krun_support}" == "enabled"
 ln -s %{_bindir}/%{name} %{buildroot}%{_bindir}/krun
+%endif
 
 %files
 %license COPYING
 %{_bindir}/%{name}
 %{_mandir}/man1/*
 
+%if "%{krun_support}" == "enabled"
 %files -n krun
 %license COPYING
 %{_bindir}/krun
+%endif
 
-%if ! 0%{?centos} <= 8
 %changelog
 %autochangelog
-%endif

--- a/tests/fedora-rawhide-mockbuild/Dockerfile
+++ b/tests/fedora-rawhide-mockbuild/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora:rawhide
 
-RUN dnf install -y git-core make rpm-build
+RUN dnf install -y git-core go-md2man make python python3-libmount rpm-build
 
 COPY run-mockbuild.sh /usr/local/bin
 

--- a/tests/fedora-rawhide-mockbuild/run-mockbuild.sh
+++ b/tests/fedora-rawhide-mockbuild/run-mockbuild.sh
@@ -2,11 +2,9 @@
 
 set -e
 cd /crun
-
 # needed to silence ambiguous directory ownership error
 git config --global --add safe.directory /crun
 git clean -fdx
-git submodule foreach --recursive git clean -fdx
 
-cd .copr
-make srpm
+make -f .copr/Makefile srpm
+make rpm


### PR DESCRIPTION
- `make -f .copr/Makefile srpm outdir=$(OUTDIR)` works.
See: https://docs.pagure.org/copr.copr/user_documentation.html#make-srpm

- `./autogen.sh && ./configure && make [srpm,rpm]` works locally.

- added Fedora version conditionals for libkrun support as
libkrun exists only for Fedora 37/rawhide on aarch64 and x86_64.

- `./autogen.sh` and `./configure` need to be run in .copr/Makefile for
`srpm`, `rpm` and `libocispec` targets as well as in `.copr/crun.spec` after
exploding the tarball for generating the actual rpms.

- rpm build release tag is of the form:
`$TIMESTAMP.$GIT_SHORTCOMMIT.$DIST`.

- `.copr/crun.spec.in` temporarily uses hardcoded `Version: 0.0` as copr seems to
use a strange and unexpected string for `$VERSION` and thus `@RPM_VERSION@`.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@giuseppe @flouthoc @rhatdan PTAL. Hopefully with this PR, we'll be all set for copr autobuilds.

Successful copr build (finally): https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/4692238/ 