### PR TITLE
wasmtime: always grant `filesystem capability` for workdir inside container 

### DIFF
--- a/src/libcrun/handlers/wasmtime.c
+++ b/src/libcrun/handlers/wasmtime.c
@@ -96,6 +96,7 @@ libwasmtime_exec (void *cookie, libcrun_container_t *container,
   void (*wasmtime_store_delete) (wasmtime_store_t * store);
   void (*wasmtime_error_message) (const wasmtime_error_t *error, wasm_name_t *message);
   void (*wasmtime_error_delete) (wasmtime_error_t * error);
+  bool (*wasi_config_preopen_dir) (wasi_config_t * config, const char *path, const char *guest_path);
 
   wasm_engine_new = dlsym (cookie, "wasm_engine_new");
   wasm_engine_delete = dlsym (cookie, "wasm_engine_delete");
@@ -121,6 +122,7 @@ libwasmtime_exec (void *cookie, libcrun_container_t *container,
   wasmtime_store_delete = dlsym (cookie, "wasmtime_store_delete");
   wasmtime_error_delete = dlsym (cookie, "wasmtime_error_delete");
   wasmtime_error_message = dlsym (cookie, "wasmtime_error_message");
+  wasi_config_preopen_dir = dlsym (cookie, "wasi_config_preopen_dir");
 
   if (wasm_engine_new == NULL || wasm_engine_delete == NULL || wasm_byte_vec_delete == NULL
       || wasm_byte_vec_new_uninitialized == NULL || wasi_config_new == NULL || wasmtime_store_new == NULL
@@ -130,7 +132,7 @@ libwasmtime_exec (void *cookie, libcrun_container_t *container,
       || wasi_config_inherit_env == NULL || wasmtime_context_set_wasi == NULL
       || wasmtime_linker_module == NULL || wasmtime_linker_get_default == NULL || wasmtime_func_call == NULL
       || wasmtime_module_delete == NULL || wasmtime_store_delete == NULL || wasi_config_set_argv == NULL
-      || wasmtime_error_delete == NULL || wasmtime_error_message == NULL)
+      || wasmtime_error_delete == NULL || wasmtime_error_message == NULL || wasi_config_preopen_dir == NULL)
     error (EXIT_FAILURE, 0, "could not find symbol in `libwasmtime.so`");
 
   // Set up wasmtime context
@@ -187,6 +189,7 @@ libwasmtime_exec (void *cookie, libcrun_container_t *container,
   wasi_config_inherit_stdin (wasi_config);
   wasi_config_inherit_stdout (wasi_config);
   wasi_config_inherit_stderr (wasi_config);
+  wasi_config_preopen_dir (wasi_config, ".", ".");
   wasm_trap_t *trap = NULL;
   err = wasmtime_context_set_wasi (context, wasi_config);
   if (err != NULL)


### PR DESCRIPTION
Following PR introduces two changes.

#### * wasmtime: inherit argv from handler argument instead of process
  libwasmtime_exec already passes `argv` which is generated from args
provided to container so use that instead of inheriting args from crun
process.

#### * wasmtime: always grant filesystem capability for workdir inside container
By default WASI programs do not have access to anything on the filesystem,
So for use cases where WASI program needs to access files on the current
path we must preopen those paths, hence by default always preopen `.` in
a `scratch` container.

For Example in below `Containerfile`, WASI program takes `inputfile` as
argument and writes output to `outputfile` where both files are present
in a path which starts with `.`.

```Dockerfile
FROM scratch
COPY inputfile /
COPY main.wasm /
CMD ["/main.wasm", "inputfile", "outputfile"]
```

Under the hood `wasmtime` preopens a directory, and make it available to
the program as a capability which can be used to open files inside that
directory. ( Using a technique based on https://github.com/musec/libpreopen )

Closes: https://github.com/containers/crun/issues/978