### PR TITLE
python: Fix argument parsing in make_context

### DIFF
--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -121,7 +121,7 @@ make_context (PyObject *self, PyObject *args, PyObject *kwargs)
   char *state_root = NULL;
   char *notify_socket = NULL;
   static char *kwlist[] =
-    { "id", "state-root", "systemd-cgroup", "notify-socket", "detach", NULL };
+    { "id", "bundle", "state-root", "systemd-cgroup", "notify-socket", "detach", NULL };
   libcrun_context_t *ctx = malloc (sizeof (*ctx));
   if (ctx == NULL)
     return NULL;
@@ -130,7 +130,7 @@ make_context (PyObject *self, PyObject *args, PyObject *kwargs)
   ctx->fifo_exec_wait_fd = -1;
 
   if (!PyArg_ParseTupleAndKeywords
-      (args, kwargs, "s|sssbsb", kwlist, &id, &bundle, &state_root,
+      (args, kwargs, "s|ssbsb", kwlist, &id, &bundle, &state_root,
        &ctx->systemd_cgroup, &notify_socket, &ctx->detach))
     return NULL;
 


### PR DESCRIPTION
In `make_context`, the number of arguments in the format string passed to `PyArg_ParseTupleAndKeywords` was not matching with the number of entries in `kwlist`, resulting in an error when trying to pass non-mandatory arguments such as `detach`.

For example, the following program:
```python
import python_crun
context = python_crun.make_context("test", detach=True)
```

Resulted in the following error:
```
Traceback (most recent call last):
  File ".../test.py", line 2, in <module>
    context = python_crun.make_context("test", detach=True)
SystemError: more argument specifiers than keyword list entries (remaining format:'sb')
```