### PR TITLE
wasm: use wasmedge library soname in dlopen

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -177,7 +177,7 @@ jobs:
               ;;
               wasmedge-build)
                   sudo docker build -t wasmedge tests/wasmedge-build
-                  sudo docker run --rm -w /crun -v ${PWD}:/crun wasmedge
+                  sudo docker run --privileged --rm -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave  -w /crun -v ${PWD}:/crun wasmedge
               ;;
           esac
 

--- a/src/libcrun/handlers/wasmedge.c
+++ b/src/libcrun/handlers/wasmedge.c
@@ -44,9 +44,9 @@ libwasmedge_load (void **cookie, libcrun_error_t *err arg_unused)
 {
   void *handle;
 
-  handle = dlopen ("libwasmedge_c.so", RTLD_NOW);
+  handle = dlopen ("libwasmedge.so.0", RTLD_NOW);
   if (handle == NULL)
-    return crun_make_error (err, 0, "could not load `libwasmedge_c.so`: %s", dlerror ());
+    return crun_make_error (err, 0, "could not load `libwasmedge.so.0`: %s", dlerror ());
   *cookie = handle;
 
   return 0;
@@ -107,7 +107,7 @@ libwasmedge_exec (void *cookie, __attribute__ ((unused)) libcrun_container_t *co
       || WasmEdge_VMRegisterModuleFromFile == NULL || WasmEdge_VMGetImportModuleContext == NULL
       || WasmEdge_ModuleInstanceInitWASI == NULL || WasmEdge_VMRunWasmFromFile == NULL
       || WasmEdge_ResultOK == NULL || WasmEdge_StringCreateByCString == NULL)
-    error (EXIT_FAILURE, 0, "could not find symbol in `libwasmedge.so`");
+    error (EXIT_FAILURE, 0, "could not find symbol in `libwasmedge.so.0`");
 
   configure = WasmEdge_ConfigureCreate ();
   if (UNLIKELY (configure == NULL))

--- a/tests/wasmedge-build/Dockerfile
+++ b/tests/wasmedge-build/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:bullseye-slim
-ARG WASM_EDGE_VERSION="0.10.0"
+ARG WASM_EDGE_VERSION="0.11.0"
 
 RUN apt-get update && apt-get install -y make git gcc build-essential pkgconf libtool \
   libsystemd-dev libprotobuf-c-dev libcap-dev libseccomp-dev libyajl-dev \
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y make git gcc build-essential pkgconf li
 #ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 RUN rm /etc/ld.so.conf.d/libc.conf
 RUN curl -sSf -o install.sh https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh
-RUN bash ./install.sh -p /usr/local -v $WASM_EDGE_VERSION 
+RUN bash ./install.sh -p /usr/local -v $WASM_EDGE_VERSION
 
 COPY run-tests.sh /usr/local/bin
 

--- a/tests/wasmedge-build/Dockerfile
+++ b/tests/wasmedge-build/Dockerfile
@@ -1,14 +1,30 @@
-FROM debian:bullseye-slim
+FROM fedora:rawhide
 ARG WASM_EDGE_VERSION="0.11.0"
 
-RUN apt-get update && apt-get install -y make git gcc build-essential pkgconf libtool \
-  libsystemd-dev libprotobuf-c-dev libcap-dev libseccomp-dev libyajl-dev \
-  go-md2man autoconf python3 automake curl libc6
+# Install the deps for building crun
+RUN dnf update -y && dnf install -y make python git gcc automake autoconf libcap-devel \
+		systemd-devel yajl-devel libseccomp-devel pkg-config \
+		go-md2man glibc-static python3-libmount libtool buildah podman
 
-#ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-RUN rm /etc/ld.so.conf.d/libc.conf
+# Install WasmEdge
 RUN curl -sSf -o install.sh https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh
 RUN bash ./install.sh -p /usr/local -v $WASM_EDGE_VERSION
+
+# The hello_wasm contains:
+# 1. The example rust application called hello, which will print something to console.
+# 2. The Containerfile for building the image including hello.wasm
+ADD hello_wasm /hello_wasm
+
+# Install Rust for building wasm application
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+SHELL ["/bin/bash", "-c"]
+RUN source "$HOME/.cargo/env" && \
+		rustup target add wasm32-wasi && \
+		cd /hello_wasm/hello && \
+		cargo build --release --target wasm32-wasi && \
+		cp ./target/wasm32-wasi/release/hello.wasm /hello_wasm && \
+		cd / && \
+		rm -rf /hello_wasm/hello
 
 COPY run-tests.sh /usr/local/bin
 

--- a/tests/wasmedge-build/hello_wasm/Containerfile
+++ b/tests/wasmedge-build/hello_wasm/Containerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY hello.wasm /
+CMD ["/hello.wasm"]

--- a/tests/wasmedge-build/hello_wasm/hello/Cargo.toml
+++ b/tests/wasmedge-build/hello_wasm/hello/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "hello"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/wasmedge-build/hello_wasm/hello/src/main.rs
+++ b/tests/wasmedge-build/hello_wasm/hello/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{}", "This is from a main function from a wasm module");
+}

--- a/tests/wasmedge-build/run-tests.sh
+++ b/tests/wasmedge-build/run-tests.sh
@@ -3,6 +3,7 @@
 set -e
 cd /crun
 
+git config --global --add safe.directory /crun
 git clean -fdx
 ./autogen.sh
 ./configure CFLAGS='-Wall -Wextra -Werror' --with-wasmedge

--- a/tests/wasmedge-build/run-tests.sh
+++ b/tests/wasmedge-build/run-tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 set -e
+
+# Build crun with wasmedge support
 cd /crun
 
 git config --global --add safe.directory /crun
@@ -8,3 +10,28 @@ git clean -fdx
 ./autogen.sh
 ./configure CFLAGS='-Wall -Wextra -Werror' --with-wasmedge
 make -j "$(nproc)"
+make install
+
+# Remove the installed crun to make sure the built crun is used
+rm -rf /usr/bin/crun
+ln -s /usr/local/bin/crun /usr/bin/crun
+
+# Test crun is used in podman
+if [[ $(podman info | grep SYSTEMD) != *WASM:wasmedge* ]]; then
+	echo "podman cannot find the built crun with +WASM:wasmedge"
+	exit 1
+fi
+
+# Build hellowasm image
+cd /hello_wasm && \
+	chmod +x ./hello.wasm && \
+	buildah build --annotation "module.wasm.image/variant=compat-smart" -t hellowasm-image .
+
+# Run hello.wasm with crun
+OUTPUT=$(podman run hellowasm-image:latest)
+EXPECTED_OUTPUT="This is from a main function from a wasm module"
+echo "$OUTPUT"
+if [[ "$OUTPUT" != "$EXPECTED_OUTPUT" ]]; then
+	echo "Run wasm failed. The execution result is not matched"
+	exit 1
+fi


### PR DESCRIPTION
Notice: The WasmEdge 0.11.0 is planned to be released at the end of this month. Since the test will use the installer to install the corresponding version of WasmEdge, please merge this PR after the WasmEdge 0.11.0 release. Thanks.


Since wasmedge implemented library versioning in "e5af947d", use
the library's soname ("libwasmedge.so.0") instead of "libwasmedge_c.so"
to ensure crun can pin to a compatible ABI version.

Notice: the soname is shipped in wasmedge 0.11.0, before this release
the libwasmedge_c.so is unversioned.

For details, please refer to
[WasmEdge PR#1783](https://github.com/WasmEdge/WasmEdge/pull/1783)

Signed-off-by: hydai <hydai@secondstate.io>