### PR TITLE
crun: reintroduce `-V` (uppercase) as an alias for `--version`

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -191,6 +191,7 @@ get_command (const char *arg)
 enum
 {
   OPTION_VERSION = 'v',
+  OPTION_VERSION_CAP = 'V',
   OPTION_DEBUG = 1000,
   OPTION_SYSTEMD_CGROUP,
   OPTION_CGROUP_MANAGER,
@@ -210,6 +211,8 @@ static struct argp_option options[] = { { "debug", OPTION_DEBUG, 0, 0, "produce 
                                         { "root", OPTION_ROOT, "DIR", 0, NULL, 0 },
                                         { "rootless", OPTION_ROOT, "VALUE", 0, NULL, 0 },
                                         { "version", OPTION_VERSION, 0, 0, NULL, 0 },
+                                        // alias OPTION_VERSION_CAP with OPTION_VERSION
+                                        { NULL, OPTION_VERSION_CAP, 0, OPTION_ALIAS, NULL, 0 },
                                         {
                                             0,
                                         } };
@@ -302,6 +305,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
       libcrun_fail_with_error (0, "please specify a command");
 
     case OPTION_VERSION:
+    case OPTION_VERSION_CAP:
       print_version (stdout, state);
       exit (EXIT_SUCCESS);
     default:


### PR DESCRIPTION
PR https://github.com/containers/crun/pull/1005 added support for `-v`
(lowercase) but dropped already working `-V` (uppercase) although less
critical but looks like a breaking change hence reintroduce `-V`
(uppercase) as argp alias to `-v` and `--version`.

See: Option `OPTION_ALIAS` here: https://www.gnu.org/software/libc/manual/html_node/Argp-Option-Flags.html

Output of `crun --help`
```console
crun --help
Usage: crun [OPTION...] COMMAND [OPTION...]

COMMANDS:
	create      - create a container
	delete      - remove definition for a container
	exec        - exec a command in a running container
	list        - list known containers
	kill        - send a signal to the container init process
	ps          - show the processes in the container
	run         - run a container
	spec        - generate a configuration file
	start       - start a container
	state       - output the state of a container
	pause       - pause all the processes in the container
	resume      - unpause the processes in the container
	update      - update container resource constraints

      --cgroup-manager=MANAGER   cgroup manager
      --debug                produce verbose output
      --log=FILE
      --log-format=FORMAT
      --root=DIR
      --rootless=VALUE
      --systemd-cgroup       use systemd cgroups
  -?, --help                 Give this help list
      --usage                Give a short usage message
  -v, -V, --version

Report bugs to https://github.com/containers/crun/issues.
```