### PR TITLE
container: drop intermediate userns feature

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -806,18 +806,6 @@ The current user is mapped to the ID 0 in the container, and any
 additional id specified in the files \fB\fC/etc/subuid\fR and \fB\fC/etc/subgid\fR
 is automatically added starting with ID 1.
 
-.SH Intermediate user namespace
-.PP
-If the configuration specifies a new user namespace made of a single
-mapping to the root user, but either the UID or the GID are set as
-nonzero then crun automatically creates another user namespace to map
-the root user to the specified UID and GID.
-
-.PP
-It enables running unprivileged containers with UID and GID different
-than zero, even when a single UID and GID are available, e.g. rootless
-users on a system without newuidmap/newgidmap.
-
 
 .SH CGROUP v2
 .PP

--- a/crun.1.md
+++ b/crun.1.md
@@ -628,17 +628,6 @@ The current user is mapped to the ID 0 in the container, and any
 additional id specified in the files `/etc/subuid` and `/etc/subgid`
 is automatically added starting with ID 1.
 
-## Intermediate user namespace
-
-If the configuration specifies a new user namespace made of a single
-mapping to the root user, but either the UID or the GID are set as
-nonzero then crun automatically creates another user namespace to map
-the root user to the specified UID and GID.
-
-It enables running unprivileged containers with UID and GID different
-than zero, even when a single UID and GID are available, e.g. rootless
-users on a system without newuidmap/newgidmap.
-
 # CGROUP v2
 
 **Note**: cgroup v2 does not yet support control of realtime processes and

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -80,8 +80,6 @@ struct libcrun_container_s
   char *config_file;
   char *config_file_content;
 
-  bool use_intermediate_userns;
-
   void *private_data;
   void (*cleanup_private_data) (void *private_data);
   struct libcrun_context_s *context;

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3266,18 +3266,6 @@ libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err)
   return 0;
 }
 
-static uid_t
-get_uid_for_intermediate_userns (libcrun_container_t *container)
-{
-  if (container->use_intermediate_userns)
-    return 0;
-
-  if (container->container_def->process && container->container_def->process->user)
-    return container->container_def->process->user->uid;
-
-  return 0;
-}
-
 static int
 open_terminal (libcrun_container_t *container, char **pty, libcrun_error_t *err)
 {
@@ -3295,7 +3283,7 @@ open_terminal (libcrun_container_t *container, char **pty, libcrun_error_t *err)
   if (container->container_def->process && container->container_def->process->user
       && container->container_def->process->user->uid)
     {
-      uid_t uid = get_uid_for_intermediate_userns (container);
+      uid_t uid = container->container_def->process->user->uid;
 
       ret = chown (*pty, uid, -1);
       if (UNLIKELY (ret < 0))
@@ -4965,117 +4953,5 @@ fallback_to_kill:
   ret = kill (status->pid, signal);
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "kill container");
-  return 0;
-}
-
-/*
-   Used when creating an intermediate user namespace.
-   If the container is running with a single UID/GID mapped, and specifies
-   a different UID/GID, then create an intermediate user namespace to do
-   all the configuration as root, and then once the container is set up,
-   create a new user namespace to map root to the desired UID/GID.
-   This implementation has some issues as some namespaces in the container
-   won't be owned by the final user namespace and it creates a process inside
-   the container PID namespace, so the next created process won't have pid=2.
-   Some of these issues could be solved or at least mitigated, but it is not worth
-   at the moment to add more complexity to address these corner cases.
-*/
-int
-libcrun_create_final_userns (libcrun_container_t *container, libcrun_error_t *err)
-{
-  runtime_spec_schema_config_schema *def = container->container_def;
-  cleanup_close int closep0 = -1;
-  cleanup_close int closep1 = -1;
-  int pid_status;
-  pid_t pid, target_pid;
-  int to_unshare;
-  size_t i;
-  int p[2];
-  int ret;
-
-  ret = pipe2 (p, O_CLOEXEC);
-  if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "create pipe2");
-
-  closep0 = p[0];
-  closep1 = p[1];
-
-  target_pid = getpid ();
-
-  pid = fork ();
-  if (UNLIKELY (pid < 0))
-    return crun_make_error (err, errno, "fork");
-
-  if (pid == 0)
-    {
-      cleanup_free char *uid_map_file = NULL;
-      cleanup_free char *gid_map_file = NULL;
-      cleanup_free char *uid_map = NULL;
-      cleanup_free char *gid_map = NULL;
-      char buffer[1];
-      size_t len;
-      uid_t uid = -1;
-      gid_t gid = -1;
-
-      close_and_reset (&closep1);
-
-      ret = TEMP_FAILURE_RETRY (read (p[0], buffer, sizeof (buffer)));
-      if (UNLIKELY (ret < 0))
-        _exit (errno);
-
-      if (container->container_def->process && container->container_def->process->user)
-        {
-          uid = container->container_def->process->user->uid;
-          gid = container->container_def->process->user->gid;
-        }
-      xasprintf (&uid_map_file, "/proc/%d/uid_map", target_pid);
-      xasprintf (&gid_map_file, "/proc/%d/gid_map", target_pid);
-
-      len = xasprintf (&gid_map, "%d 0 1", gid);
-      ret = write_file (gid_map_file, gid_map, len, err);
-      if (UNLIKELY (ret < 0))
-        _exit (crun_error_get_errno (err));
-
-      len = xasprintf (&uid_map, "%d 0 1", uid);
-      ret = write_file (uid_map_file, uid_map, len, err);
-      if (UNLIKELY (ret < 0))
-        _exit (crun_error_get_errno (err));
-
-      _exit (EXIT_SUCCESS);
-    }
-
-  close_and_reset (&closep0);
-
-  ret = unshare (CLONE_NEWUSER);
-  if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "unshare (CLONE_NEWUSER)");
-
-  ret = TEMP_FAILURE_RETRY (write (p[1], "0", 1));
-  if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "write to sync pipe");
-
-  ret = TEMP_FAILURE_RETRY (waitpid (pid, &pid_status, 0));
-  if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "waitpid for exec child pid");
-
-  if (UNLIKELY (WEXITSTATUS (pid_status) != 0))
-    return crun_make_error (err, WEXITSTATUS (pid_status), "setting mapping for final userns");
-
-  to_unshare = 0;
-  for (i = 0; i < def->linux->namespaces_len; i++)
-    {
-      if (def->linux->namespaces[i]->path != NULL && def->linux->namespaces[i]->path[0] != '\0')
-        continue;
-
-      to_unshare |= libcrun_find_namespace (def->linux->namespaces[i]->type);
-    }
-
-  if (to_unshare)
-    {
-      ret = unshare (to_unshare & (CLONE_NEWIPC | CLONE_NEWNET | CLONE_NEWNS));
-      if (UNLIKELY (ret < 0))
-        return crun_make_error (err, errno, "unshare");
-    }
-
   return 0;
 }


### PR DESCRIPTION
the workaround is not required anymore since all the needed pieces to
support running with a single user mapped with non-zero UID are
already implemented in Podman.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>