### PR TITLE
crun: dlopen libcrun

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,9 +90,14 @@ endif
 crun_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -D CRUN_LIBDIR="\"$(CRUN_LIBDIR)\""
 crun_SOURCES = src/crun.c src/run.c src/delete.c src/kill.c src/pause.c src/unpause.c src/spec.c \
 		src/exec.c src/list.c src/create.c src/start.c src/state.c src/update.c src/ps.c \
-		src/checkpoint.c src/restore.c
+		src/checkpoint.c src/restore.c src/libcrun/cloned_binary.c
+
+if DYNLOAD_LIBCRUN
+crun_LDFLAGS = -Wl,--unresolved-symbols=ignore-all $(CRUN_LDFLAGS)
+else
 crun_LDADD = libcrun.la $(FOUND_LIBS) $(maybe_libyajl.la)
 crun_LDFLAGS = $(CRUN_LDFLAGS)
+endif
 
 EXTRA_DIST = COPYING COPYING.libcrun README.md NEWS SECURITY.md rpm/crun.spec.in autogen.sh \
 	src/crun.h src/list.h src/run.h src/delete.h src/kill.h src/pause.h src/unpause.h \

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,16 @@ case "${enableval}" in
 	*) AC_MSG_ERROR(bad value ${enableval} for --enable-embedded-yajl) ;;
 esac],[embedded_yajl=false])
 
+AC_ARG_ENABLE(dynload-libcrun,
+AS_HELP_STRING([--enable-dynload-libcrun], [Dynamically load libcrun]),
+[
+case "${enableval}" in
+	yes) dynload_libcrun=true ;;
+	no)  dynload_libcrun=false ;;
+	*) AC_MSG_ERROR(bad value ${enableval} for --enable-dynload-libcrun) ;;
+esac],[dynload_libcrun=false])
+AM_CONDITIONAL([DYNLOAD_LIBCRUN], [test x"$dynload_libcrun" = xtrue])
+
 AM_CONDITIONAL([HAVE_EMBEDDED_YAJL], [test x"$embedded_yajl" = xtrue])
 AM_COND_IF([HAVE_EMBEDDED_YAJL], [], [
 AC_SEARCH_LIBS(yajl_tree_get, [yajl], [AC_DEFINE([HAVE_YAJL], 1, [Define if libyajl is available])], [AC_MSG_ERROR([*** libyajl headers not found])])
@@ -137,14 +147,34 @@ AS_IF([test "x$enable_bpf" != "xno"], [
 	])
 ])
 
+use_fPIC=no
+libcrun_public='__attribute__((visibility("default"))) extern'
+if test "x$enable_shared" = "xyes"; then
+        AC_DEFINE([SHARED_LIBCRUN], 1, [Define if shared libraries are enabled])
+        AC_SUBST([SHARED_LIBCRUN])
+        use_fPIC=yes
+        if test "x$dynload_libcrun" = "xyes"; then
+            libcrun_public='__attribute__((visibility("default"))) __attribute__((weak)) extern'
+            AC_DEFINE([DYNLOAD_LIBCRUN], 1, [Define if shared libraries are enabled])
+            AC_SUBST([DYNLOAD_LIBCRUN])
+        else
+            libcrun_public='__attribute__((visibility("default"))) extern'
+        fi
+fi
+
+AC_DEFINE_UNQUOTED([LIBCRUN_PUBLIC], [$libcrun_public], [LIBCRUN_PUBLIC])
 
 AC_ARG_WITH([python-bindings], AS_HELP_STRING([--with-python-bindings], [build the Python bindings]))
 AS_IF([test "x$with_python_bindings" = "xyes"], [
 	PKG_CHECK_MODULES([PYTHON], [python3], [], [AC_MSG_ERROR([*** python headers not found])])
+        use_fPIC=yes
+])
+
+AS_IF([test "x$use_fPIC" = "xyes"], [
 	# configure should not touch CFLAGS/LDFLAGS but we need it to propagate it
 	# to libocispec.
-	CFLAGS+=" -fPIC "
-	LDFLAGS+=" -fPIC "
+	export CFLAGS="$CFLAGS -fPIC"
+	export LDFLAGS="$LDFLAGS -fPIC"
 ])
 
 dnl criu
