### PR TITLE
autobuild copr rpms with wasmtime support

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,20 +1,19 @@
 CWD:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-FEDORA_VERSION=$(shell rpm --eval %{?fedora})
-
-# libkrun only available on Fedora 37/Rawhide
-ifeq ($(FEDORA_VERSION), 37)
-KRUN_SUPPORT := 1
-else
-KRUN_SUPPORT := 0
+SUDO_CMD :=
+ifneq ($(shell id -u), 0)
+SUDO_CMD := sudo
 endif
+
+# Only install deps for Copr's make_srpm method to be happy. Doesn't include all
+# rpm build deps
+srpm-dep:
+	$(SUDO_CMD) dnf -y install autoconf automake git git-archive-all \
+		libcap-devel libseccomp-devel libtool m4 rpm-build systemd-devel \
+		yajl-devel
 
 .ONESHELL:
-tarball-prep:
-	dnf -y install autoconf automake git git-archive-all libcap-devel libseccomp-devel libtool m4 rpm-build systemd-devel yajl-devel
-ifeq ($(KRUN_SUPPORT), 1)
-	dnf -y install libkrun-devel
-endif
+tarball-prep: srpm-dep
 	cd "$(CWD)/..";
 	git config --global --add safe.directory /crun
 	git config --global --add safe.directory /crun/libocispec
@@ -27,15 +26,13 @@ endif
 	git config --global --add safe.directory $(shell pwd)/libocispec/yajl
 	git-archive-all --prefix=crun-HEAD/ --force-submodules crun-HEAD.tar.gz
 
+# Configure options intentionally don't match the ones used in crun.spec.in to
+# minimize the dependencies required for Copr's make_srpm method.
 .ONESHELL:
 setup: tarball-prep
 	cd "$(CWD)/..";
 	./autogen.sh
-ifeq ($(KRUN_SUPPORT), 1)
-	./configure --disable-silent-rules --with-libkrun
-else
 	./configure --disable-silent-rules
-endif
 
 .ONESHELL:
 srpm: setup

--- a/rpm/crun.spec.in
+++ b/rpm/crun.spec.in
@@ -1,9 +1,15 @@
+%global krun_opts %{nil}
+
 %if 0%{?fedora} >= 37
-%ifarch aarch64,x86_64
+%ifarch aarch64 || x86_64
 %global krun_support enabled
+%global krun_opts --with-libkrun
 %endif
-%else
-%global krun_support disabled
+%endif
+
+%if 0%{?fedora}
+%global wasmtime_support enabled
+%global wasmtime_opts --with-wasmtime
 %endif
 
 Summary: OCI runtime written in C
@@ -34,6 +40,9 @@ BuildRequires: libseccomp-devel
 BuildRequires: python3-libmount
 BuildRequires: libtool
 BuildRequires: go-md2man
+%if "%{wasmtime_support}" == "enabled"
+BuildRequires: wasmtime-c-api-devel
+%endif
 Provides: oci-runtime
 
 %description
@@ -53,13 +62,7 @@ krun is a symlink to the crun binary, with libkrun as an additional dependency.
 
 %build
 ./autogen.sh
-
-%if "%{krun_support}" == "enabled"
-./configure --disable-silent-rules --with-libkrun
-%else
-./configure --disable-silent-rules
-%endif
-
+./configure --disable-silent-rules %{wasmtime_opts} %{krun_opts}
 %make_build
 
 %install
@@ -86,6 +89,3 @@ ln -s %{_bindir}/%{name} %{buildroot}%{_bindir}/krun
 %license COPYING
 %{_bindir}/krun
 %endif
-
-%changelog
-%autochangelog


### PR DESCRIPTION
Limited to Fedora rpms for now as wasmtime rpms don't yet build on
RHEL 8/9.

wasmtime-c-api-devel can be installed from a separate copr:
`lsm5/wasmtime` at the time of this commit, but subject to change.
The wasmtime Copr is added as an `External Repository` to
`rhcontainerbot/podman-next` so there's no need for extra configuration
in the crun repo itself.

Also reduce the dependencies installed and configure opts used in
`.copr/Makefile` as we only care about making Copr's `make_srpm` method
happy and it doesn't affect the final rpms.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

Successful copr build with wasmtime enabled at: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/playground/build/4726411/

@giuseppe @flouthoc @font PTAL


