### PR TITLE
copr: depend on wasmtime-c-api for shared lib

### DIFF
--- a/rpm/crun.spec.in
+++ b/rpm/crun.spec.in
@@ -42,6 +42,7 @@ BuildRequires: libtool
 BuildRequires: go-md2man
 %if "%{wasmtime_support}" == "enabled"
 BuildRequires: wasmtime-c-api-devel
+Requires: wasmtime-c-api
 %endif
 Provides: oci-runtime
 


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@giuseppe @rhatdan @flouthoc PTAL

/cc @font 

To test:
```
$ sudo dnf -y copr enable lsm5/wasmtime
$ sudo dnf -y copr enable rhcontainerbot/playground
$ sudo dnf -y install crun

$ cargo new hello_wasm --bin
$ cd hello_wasm

# make sure wasm32-wasi target is installed
$ sudo dnf -y install rust-std-static-wasm32-wasi
OR 
$  cargo build --target wasm32-wasi

$ cp target/wasm32-wasi/debug/hello_wasm.wasm .
$ echo 'FROM scratch
COPY hello_wasm.wasm /
CMD ["/hello_wasm.wasm"]' > Containerfile

$ buildah build --annotation "module.wasm.image/variant=compat" -t mywasm-image .
$ podman run mywasm-image:latest
```