### PR TITLE
container: cache the seccomp generated bpf

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ These dependencies are required for the build:
 
 ```console
 $ sudo dnf install -y make python git gcc automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel pkg-config \
+    systemd-devel yajl-devel libseccomp-devel pkg-config libgcrypt-devel \
     go-md2man glibc-static python3-libmount libtool
 ```
 
@@ -70,7 +70,7 @@ $ sudo dnf install -y make python git gcc automake autoconf libcap-devel \
 ```console
 $ sudo yum --enablerepo='*' --disablerepo='media-*' install -y make automake \
     autoconf gettext \
-    libtool gcc libcap-devel systemd-devel yajl-devel \
+    libtool gcc libcap-devel systemd-devel yajl-devel libgcrypt-devel \
     glibc-static libseccomp-devel python36 git
 ```
 
@@ -90,7 +90,7 @@ $ export PATH=$PATH:$GOPATH/bin
 ```console
 $ sudo apt-get install -y make git gcc build-essential pkgconf libtool \
    libsystemd-dev libprotobuf-c-dev libcap-dev libseccomp-dev libyajl-dev \
-   go-md2man autoconf python3 automake
+   libgcrypt20-dev go-md2man autoconf python3 automake
 ```
 
 ### Alpine

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,9 @@ AS_IF([test "x$enable_caps" != "xno"], [
 	])
 ])
 
