### PR TITLE
Refer to libocispec header files under ocispec/

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -18,7 +18,7 @@
 #define _GNU_SOURCE
 
 #include <config.h>
-#include <runtime_spec_schema_config_schema.h>
+#include <ocispec/runtime_spec_schema_config_schema.h>
 #include <stdbool.h>
 #include "container.h"
 #include "utils.h"

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -20,7 +20,7 @@
 #define CONTAINER_H
 
 #include <config.h>
-#include <runtime_spec_schema_config_schema.h>
+#include <ocispec/runtime_spec_schema_config_schema.h>
 #include "error.h"
 
 enum handler_configure_phase

--- a/src/libcrun/ebpf.h
+++ b/src/libcrun/ebpf.h
@@ -24,7 +24,7 @@
 #include "error.h"
 #include <errno.h>
 #include <argp.h>
-#include <runtime_spec_schema_config_schema.h>
+#include <ocispec/runtime_spec_schema_config_schema.h>
 #include "container.h"
 
 struct bpf_program;

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -24,7 +24,7 @@
 #include <errno.h>
 #include <argp.h>
 #include <sys/syscall.h>
-#include <runtime_spec_schema_config_schema.h>
+#include <ocispec/runtime_spec_schema_config_schema.h>
 #include "container.h"
 #include "status.h"
 

--- a/src/libcrun/seccomp.h
+++ b/src/libcrun/seccomp.h
@@ -23,7 +23,7 @@
 #include "error.h"
 #include <errno.h>
 #include <argp.h>
-#include <runtime_spec_schema_config_schema.h>
+#include <ocispec/runtime_spec_schema_config_schema.h>
 #include "container.h"
 
 enum

--- a/src/libcrun/status.h
+++ b/src/libcrun/status.h
@@ -20,7 +20,7 @@
 #define STATUS_H
 
 #include <config.h>
-#include <runtime_spec_schema_config_schema.h>
+#include <ocispec/runtime_spec_schema_config_schema.h>
 #include "error.h"
 #include "container.h"
 

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -27,7 +27,7 @@
 #include <dirent.h>
 #include <unistd.h>
 #include <signal.h>
-#include <runtime_spec_schema_config_schema.h>
+#include <ocispec/runtime_spec_schema_config_schema.h>
 #include <sys/wait.h>
 #include "container.h"
 


### PR DESCRIPTION
Because of the changes in https://github.com/containers/libocispec/pull/120, we will need to refer to libocispec headers in `ocispec/`.

Signed-off-by: Ronal Abraham <ronalabraham@gmail.com>