### PR TITLE
python: Fix argument type in container_delete

### DIFF
--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -211,7 +211,7 @@ container_delete (PyObject *self, PyObject *args)
   libcrun_context_t *ctx;
   int ret;
 
-  if (!PyArg_ParseTuple (args, "Osn", &ctx_obj, &id, &force))
+  if (!PyArg_ParseTuple (args, "Osb", &ctx_obj, &id, &force))
     return NULL;
 
   ctx = PyCapsule_GetPointer (ctx_obj, CONTEXT_OBJ_TAG);


### PR DESCRIPTION
In `container_delete`, the type used for the `force` boolean should be `b` (a single unsigned byte) instead of `n` (the size of `size_t`). This incorrect type can cause the neighboring `id` argument to be overwritten with a NULL value, which makes the container deletion fail.

For example, assuming the `test` container exists, the following program:

```python
import python_crun
context = python_crun.make_context("test")
python_crun.delete(context, "test", True)
```

Previously resulted in the following error:

```
Traceback (most recent call last):
  File ".../test.py", line 3, in <module>
    python_crun.delete(context, "test", True)
RuntimeError: cannot open directory '/run/user/1000/crun/(null)': Bad address
```