### PR TITLE
Copr: wasmtime support only for non-x86

### DIFF
--- a/rpm/crun.spec.in
+++ b/rpm/crun.spec.in
@@ -8,8 +8,10 @@
 %endif
 
 %if 0%{?fedora}
+%ifnarch %{ix86}
 %global wasmtime_support enabled
 %global wasmtime_opts --with-wasmtime
+%endif
 %endif
 
 Summary: OCI runtime written in C


### PR DESCRIPTION
wasmtime-c-api-devel package has not been enabled for i386 on the
podman-next copr, hence wasmtime support should be disabled for crun on
i386.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@giuseppe @rhatdan @flouthoc PTAL