+dnl libgcrypt
+AC_SEARCH_LIBS([gcry_check_version], [gcrypt], [AC_DEFINE([HAVE_GCRYPT], 1, [Define if gcrypt is available])], [])
+
 dnl dl
 AC_ARG_ENABLE([dl], AS_HELP_STRING([--disable-dl], [Disable dynamic libraries support]))
 AS_IF([test "x$enable_dl" != "xno"], [

--- a/src/crun.c
+++ b/src/crun.c
@@ -30,6 +30,7 @@
 #include "crun.h"
 #include "libcrun/utils.h"
 #include "libcrun/custom-handler.h"
+#include "libcrun/status.h"
 
 /* Commands.  */
 #include "run.h"
@@ -222,8 +223,10 @@ static struct argp_option options[] = { { "debug", OPTION_DEBUG, 0, 0, "produce 
 static void
 print_version (FILE *stream, struct argp_state *state arg_unused)
 {
+  cleanup_free char *rundir = libcrun_get_state_directory (arguments.root, NULL);
   fprintf (stream, "%s version %s\n", PACKAGE_NAME, PACKAGE_VERSION);
   fprintf (stream, "commit: %s\n", GIT_VERSION);
+  fprintf (stream, "rundir: %s\n", rundir);
   fprintf (stream, "spec: 1.0.0\n");
 #ifdef HAVE_SYSTEMD
   fprintf (stream, "+SYSTEMD ");

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2195,6 +2195,9 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
       if (annotation && strcmp (annotation, "0") != 0)
         seccomp_gen_options = LIBCRUN_SECCOMP_FAIL_UNKNOWN_SYSCALL;
 
+      if (seccomp_bpf_data)
+        seccomp_gen_options |= LIBCRUN_SECCOMP_SKIP_CACHE;
+
       libcrun_seccomp_gen_ctx_init (&seccomp_gen_ctx, container, true, seccomp_gen_options);
 
       ret = libcrun_open_seccomp_bpf (&seccomp_gen_ctx, &seccomp_fd, err);

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3275,6 +3275,8 @@ libcrun_container_exec_with_options (libcrun_context_t *context, const char *id,
   if (container == NULL)
     return crun_make_error (err, 0, "error loading config.json");
 
+  container->context = context;
+
   if (container_status == 0)
     return crun_make_error (err, 0, "the container `%s` is not running", id);
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2313,27 +2313,9 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
     {
       if (seccomp_bpf_data != NULL)
         {
-          cleanup_free char *bpf_data = NULL;
-          size_t size = 0;
-          size_t in_size;
-          int consumed;
-
-          in_size = strlen (seccomp_bpf_data);
-          bpf_data = xmalloc (in_size + 1);
-
-          consumed = base64_decode (seccomp_bpf_data, in_size, bpf_data, in_size, &size);
-          if (UNLIKELY (consumed != (int) in_size))
-            {
-              ret = crun_make_error (err, 0, "invalid seccomp BPF data");
-              goto fail;
-            }
-
-          ret = safe_write (seccomp_fd, bpf_data, (ssize_t) size);
+          ret = libcrun_copy_seccomp (&seccomp_gen_ctx, seccomp_bpf_data, err);
           if (UNLIKELY (ret < 0))
-            {
-              ret = crun_make_error (err, 0, "write to seccomp fd");
-              goto fail;
-            }
+            goto fail;
         }
       else
         {

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -33,6 +33,7 @@
 #include <sys/resource.h>
 #include <sys/sysmacros.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 
@@ -81,6 +82,21 @@
 #ifndef SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
 #  define SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV (1UL << 5)
 #endif
+
+#define SECCOMP_CACHE_DIR ".cache/seccomp"
+
+/* On Linux 5.19.15 x86_64, tmpfs reports 20 bytes + 20 bytes for each entry, so allow
+   at least 32 entries.  */
+#define MIN_CACHE_DIR_INODE_SIZE (20 + 32 * 20)
+
+/* Heuristic to avoid the cache directory grows indefinitely.  The inode size for
+   the directory is proportional to the number of entries it contains and it is
+   cheaper to compute than iterating the cache directory.  */
+static inline off_t
+get_cache_dir_inode_max_size (off_t size_rundir)
+{
+  return size_rundir * 3 + MIN_CACHE_DIR_INODE_SIZE;
+}
 
 static int
 syscall_seccomp (unsigned int operation, unsigned int flags, void *args)
@@ -344,15 +360,23 @@ seccomp_action_supports_errno (const char *action)
          || strcmp (action, "SCMP_ACT_TRACE") == 0;
 }
 
+/* Calculate a checksum for the specified seccomp configuration.
+
+   Returns:
+   < 0 in case of errors
+     0 if the checksum is not supported
+   > 0 the checksum is supported and the value is in OUT.
+ */
 static int
-calculate_seccomp_checksum (libcrun_container_t *container, unsigned int seccomp_gen_options, seccomp_checksum_t out, libcrun_error_t *err)
+calculate_seccomp_checksum (runtime_spec_schema_config_linux_seccomp *seccomp, unsigned int seccomp_gen_options, seccomp_checksum_t out, libcrun_error_t *err)
 {
 #if HAVE_GCRYPT
-  runtime_spec_schema_config_linux_seccomp *seccomp;
   gcry_error_t gcrypt_err;
+  struct utsname utsbuf;
   unsigned char *res;
   gcry_md_hd_t hd;
   size_t i;
+  int ret;
 
 #  define PROCESS_STRING(X)                      \
     do                                           \
@@ -367,15 +391,6 @@ calculate_seccomp_checksum (libcrun_container_t *container, unsigned int seccomp
       {                                       \
         gcry_md_write (hd, &(X), sizeof (X)); \
     } while (0)
-
-  out[0] = 0;
-
-  if (container == NULL || container->container_def == NULL || container->container_def->linux == NULL)
-    return 0;
-
-  seccomp = container->container_def->linux->seccomp;
-  if (seccomp == NULL)
-    return 0;
 
   gcrypt_err = gcry_md_open (&hd, GCRY_MD_SHA256, 0);
   if (gcrypt_err)
@@ -392,6 +407,15 @@ calculate_seccomp_checksum (libcrun_container_t *container, unsigned int seccomp
     PROCESS_DATA (version->micro);
   }
 #  endif
+
+  memset (&utsbuf, 0, sizeof (utsbuf));
+  ret = uname (&utsbuf);
+  if (UNLIKELY (ret != 0))
+    return crun_make_error (err, errno, "uname");
+
+  PROCESS_STRING (utsbuf.release);
+  PROCESS_STRING (utsbuf.version);
+  PROCESS_STRING (utsbuf.machine);
 
   PROCESS_DATA (seccomp_gen_options);
 
@@ -429,13 +453,215 @@ calculate_seccomp_checksum (libcrun_container_t *container, unsigned int seccomp
 
 #  undef PROCESS_STRING
 #  undef PROCESS_DATA
+  return 1;
 #else
-  (void) container;
+  (void) seccomp;
   (void) seccomp_gen_options;
   (void) out;
   (void) err;
   out[0] = 0;
+  return 0;
 #endif
+}
+
+static int
+open_rundir_dirfd (const char *state_root, libcrun_error_t *err)
+{
+  cleanup_free char *dir = NULL;
+  int dirfd;
+
+  dir = libcrun_get_state_directory (state_root, NULL);
+  if (UNLIKELY (dir == NULL))
+    return crun_make_error (err, 0, "cannot get state directory");
+
+  dirfd = TEMP_FAILURE_RETRY (open (dir, O_PATH | O_DIRECTORY | O_CLOEXEC));
+  if (UNLIKELY (dirfd < 0))
+    return crun_make_error (err, errno, "open `%s`", dir);
+
+  return dirfd;
+}
+
+struct cache_entry
+{
+  seccomp_checksum_t checksum;
+  struct timespec atime;
+};
+
+static int
+compare_entries_by_atime (const void *a, const void *b)
+{
+  const struct cache_entry *entry_a = a;
+  const struct cache_entry *entry_b = b;
+  int ret;
+
+  ret = entry_a->atime.tv_sec - entry_b->atime.tv_sec;
+  if (ret)
+    return ret;
+
+  return entry_a->atime.tv_nsec - entry_b->atime.tv_nsec;
+}
+
+static int
+evict_cache (int root_dfd, libcrun_error_t *err)
+{
+  cleanup_close int cache_dir_fd = -1;
+  off_t cache_dir_inode_max_size;
+  struct stat st;
+  int ret;
+
+  ret = TEMP_FAILURE_RETRY (fstat (root_dfd, &st));
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "fstat rundir");
+
+  cache_dir_inode_max_size = get_cache_dir_inode_max_size (st.st_size);
+
+  cache_dir_fd = TEMP_FAILURE_RETRY (openat (root_dfd, SECCOMP_CACHE_DIR, O_DIRECTORY | O_CLOEXEC));
+  if (UNLIKELY (cache_dir_fd < 0))
+    {
+      if (errno == ENOENT)
+        return 0;
+      return crun_make_error (err, errno, "open `%s`", SECCOMP_CACHE_DIR);
+    }
+
+  ret = TEMP_FAILURE_RETRY (fstat (cache_dir_fd, &st));
+  if (ret == 0 && st.st_size > cache_dir_inode_max_size)
+    {
+      cleanup_free struct cache_entry *entries = NULL;
+      cleanup_dir DIR *d = NULL;
+      size_t i, n_entries = 0;
+      struct dirent *de;
+      int dfd;
+
+      d = fdopendir (cache_dir_fd);
+      if (d == NULL)
+        return crun_make_error (err, errno, "cannot open seccomp cache directory");
+      /* fdopendir owns the fd now.  */
+      cache_dir_fd = -1;
+
+      dfd = dirfd (d);
+      while ((de = readdir (d)))
+        {
+          if (de->d_name[0] == '.')
+            continue;
+
+          ret = TEMP_FAILURE_RETRY (fstatat (dfd, de->d_name, &st, AT_SYMLINK_NOFOLLOW));
+          if (UNLIKELY (ret < 0))
+            continue;
+
+          /* The cache file is already used, it is pointless to free it.  */
+          if (st.st_nlink > 1)
+            continue;
+
+          /* If the sticky bit is set, then ignore it.  */
+          if (st.st_mode & S_ISVTX)
+            continue;
+
+          if (strlen (de->d_name) != sizeof (seccomp_checksum_t) - 1)
+            {
+              /* No mercy for unknown files.  */
+              unlinkat (dfd, de->d_name, 0);
+              continue;
+            }
+          else
+            {
+              entries = xrealloc (entries, sizeof (struct cache_entry) * (n_entries + 1));
+
+              memcpy (entries[n_entries].checksum, de->d_name, sizeof (seccomp_checksum_t));
+              entries[n_entries].atime = st.st_atim;
+              n_entries++;
+            }
+        }
+
+      qsort (entries, n_entries, sizeof (struct cache_entry), compare_entries_by_atime);
+
+      /* Attempt to delete half of them.  */
+      for (i = 0; i < (n_entries == 1 ? 1 : n_entries / 2); i++)
+        unlinkat (dfd, entries[i].checksum, 0);
+    }
+  return 0;
+}
+
+static int
+store_seccomp_cache (struct libcrun_seccomp_gen_ctx_s *ctx, libcrun_error_t *err)
+{
+  libcrun_container_t *container = ctx->container;
+  cleanup_free char *src_path = NULL;
+  cleanup_free char *dest_path = NULL;
+  cleanup_close int dirfd = -1;
+  int ret;
+
+  if (ctx->options & LIBCRUN_SECCOMP_SKIP_CACHE)
+    return 0;
+
+  if (is_empty_string (ctx->checksum))
+    return 0;
+
+  dirfd = open_rundir_dirfd (container->context->state_root, err);
+  if (UNLIKELY (dirfd < 0))
+    return dirfd;
+
+  /* relative path to dirfd.  */
+  ret = append_paths (&src_path, err, container->context->id, "seccomp.bpf", NULL);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = append_paths (&dest_path, err, SECCOMP_CACHE_DIR, ctx->checksum, NULL);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = crun_ensure_directory_at (dirfd, SECCOMP_CACHE_DIR, 0700, true, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = evict_cache (dirfd, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = linkat (dirfd, src_path, dirfd, dest_path, 0);
+  if (UNLIKELY (ret < 0 && errno != EEXIST))
+    return crun_make_error (err, errno, "link `%s` to `%s`", src_path, dest_path);
+  return 0;
+}
+
+static inline runtime_spec_schema_config_linux_seccomp *
+get_seccomp_configuration (struct libcrun_seccomp_gen_ctx_s *ctx)
+{
+  if (ctx->container == NULL || ctx->container->container_def == NULL
+      || ctx->container->container_def->linux == NULL)
+    return 0;
+
+  return ctx->container->container_def->linux->seccomp;
+}
+
+static int
+find_in_cache (struct libcrun_seccomp_gen_ctx_s *ctx, int dirfd, const char *dest_path, bool *created, libcrun_error_t *err)
+{
+  runtime_spec_schema_config_linux_seccomp *seccomp;
+  cleanup_free char *cache_file_path = NULL;
+  int ret;
+
+  if (ctx->options & LIBCRUN_SECCOMP_SKIP_CACHE)
+    return 0;
+
+  seccomp = get_seccomp_configuration (ctx);
+  if (seccomp == NULL)
+    return 0;
+
+  /* if the checksum could not be computed, returns early.  */
+  ret = calculate_seccomp_checksum (seccomp, ctx->options, ctx->checksum, err);
+  if (UNLIKELY (ret <= 0))
+    return ret;
+
+  ret = append_paths (&cache_file_path, err, SECCOMP_CACHE_DIR, ctx->checksum, NULL);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = TEMP_FAILURE_RETRY (linkat (dirfd, cache_file_path, dirfd, dest_path, 0));
+  if (UNLIKELY (ret < 0 && errno != ENOENT))
+    return crun_make_error (err, errno, "linkat `%s` to `%s`", cache_file_path, dest_path);
+
+  *created = ret == 0;
+
   return 0;
 }
 
@@ -449,6 +675,10 @@ libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_err
   cleanup_seccomp scmp_filter_ctx ctx = NULL;
   int action, default_action, default_errno_value = EPERM;
   const char *def_action = NULL;
+
+  /* The bpf filter was loaded from the cache, nothing to do here.  */
+  if (gen_ctx->from_cache)
+    return 0;
 
   if (gen_ctx->container == NULL || gen_ctx->container->container_def == NULL || gen_ctx->container->container_def->linux == NULL)
     return 0;
@@ -605,6 +835,8 @@ libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_err
       ret = seccomp_export_bpf (ctx, gen_ctx->fd);
       if (UNLIKELY (ret < 0))
         return crun_make_error (err, -ret, "seccomp_export_bpf");
+
+      return store_seccomp_cache (gen_ctx, err);
     }
 
   return 0;
@@ -641,7 +873,6 @@ libcrun_open_seccomp_bpf (struct libcrun_seccomp_gen_ctx_s *ctx, int *fd, libcru
 {
   cleanup_close int dirfd = -1;
   cleanup_free char *dest_path = NULL;
-  cleanup_free char *dir = NULL;
   libcrun_container_t *container = ctx->container;
   int ret;
 
@@ -650,13 +881,9 @@ libcrun_open_seccomp_bpf (struct libcrun_seccomp_gen_ctx_s *ctx, int *fd, libcru
   if (container == NULL || container->context == NULL)
     return crun_make_error (err, EINVAL, "invalid internal state");
 
-  dir = libcrun_get_state_directory (container->context->state_root, NULL);
-  if (UNLIKELY (dir == NULL))
-    return crun_make_error (err, 0, "cannot get state directory");
-
-  dirfd = TEMP_FAILURE_RETRY (open (dir, O_PATH | O_DIRECTORY | O_CLOEXEC));
+  dirfd = open_rundir_dirfd (container->context->state_root, err);
   if (UNLIKELY (dirfd < 0))
-    return crun_make_error (err, errno, "open `%s`", dir);
+    return dirfd;
 
   /* relative path to dirfd.  */
   ret = append_paths (&dest_path, err, container->context->id, "seccomp.bpf", NULL);
@@ -665,6 +892,18 @@ libcrun_open_seccomp_bpf (struct libcrun_seccomp_gen_ctx_s *ctx, int *fd, libcru
 
   if (ctx->create)
     {
+      bool created = false;
+
+      ret = find_in_cache (ctx, dirfd, dest_path, &created, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+
+      if (created)
+        {
+          ctx->from_cache = true;
+          goto open_existing_file;
+        }
+
       ret = TEMP_FAILURE_RETRY (openat (dirfd, dest_path, O_RDWR | O_CREAT, 0700));
       if (UNLIKELY (ret < 0))
         return crun_make_error (err, errno, "open `seccomp.bpf`");
@@ -672,6 +911,7 @@ libcrun_open_seccomp_bpf (struct libcrun_seccomp_gen_ctx_s *ctx, int *fd, libcru
     }
   else
     {
+    open_existing_file:
       ret = TEMP_FAILURE_RETRY (openat (dirfd, dest_path, O_RDONLY));
       if (UNLIKELY (ret < 0))
         {

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -614,6 +614,29 @@ libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_err
 }
 
 int
+libcrun_copy_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, const char *b64_bpf, libcrun_error_t *err)
+{
+  cleanup_free char *bpf_data = NULL;
+  size_t size = 0;
+  size_t in_size;
+  int consumed;
+  int ret;
+
+  in_size = strlen (b64_bpf);
+  bpf_data = xmalloc (in_size + 1);
+
+  consumed = base64_decode (b64_bpf, in_size, bpf_data, in_size, &size);
+  if (UNLIKELY (consumed != (int) in_size))
+    return crun_make_error (err, 0, "invalid seccomp BPF data");
+
+  ret = safe_write (gen_ctx->fd, bpf_data, (ssize_t) size);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, 0, "write to seccomp fd");
+
+  return 0;
+}
+
+int
 libcrun_open_seccomp_bpf (struct libcrun_seccomp_gen_ctx_s *ctx, int *fd, libcrun_error_t *err)
 {
   cleanup_free char *dest_path = NULL;

--- a/src/libcrun/seccomp.h
+++ b/src/libcrun/seccomp.h
@@ -53,6 +53,7 @@ static inline void libcrun_seccomp_gen_ctx_init (struct libcrun_seccomp_gen_ctx_
 }
 
 int libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_error_t *err);
+int libcrun_copy_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, const char *b64_bpf, libcrun_error_t *err);
 int libcrun_apply_seccomp (int infd, int listener_receiver_fd, const char *receiver_fd_payload,
                            size_t receiver_fd_payload_len, char **flags, size_t flags_len, libcrun_error_t *err);
 int libcrun_open_seccomp_bpf (struct libcrun_seccomp_gen_ctx_s *ctx, int *fd, libcrun_error_t *err);

--- a/src/libcrun/seccomp.h
+++ b/src/libcrun/seccomp.h
@@ -33,8 +33,28 @@ enum
 
 typedef char seccomp_checksum_t[65];
 
-int libcrun_generate_seccomp (libcrun_container_t *container, int outfd, unsigned int options, libcrun_error_t *err);
+struct libcrun_seccomp_gen_ctx_s
+{
+  libcrun_container_t *container;
+  seccomp_checksum_t checksum;
+  unsigned int options;
+  bool create;
+
+  /* Not owned here, it is the caller responsibility to close it.  */
+  int fd;
+};
+
+static inline void libcrun_seccomp_gen_ctx_init (struct libcrun_seccomp_gen_ctx_s *ctx, libcrun_container_t *container, bool create, unsigned int seccomp_gen_options)
+{
+  memset (ctx, 0, sizeof (*ctx));
+  ctx->create = create;
+  ctx->container = container;
+  ctx->options = seccomp_gen_options;
+}
+
+int libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_error_t *err);
 int libcrun_apply_seccomp (int infd, int listener_receiver_fd, const char *receiver_fd_payload,
                            size_t receiver_fd_payload_len, char **flags, size_t flags_len, libcrun_error_t *err);
+int libcrun_open_seccomp_bpf (struct libcrun_seccomp_gen_ctx_s *ctx, int *fd, libcrun_error_t *err);
 
 #endif

--- a/src/libcrun/seccomp.h
+++ b/src/libcrun/seccomp.h
@@ -31,6 +31,8 @@ enum
   LIBCRUN_SECCOMP_FAIL_UNKNOWN_SYSCALL = 1 << 0,
 };
 
+typedef char seccomp_checksum_t[65];
+
 int libcrun_generate_seccomp (libcrun_container_t *container, int outfd, unsigned int options, libcrun_error_t *err);
 int libcrun_apply_seccomp (int infd, int listener_receiver_fd, const char *receiver_fd_payload,
                            size_t receiver_fd_payload_len, char **flags, size_t flags_len, libcrun_error_t *err);

--- a/src/libcrun/seccomp.h
+++ b/src/libcrun/seccomp.h
@@ -29,6 +29,7 @@
 enum
 {
   LIBCRUN_SECCOMP_FAIL_UNKNOWN_SYSCALL = 1 << 0,
+  LIBCRUN_SECCOMP_SKIP_CACHE = 1 << 1,
 };
 
 typedef char seccomp_checksum_t[65];
@@ -39,12 +40,14 @@ struct libcrun_seccomp_gen_ctx_s
   seccomp_checksum_t checksum;
   unsigned int options;
   bool create;
+  bool from_cache;
 
   /* Not owned here, it is the caller responsibility to close it.  */
   int fd;
 };
 
-static inline void libcrun_seccomp_gen_ctx_init (struct libcrun_seccomp_gen_ctx_s *ctx, libcrun_container_t *container, bool create, unsigned int seccomp_gen_options)
+static inline void
+libcrun_seccomp_gen_ctx_init (struct libcrun_seccomp_gen_ctx_s *ctx, libcrun_container_t *container, bool create, unsigned int seccomp_gen_options)
 {
   memset (ctx, 0, sizeof (*ctx));
   ctx->create = create;

--- a/tests/alpine-build/Dockerfile
+++ b/tests/alpine-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 RUN apk add gcc automake autoconf libtool gettext pkgconf git make musl-dev \
-    python3 libcap-dev libseccomp-dev yajl-dev argp-standalone go-md2man
+    python3 libcap-dev libgcrypt-dev libseccomp-dev yajl-dev argp-standalone go-md2man
 
 COPY run-tests.sh /usr/local/bin
 

--- a/tests/centos8-build/Dockerfile
+++ b/tests/centos8-build/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream8
 
 RUN yum --enablerepo='powertools' install -y make automake autoconf gettext \
     criu-devel libtool gcc libcap-devel systemd-devel yajl-devel \
-    libseccomp-devel python36 libtool git
+    libgcrypt-devel libseccomp-devel python36 libtool git
 
 COPY run-tests.sh /usr/local/bin
 

--- a/tests/centos9-build/Dockerfile
+++ b/tests/centos9-build/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream9
 
 RUN yum  --enablerepo='appstream'  --enablerepo='baseos' --enablerepo='crb' install -y make \
     automake autoconf gettext criu-devel libtool gcc libcap-devel systemd-devel yajl-devel \
-    libseccomp-devel python3 libtool git protobuf-c protobuf-c-devel
+    libgcrypt-devel libseccomp-devel python3 libtool git protobuf-c protobuf-c-devel
 
 COPY run-tests.sh /usr/local/bin
 

--- a/tests/containerd/Dockerfile
+++ b/tests/containerd/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/go/b
 RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get install -y bash golang-1.18 libbtrfs-dev libnl-3-dev libnet1-dev \
-            protobuf-c-compiler libcap-dev libaio-dev \
+            protobuf-c-compiler libgcrypt20-dev libcap-dev libaio-dev \
             curl libprotobuf-c-dev libprotobuf-dev socat libseccomp-dev \
             pigz lsof make git gcc build-essential pkgconf libtool \
             libsystemd-dev libcap-dev libyajl-dev \

--- a/tests/cri-o/Dockerfile
+++ b/tests/cri-o/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 RUN yum install -y python git gcc automake autoconf libcap-devel \
     systemd-devel yajl-devel libseccomp-devel go-md2man conntrack-tools which \
     glibc-static python3-libmount libtool make podman xz nmap-ncat jq bats \
-    iproute openssl iputils socat && \
+    libgcrypt-devel iproute openssl iputils socat && \
     dnf install -y 'dnf-command(builddep)' && dnf builddep -y podman && \
     dnf remove -y golang && \
     sudo dnf update -y && \

--- a/tests/fuzzing/Dockerfile
+++ b/tests/fuzzing/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:latest
 
 RUN yum install -y golang python git automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel go-md2man \
+    libgcrypt-devel systemd-devel yajl-devel libseccomp-devel go-md2man \
     glibc-static python3-libmount libtool make honggfuzz git
 
 RUN git clone https://github.com/giuseppe/containers-fuzzing-corpus /testcases

--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -4,7 +4,7 @@ ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
 RUN dnf install -y golang python git gcc automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel go-md2man \
+    systemd-devel yajl-devel libseccomp-devel go-md2man libgcrypt-devel \
     glibc-static python3-libmount libtool make podman xz nmap-ncat \
     containernetworking-plugins 'dnf-command(builddep)' && \
     dnf builddep -y podman && \

--- a/tests/tests_libcrun_fuzzer.c
+++ b/tests/tests_libcrun_fuzzer.c
@@ -142,6 +142,7 @@ generate_seccomp (uint8_t *buf, size_t len)
   cleanup_container libcrun_container_t *container = NULL;
   cleanup_free char *conf = NULL;
   cleanup_close int outfd = -1;
+  struct libcrun_seccomp_gen_ctx_s ctx;
 
   conf = make_nul_terminated (buf, len);
   if (conf == NULL)
@@ -158,7 +159,10 @@ generate_seccomp (uint8_t *buf, size_t len)
   if (outfd < 0)
     return 0;
 
-  libcrun_generate_seccomp (container, outfd, 0, &err);
+  libcrun_seccomp_gen_ctx_init (&ctx, container, true, 0);
+  ctx.fd = outfd;
+
+  libcrun_generate_seccomp (&ctx, &err);
   crun_error_release (&err);
   return 0;
 }

--- a/tests/wasmedge-build/Dockerfile
+++ b/tests/wasmedge-build/Dockerfile
@@ -4,6 +4,7 @@ ARG WASM_EDGE_VERSION="0.11.0"
 # Install the deps for building crun
 RUN dnf update -y && dnf install -y make python git gcc automake autoconf libcap-devel \
 		systemd-devel yajl-devel libseccomp-devel pkg-config diffutils \
+		libgcrypt-devel systemd-devel yajl-devel libseccomp-devel pkg-config \
 		go-md2man glibc-static python3-libmount libtool buildah podman
 
 # Install WasmEdge


### PR DESCRIPTION
store the generated seccomp bpf by the checksum of its input data.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
