### PR TITLE
add support for setting the domainname if provided in the spec

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1155,6 +1155,10 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
   if (UNLIKELY (ret < 0))
     return ret;
 
+  ret = libcrun_set_domainname (container, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   if (container->container_def->linux && container->container_def->linux->personality)
     {
       ret = libcrun_set_personality (container->container_def->linux->personality, err);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3114,6 +3114,22 @@ libcrun_set_hostname (libcrun_container_t *container, libcrun_error_t *err)
 }
 
 int
+libcrun_set_domainname (libcrun_container_t *container, libcrun_error_t *err)
+{
+  runtime_spec_schema_config_schema *def = container->container_def;
+  int has_uts = get_private_data (container)->unshare_flags & CLONE_NEWUTS;
+  int ret;
+  if (is_empty_string (def->domainname))
+    return 0;
+  if (! has_uts)
+    return crun_make_error (err, 0, "domainname requires the UTS namespace");
+  ret = setdomainname (def->domainname, strlen (def->domainname));
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "setdomainname");
+  return 0;
+}
+
+int
 libcrun_set_oom (libcrun_container_t *container, libcrun_error_t *err)
 {
   runtime_spec_schema_config_schema *def = container->container_def;

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -69,6 +69,7 @@ int libcrun_set_rlimits (runtime_spec_schema_config_schema_process_rlimits_eleme
 int libcrun_set_selinux_exec_label (runtime_spec_schema_config_schema_process *proc, libcrun_error_t *err);
 int libcrun_set_apparmor_profile (runtime_spec_schema_config_schema_process *proc, libcrun_error_t *err);
 int libcrun_set_hostname (libcrun_container_t *container, libcrun_error_t *err);
+int libcrun_set_domainname (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_oom (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_terminal (libcrun_container_t *container, libcrun_error_t *err);

--- a/tests/init.c
+++ b/tests/init.c
@@ -468,7 +468,20 @@ main (int argc, char **argv)
         error (EXIT_FAILURE, errno, "printf");
       return 0;
     }
+  if (strcmp (argv[1], "getdomainname") == 0)
+    {
+      char buffer[64] = {};
+      int ret;
 
+      ret = getdomainname (buffer, sizeof (buffer) - 1);
+      if (ret < 0)
+        error (EXIT_FAILURE, errno, "getdomainname");
+
+      ret = printf ("%s\n", buffer);
+      if (ret < 0)
+        error (EXIT_FAILURE, errno, "printf");
+      return 0;
+    }
   if (strcmp (argv[1], "isatty") == 0)
     {
       int fd;

--- a/tests/test_domainname.py
+++ b/tests/test_domainname.py
@@ -1,0 +1,47 @@
+#!/bin/env python3
+# crun - OCI runtime written in C
+#
+# Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+# crun is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# crun is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with crun.  If not, see <http://www.gnu.org/licenses/>.
+
+from tests_utils import *
+
+def test_domainname():
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'getdomainname']
+    conf['domainname'] = "foomachine"
+    add_all_namespaces(conf)
+    out, _ = run_and_get_output(conf)
+    if "foomachine" not in out:
+        return -1
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'getdomainname']
+    add_all_namespaces(conf, utsns=False)
+    try:
+        _, cid = run_and_get_output(conf)
+        sys.stderr.write("unexpected success\n")
+        return -1
+    except:
+        return 0
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+
+    
+all_tests = {
+    "domainname" : test_domainname,
+}
+
+if __name__ == "__main__":
+    tests_main(all_tests)


### PR DESCRIPTION
the runtime-spec recently gained the ability to store the domainname for a container. This field functions very similarly to hostname, where if provided the field is funneled into the `setdomainname` command

Signed-off-by: Charlie Doern <cdoern@redhat.com>