### PR TITLE
wasm: inherit environment variables in the WasmEdge handler

### DIFF
--- a/src/libcrun/handlers/wasmedge.c
+++ b/src/libcrun/handlers/wasmedge.c
@@ -80,6 +80,7 @@ libwasmedge_exec (void *cookie, __attribute__ ((unused)) libcrun_container_t *co
   bool (*WasmEdge_ResultOK) (const WasmEdge_Result Res);
   WasmEdge_String (*WasmEdge_StringCreateByCString) (const char *Str);
   uint32_t argn = 0;
+  uint32_t envn = 0;
   const char *dirs[1] = { "/:/" };
   WasmEdge_ConfigureContext *configure;
   WasmEdge_VMContext *vm;
@@ -135,8 +136,11 @@ libwasmedge_exec (void *cookie, __attribute__ ((unused)) libcrun_container_t *co
 
   for (char *const *arg = argv; *arg != NULL; ++arg, ++argn)
     ;
+  extern char **environ;
+  for (char *const *env = environ; *env != NULL; ++env, ++envn)
+    ;
 
-  WasmEdge_ModuleInstanceInitWASI (wasi_module, (const char *const *) &argv[0], argn, NULL, 0, dirs, 1, NULL, 0);
+  WasmEdge_ModuleInstanceInitWASI (wasi_module, (const char *const *) &argv[0], argn, (const char *const *) &environ[0], envn, dirs, 1, NULL, 0);
 
   result = WasmEdge_VMRunWasmFromFile (vm, pathname, WasmEdge_StringCreateByCString ("_start"), NULL, 0, NULL, 0);
 

--- a/tests/wasmedge-build/Dockerfile
+++ b/tests/wasmedge-build/Dockerfile
@@ -3,7 +3,7 @@ ARG WASM_EDGE_VERSION="0.11.0"
 
 # Install the deps for building crun
 RUN dnf update -y && dnf install -y make python git gcc automake autoconf libcap-devel \
-		systemd-devel yajl-devel libseccomp-devel pkg-config \
+		systemd-devel yajl-devel libseccomp-devel pkg-config diffutils \
 		go-md2man glibc-static python3-libmount libtool buildah podman
 
 # Install WasmEdge

--- a/tests/wasmedge-build/hello_wasm/Containerfile
+++ b/tests/wasmedge-build/hello_wasm/Containerfile
@@ -1,3 +1,4 @@
 FROM scratch
 COPY hello.wasm /
-CMD ["/hello.wasm"]
+ENV key=value
+CMD ["/hello.wasm", "arg1", "arg2"]

--- a/tests/wasmedge-build/hello_wasm/expected_output
+++ b/tests/wasmedge-build/hello_wasm/expected_output
@@ -1,0 +1,8 @@
+Print env::args()
+/hello.wasm
+arg1
+arg2
+Print env::vars()
+container: "podman"
+key: "value"
+This is from a main function from a wasm module

--- a/tests/wasmedge-build/hello_wasm/hello/src/main.rs
+++ b/tests/wasmedge-build/hello_wasm/hello/src/main.rs
@@ -1,3 +1,19 @@
+use std::env;
 fn main() {
+    println!("Print env::args()");
+    for arg in env::args() {
+        println!("{arg}");
+    }
+    println!("Print env::vars()");
+    // In this test, the `container=podman`
+    match env::var("container") {
+        Ok(val) => println!("container: {val:?}"),
+        Err(e) => println!("couldn't interpret container: {e}"),
+    }
+    // In this test, the `key=value`
+    match env::var("key") {
+        Ok(val) => println!("key: {val:?}"),
+        Err(e) => println!("couldn't interpret key: {e}"),
+    }
     println!("{}", "This is from a main function from a wasm module");
 }

--- a/tests/wasmedge-build/run-tests.sh
+++ b/tests/wasmedge-build/run-tests.sh
@@ -29,9 +29,12 @@ cd /hello_wasm && \
 
 # Run hello.wasm with crun
 OUTPUT=$(podman run hellowasm-image:latest)
-EXPECTED_OUTPUT="This is from a main function from a wasm module"
-echo "$OUTPUT"
-if [[ "$OUTPUT" != "$EXPECTED_OUTPUT" ]]; then
+FILE1="tmp.output"
+FILE2="expected_output"
+echo "$OUTPUT" > "$FILE1"
+if cmp -s "$FILE1" "$FILE2"; then
+	echo "Run wasm success. The execution result is exactly matched"
+else
 	echo "Run wasm failed. The execution result is not matched"
 	exit 1
 fi


### PR DESCRIPTION
In the current implementation, the WasmEdge handler doesn't inherit the environment variables from the current process. Hence, the environment variables that are provided by the containers are all dropped. This will make some information that is passed by k8s also dropped.

This commit adds `args` and `envs` test to verify the behavior of `std::env::args()` and `std::env::vars()`.

Signed-off-by: hydai <hydai@secondstate.io>