### PR TITLE
linux: add run.oci.pidfd_receiver=PATH annotation

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -533,6 +533,15 @@ will skip the \fB\fCsetgroups\fR syscall that is used to either set the
 additional groups specified in the OCI configuration, or to reset the
 list of additional groups if none is specified.
 
+.SH \fB\fCrun.oci.pidfd_receiver=PATH\fR
+.PP
+It is an experimental feature and will be removed once the feature is in the
+OCI runtime specs.
+
+.PP
+If present, specify the path to the UNIX socket that will receive the
+pidfd for the container process.
+
 .SH \fB\fCrun.oci.systemd.force_cgroup_v1=/PATH\fR
 .PP
 If the annotation \fB\fCrun.oci.systemd.force_cgroup_v1=/PATH\fR is present, then crun

--- a/crun.1.md
+++ b/crun.1.md
@@ -427,6 +427,14 @@ will skip the `setgroups` syscall that is used to either set the
 additional groups specified in the OCI configuration, or to reset the
 list of additional groups if none is specified.
 
+## `run.oci.pidfd_receiver=PATH`
+
+It is an experimental feature and will be removed once the feature is in the
+OCI runtime specs.
+
+If present, specify the path to the UNIX socket that will receive the
+pidfd for the container process.
+
 ## `run.oci.systemd.force_cgroup_v1=/PATH`
 
 If the annotation `run.oci.systemd.force_cgroup_v1=/PATH` is present, then crun


### PR DESCRIPTION
if specified, the runtime creates a pidfd for the container process and pass it to the UNIX socket that is listening on the specified path.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
