### PR TITLE
some little bug fix maybe

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1441,6 +1441,8 @@ run_process_with_stdin_timeout_envp (char *path, char **args, const char *cwd, i
   cleanup_close int pipe_w = -1;
   sigset_t mask;
 
+  sigemptyset (&mask);
+
   ret = pipe (stdin_pipe);
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "pipe");


### PR DESCRIPTION
1. I am not sure why crun config fd 0 in `libcrun_terminal_setup_size`, should it be `fd`?
2. I think we should init `mask` as a empty sigset before call sigaddset.
3. should we unblock sigchld as soon as hook finish?