@@ -201,7 +231,6 @@ AC_COMPILE_IFELSE(
 		 AC_DEFINE([HAVE_SECCOMP_GET_NOTIF_SIZES], 1, [Define if SECCOMP_GET_NOTIF_SIZES is available])],
 		[AC_MSG_RESULT(no)])
 
-AC_DEFINE([LIBCRUN_PUBLIC], [__attribute__((visibility("default"))) extern], [LIBCRUN_PUBLIC])
 AC_SUBST([FOUND_LIBS])
 AC_SUBST([CRUN_LDFLAGS])
 
@@ -223,6 +252,7 @@ AC_SEARCH_LIBS([argp_parse], [argp], [], [AC_MSG_ERROR([*** argp functions not f
 
 AM_CONDITIONAL([PYTHON_BINDINGS], [test "x$with_python_bindings" = "xyes"])
 AM_CONDITIONAL([CRIU_SUPPORT], [test "x$have_criu" = "xyes"])
+AM_CONDITIONAL([SHARED_LIBCRUN], [test "x$enable_shared" = "xyes"])
 
 AC_CONFIG_FILES([Makefile rpm/crun.spec])
 

--- a/src/exec.c
+++ b/src/exec.c
@@ -229,6 +229,10 @@ make_oci_process_user (const char *userspec)
 
 #define cleanup_process_schema __attribute__ ((cleanup (cleanup_process_schemap)))
 
+#ifdef SHARED_LIBCRUN
+void __attribute__ ((weak)) free_runtime_spec_schema_config_schema_process (runtime_spec_schema_config_schema_process *ptr);
+#endif
+
 static inline void
 cleanup_process_schemap (runtime_spec_schema_config_schema_process **p)
 {

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -195,6 +195,8 @@ LIBCRUN_PUBLIC int libcrun_container_restore (libcrun_context_t *context, const 
 
 LIBCRUN_PUBLIC int libcrun_container_read_pids (libcrun_context_t *context, const char *id, bool recurse, pid_t **pids, libcrun_error_t *err);
 
+LIBCRUN_PUBLIC int libcrun_write_json_containers_list (libcrun_context_t *context, FILE *out, libcrun_error_t *err);
+
 // Not part of the public API, just a method in container.c we need to access from linux.c
 void get_root_in_the_userns (runtime_spec_schema_config_schema *def, uid_t host_uid, gid_t host_gid,
                              uid_t *uid, gid_t *gid);

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -169,6 +169,18 @@ LIBCRUN_PUBLIC int libcrun_container_update (libcrun_context_t *context, const c
 LIBCRUN_PUBLIC int libcrun_container_update_from_file (libcrun_context_t *context, const char *id, const char *file,
                                                        libcrun_error_t *err);
 
+struct libcrun_update_value_s
+{
+  const char *section;
+  const char *name;
+  bool numeric;
+  const char *value;
+};
+
+LIBCRUN_PUBLIC int libcrun_container_update_from_values (libcrun_context_t *context, const char *id,
+                                                         struct libcrun_update_value_s *values, size_t len,
+                                                         libcrun_error_t *err);
+
 LIBCRUN_PUBLIC int libcrun_container_spec (bool root, FILE *out, libcrun_error_t *err);
 
 LIBCRUN_PUBLIC int libcrun_container_pause (libcrun_context_t *context, const char *id, libcrun_error_t *err);


### PR DESCRIPTION
If crun is compiled with --enable-shared, then open the libcrun
dependency with dlopen.  This is useful to reduce the number of
syscalls crun performs before re-execing itself (through
cloned_binary.c), since every ELF dependency is resolved by the
dynamic loader before the program is executed.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
