### PR TITLE
defer creation of sysctl until after all namespaces have been created

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1058,9 +1058,10 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
   if (has_terminal && entrypoint_args->context->console_socket)
     console_socket = entrypoint_args->console_socket_fd;
 
-  ret = libcrun_set_sysctl (container, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
+  sysCtlReturn sysReturn;
+  sysReturn = libcrun_set_sysctl (container, err);
+  if (UNLIKELY (sysReturn.returnValue < 0))
+    return sysReturn.returnValue;
 
   ret = libcrun_container_notify_handler (entrypoint_args, HANDLER_CONFIGURE_BEFORE_MOUNTS, container, rootfs, err);
   if (UNLIKELY (ret < 0))
@@ -1239,6 +1240,11 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
       if (UNLIKELY (ret < 0))
         return ret;
     }
+
+  // set sysctl after namespaces are created
+    ret = libcrun_set_additional_sysctl (&sysReturn, container, err);
+    if (UNLIKELY (ret < 0))
+      return ret;
 
   capabilities = def->process ? def->process->capabilities : NULL;
   no_new_privs = def->process ? def->process->no_new_privileges : 1;

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -38,6 +38,14 @@ struct device_s
   gid_t gid;
 };
 
+typedef struct
+{
+  int returnValue;
+  char **keys;
+  char **values;
+  size_t len;
+} sysCtlReturn;
+
 typedef int (*container_entrypoint_t) (void *args, char *notify_socket, int sync_socket, libcrun_error_t *err);
 
 typedef int (*set_mounts_cb_t) (void *args, libcrun_error_t *err);
@@ -59,7 +67,8 @@ int libcrun_set_selinux_exec_label (runtime_spec_schema_config_schema_process *p
 int libcrun_set_apparmor_profile (runtime_spec_schema_config_schema_process *proc, libcrun_error_t *err);
 int libcrun_set_hostname (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_oom (libcrun_container_t *container, libcrun_error_t *err);
-int libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err);
+sysCtlReturn libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err);
+int libcrun_set_additional_sysctl (sysCtlReturn *sysctls, libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_terminal (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_join_process (libcrun_container_t *container, pid_t pid_to_join, libcrun_container_status_t *status,
                           const char *cgroup, int detach, int *terminal_fd, libcrun_error_t *err);

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -200,34 +200,19 @@ def test_uts_sysctl():
                 run_crun_command(["delete", "-f", cid])
 
     conf = base_config()
-    conf['process']['args'] = ['/init', 'true']
-    add_all_namespaces(conf, utsns=False)
-    conf['linux']['sysctl'] = {'kernel.domainname' : 'foo'}
+    conf['process']['args'] = ['./init', 'cat', '/etc/hosts']
+    add_all_namespaces(conf, utsns=True)
+    conf['linux']['sysctl'] = {'kernel.domainname' : 'baz.foo'}
     cid = None
     try:
-        _, cid = run_and_get_output(conf)
-        sys.stderr.write("unexpected success\n")
-        return -1
-    except:
-        return 0
-    finally:
-        if cid is not None:
-            run_crun_command(["delete", "-f", cid])
-
-    conf = base_config()
-    conf['process']['args'] = ['/init', 'true']
-    add_all_namespaces(conf)
-    conf['linux']['sysctl'] = {'kernel.domainname' : 'foo'}
-    cid = None
-    try:
-        _, cid = run_and_get_output(conf)
-        return 0
+        out, _ = run_and_get_output(conf)
+        if "baz.foo" not in str(out):
+            return -1
     except:
         return -1
     finally:
         if cid is not None:
             run_crun_command(["delete", "-f", cid])
-    return 0
 
 def test_start():
     conf = base_config()


### PR DESCRIPTION
there is a bug in rootless podman that does not allow users to set
kernel.domainname because the uts namespace is not set up before the sysctl's are
added.

I moved the libcrun_set_sysctl down to a point where i think all of the namespaces have been created

Signed-off-by: Charlie Doern <cdoern@redhat.com>