### PR TITLE
Copr: Fix i386 builds

### DIFF
--- a/rpm/crun.spec.in
+++ b/rpm/crun.spec.in
@@ -7,11 +7,8 @@
 %endif
 %endif
 
-%if 0%{?fedora}
-%ifnarch %{ix86}
+%ifnarch %{ix86} || ppc64le
 %global wasmtime_support enabled
-%global wasmtime_opts --with-wasmtime
-%endif
 %endif
 
 Summary: OCI runtime written in C
@@ -30,7 +27,6 @@ URL: https://github.com/containers/%{name}
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: gcc
-BuildRequires: python
 BuildRequires: git-core
 BuildRequires: libcap-devel
 %if "%{krun_support}" == "enabled"
@@ -45,6 +41,11 @@ BuildRequires: go-md2man
 %if "%{wasmtime_support}" == "enabled"
 BuildRequires: wasmtime-c-api-devel
 Requires: wasmtime-c-api
+%endif
+%if 0%{?rhel} == 8
+BuildRequires: python3
+%else
+BuildRequires: python
 %endif
 Provides: oci-runtime
 
@@ -65,7 +66,11 @@ krun is a symlink to the crun binary, with libkrun as an additional dependency.
 
 %build
 ./autogen.sh
-./configure --disable-silent-rules %{wasmtime_opts} %{krun_opts}
+%if "%{wasmtime_support}" == "enabled"
+./configure --disable-silent-rules --with-wasmtime %{krun_opts}
+%else
+./configure --disable-silent-rules %{krun_opts}
+%endif
 %make_build
 
 %install


### PR DESCRIPTION
Follow up on f34ebf2.

Also disable wasmtime support for ppc64le as there are no successful wasmtime builds for it yet.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

Successful build for all arches along with centos and epel https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/4830805/

@giuseppe @flouthoc PTAL. Sorry my previous commit didn't actually fix i386 builds because it kept complaining about `wasmtime_opts-unknown`, so I just got rid of that macro. The current patch is a little ugly, but works.