### PR TITLE
seccomp: use helper process to send listener fd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_PATH_PROG(MD2MAN, go-md2man)
 
 AM_CONDITIONAL([HAVE_MD2MAN], [test "x$ac_cv_path_MD2MAN" != x])
 
-AC_CHECK_HEADERS([error.h linux/openat2.h])
+AC_CHECK_HEADERS([error.h linux/openat2.h stdatomic.h])
 
 AC_CHECK_FUNCS(copy_file_range fgetxattr statx fgetpwent_r issetugid)
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -4187,7 +4187,7 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
             return crun_make_error (err, errno, "read pid from sync socket");
 
           /* Cleanup the first process.  */
-          ret = TEMP_FAILURE_RETRY (waitpid (pid, NULL, 0));
+          ret = waitpid_ignore_stopped (pid, NULL, 0);
 
           pid_to_clean = pid = new_pid;
 
@@ -4231,7 +4231,7 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
             return ret;
 
           /* Cleanup the first process.  */
-          waitpid (pid, NULL, 0);
+          waitpid_ignore_stopped (pid, NULL, 0);
 
           pid_to_clean = pid = grandchild;
         }
@@ -4325,7 +4325,7 @@ join_process_parent_helper (pid_t child_pid, int sync_socket_fd,
     return crun_make_error (err, errno, "read from sync socket");
 
   /* Wait for the child pid so we ensure the grandchild gets properly reparented.  */
-  ret = TEMP_FAILURE_RETRY (waitpid (child_pid, &pid_status, 0));
+  ret = waitpid_ignore_stopped (child_pid, &pid_status, 0);
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "waitpid for exec child pid");
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -33,7 +33,6 @@
 #  define HAVE_NEW_MOUNT_API
 #endif
 
-#include <sys/syscall.h>
 #include <sys/prctl.h>
 #ifdef HAVE_CAP
 #  include <sys/capability.h>
@@ -206,16 +205,6 @@ libcrun_find_namespace (const char *name)
     if (strcmp (it->name, name) == 0)
       return it->value;
   return -1;
-}
-
-static int
-syscall_clone (unsigned long flags, void *child_stack)
-{
-#if defined __s390__ || defined __CRIS__
-  return (int) syscall (__NR_clone, child_stack, flags);
-#else
-  return (int) syscall (__NR_clone, flags, child_stack);
-#endif
 }
 
 #ifndef __aligned_u64

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -23,6 +23,7 @@
 #include "error.h"
 #include <errno.h>
 #include <argp.h>
+#include <sys/syscall.h>
 #include <runtime_spec_schema_config_schema.h>
 #include "container.h"
 #include "status.h"
@@ -37,6 +38,16 @@ struct device_s
   uid_t uid;
   gid_t gid;
 };
+
+static inline int
+syscall_clone (unsigned long flags, void *child_stack)
+{
+#if defined __s390__ || defined __CRIS__
+  return (int) syscall (__NR_clone, child_stack, flags);
+#else
+  return (int) syscall (__NR_clone, flags, child_stack);
+#endif
+}
 
 typedef int (*container_entrypoint_t) (void *args, char *notify_socket, int sync_socket, libcrun_error_t *err);
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1558,15 +1558,11 @@ run_process_with_stdin_timeout_envp (char *path, char **args, const char *cwd, i
     }
 
 read_waitpid:
-  r = TEMP_FAILURE_RETRY (waitpid (pid, &status, 0));
+  r = waitpid_ignore_stopped (pid, &status, 0);
   if (r < 0)
     ret = crun_make_error (err, errno, "waitpid");
-  else if (WIFEXITED (status))
-    ret = WEXITSTATUS (status);
-  else if (WIFSIGNALED (status))
-    ret = 127 + WTERMSIG (status);
   else
-    ret = crun_make_error (err, 0, "invalid return status for process");
+    ret = get_process_exit_status (status);
 
   /* Prevent to cleanup the pid again.  */
   pid = 0;

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -349,4 +349,32 @@ is_empty_string (const char *s)
   return s == NULL || s[0] == '\0';
 }
 
+static inline int
+waitpid_ignore_stopped (pid_t pid, int *status, int options)
+{
+  int ret, s = 0;
+  do
+    {
+      ret = TEMP_FAILURE_RETRY (waitpid (pid, &s, options));
+      if (ret < 0)
+        return ret;
+  } while (WIFSTOPPED (s) | WIFCONTINUED (s));
+
+  if (status)
+    *status = s;
+
+  return ret;
+}
+
+static inline int
+get_process_exit_status (int status)
+{
+  if (WIFEXITED (status))
+    return WEXITSTATUS (status);
+  if (WIFSIGNALED (status))
+    return 128 + WTERMSIG (status);
+
+  return -1;
+}
+
 #endif

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -50,6 +50,7 @@
 #define cleanup_dir __attribute__ ((cleanup (cleanup_dirp)))
 #define arg_unused __attribute__ ((unused))
 #define cleanup_pid __attribute__ ((cleanup (cleanup_pidp)))
+#define cleanup_mmap __attribute__ ((cleanup (cleanup_mmapp)))
 
 #define LIKELY(x) __builtin_expect ((x), 1)
 #define UNLIKELY(x) __builtin_expect ((x), 0)
@@ -113,6 +114,34 @@ cleanup_pidp (void *p)
       TEMP_FAILURE_RETRY (kill (*pp, SIGKILL));
       TEMP_FAILURE_RETRY (waitpid (*pp, NULL, 0));
     }
+}
+
+struct libcrun_mmap_s
+{
+  void *addr;
+  size_t length;
+};
+
+int libcrun_mmap (struct libcrun_mmap_s **ret, void *addr, size_t length,
+                  int prot, int flags, int fd, off_t offset,
+                  libcrun_error_t *err);
+
+int libcrun_munmap (struct libcrun_mmap_s *mmap, libcrun_error_t *err);
+
+static inline void
+cleanup_mmapp (void *p)
+{
+  int ret;
+  libcrun_error_t tmp_err = NULL;
+  struct libcrun_mmap_s **mm;
+
+  mm = (struct libcrun_mmap_s **) p;
+  if (*mm == NULL)
+    return;
+
+  ret = libcrun_munmap (*mm, &tmp_err);
+  if (UNLIKELY (ret < 0))
+    crun_error_release (&tmp_err);
 }
 
 struct libcrun_fd_map


### PR DESCRIPTION
use a helper process to send the listener fd to the child process, in
this way the sendmssg syscall happens from an environment that is not
seccomp filtered.
    
The helper process shares the fd table with the main process, so there
is no need to send the fd around, and no syscalls are invoked between
the seccomp filter setup and the sendmssg, so that all syscalls can
use SCMP_ACT_NOTIFY without any risk of deadlocking the runtime itself.
    
Closes: https://github.com/containers/crun/issues/1002
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
