### PR TITLE
tests: fix fedora rawhide mockbuild

### DIFF
--- a/tests/fedora-rawhide-mockbuild/run-mockbuild.sh
+++ b/tests/fedora-rawhide-mockbuild/run-mockbuild.sh
@@ -7,4 +7,9 @@ git config --global --add safe.directory /crun
 git clean -fdx
 
 make -f .copr/Makefile srpm
+
+dnf -y install 'dnf-command(copr)'
+# Copr repo subject to change after discussions with wasmtime upstream
+dnf -y copr enable lsm5/wasmtime
+dnf -y install libkrun-devel wasmtime-c-api-devel
 make rpm


### PR DESCRIPTION
Install dependencies for `make rpm`.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@giuseppe @rhatdan PTAL