### PR TITLE
container: use clone3 to join directly the target cgroup

### DIFF
--- a/src/libcrun/cgroup-cgroupfs.c
+++ b/src/libcrun/cgroup-cgroupfs.c
@@ -90,6 +90,7 @@ libcrun_destroy_cgroup_cgroupfs (struct libcrun_cgroup_status *cgroup_status,
 }
 
 struct libcrun_cgroup_manager cgroup_manager_cgroupfs = {
+  .precreate_cgroup = NULL,
   .create_cgroup = libcrun_cgroup_enter_cgroupfs,
   .destroy_cgroup = libcrun_destroy_cgroup_cgroupfs,
 };

--- a/src/libcrun/cgroup-cgroupfs.c
+++ b/src/libcrun/cgroup-cgroupfs.c
@@ -37,27 +37,71 @@
 #include <fcntl.h>
 #include <libgen.h>
 
+static char *
+make_cgroup_path (const char *path, const char *id)
+{
+  const char *cgroup_path = path;
+  char *ret;
+
+  if (cgroup_path == NULL)
+    xasprintf (&ret, "/%s", id);
+  else if (cgroup_path[0] == '/')
+    ret = xstrdup (cgroup_path);
+  else
+    xasprintf (&ret, "/%s", cgroup_path);
+
+  return ret;
+}
+
+static int
+libcrun_precreate_cgroup_cgroupfs (struct libcrun_cgroup_args *args, int *dirfd, libcrun_error_t *err)
+{
+  cleanup_free char *sub_path = make_cgroup_path (args->cgroup_path, args->id);
+  cleanup_free char *cgroup_path = NULL;
+  int ret;
+
+  /* No need to check the mode since this feature is supported only on cgroup v2, and
+     libcrun_cgroup_preenter already performs this check.  */
+
+  *dirfd = -1;
+
+  ret = append_paths (&cgroup_path, err, CGROUP_ROOT, sub_path, NULL);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = crun_ensure_directory (cgroup_path, 0755, true, err);
+  if (UNLIKELY (ret < 0))
+    {
+      libcrun_error_release (err);
+      return 0;
+    }
+
+  ret = enable_controllers (sub_path, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  *dirfd = open (cgroup_path, O_CLOEXEC | O_NOFOLLOW | O_DIRECTORY | O_RDONLY);
+  if (UNLIKELY (*dirfd < 0))
+    return crun_make_error (err, errno, "open `%s`", cgroup_path);
+
+  return 0;
+}
+
 static int
 libcrun_cgroup_enter_cgroupfs (struct libcrun_cgroup_args *args, struct libcrun_cgroup_status *out, libcrun_error_t *err)
 {
-  const char *cgroup_path = args->cgroup_path;
-  const char *id = args->id;
   pid_t pid = args->pid;
   int cgroup_mode;
+
+  /* The cgroup was already joined, nothing more left to do.  */
+  if (args->joined)
+    return 0;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
   if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
 
-  if (cgroup_path == NULL)
-    xasprintf (&(out->path), "/%s", id);
-  else
-    {
-      if (cgroup_path[0] == '/')
-        out->path = xstrdup (cgroup_path);
-      else
-        xasprintf (&(out->path), "/%s", cgroup_path);
-    }
+  out->path = make_cgroup_path (args->cgroup_path, args->id);
 
   if (cgroup_mode == CGROUP_MODE_UNIFIED)
     {
@@ -90,7 +134,7 @@ libcrun_destroy_cgroup_cgroupfs (struct libcrun_cgroup_status *cgroup_status,
 }
 
 struct libcrun_cgroup_manager cgroup_manager_cgroupfs = {
-  .precreate_cgroup = NULL,
+  .precreate_cgroup = libcrun_precreate_cgroup_cgroupfs,
   .create_cgroup = libcrun_cgroup_enter_cgroupfs,
   .destroy_cgroup = libcrun_destroy_cgroup_cgroupfs,
 };

--- a/src/libcrun/cgroup-internal.h
+++ b/src/libcrun/cgroup-internal.h
@@ -43,6 +43,7 @@ struct libcrun_cgroup_manager
 {
   /* Create a new cgroup and fill PATH in OUT.  */
   int (*create_cgroup) (struct libcrun_cgroup_args *args, struct libcrun_cgroup_status *out, libcrun_error_t *err);
+  int (*precreate_cgroup) (struct libcrun_cgroup_args *args, int *dirfd, libcrun_error_t *err);
   /* Destroy the cgroup and kill any process if needed.  */
   int (*destroy_cgroup) (struct libcrun_cgroup_status *cgroup_status, libcrun_error_t *err);
   /* Additional resources configuration specific to this manager.  */

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1039,6 +1039,7 @@ libcrun_update_resources_systemd (struct libcrun_cgroup_status *cgroup_status,
 #endif
 
 struct libcrun_cgroup_manager cgroup_manager_systemd = {
+  .precreate_cgroup = NULL,
   .create_cgroup = libcrun_cgroup_enter_systemd,
   .destroy_cgroup = libcrun_destroy_cgroup_systemd,
   .update_resources = libcrun_update_resources_systemd,

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -51,9 +51,11 @@ struct libcrun_cgroup_args
   uid_t root_uid;
   gid_t root_gid;
   const char *id;
+  bool joined;
 };
 
 /* cgroup life-cycle management.  */
+int libcrun_cgroup_preenter (struct libcrun_cgroup_args *args, int *dirfd, libcrun_error_t *err);
 int libcrun_cgroup_enter (struct libcrun_cgroup_args *args, struct libcrun_cgroup_status **out, libcrun_error_t *err);
 int libcrun_cgroup_enter_finalize (struct libcrun_cgroup_args *args, struct libcrun_cgroup_status *cgroup_status, libcrun_error_t *err);
 int libcrun_cgroup_destroy (struct libcrun_cgroup_status *cgroup_status, libcrun_error_t *err);

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -53,11 +53,18 @@ typedef int (*container_entrypoint_t) (void *args, char *notify_socket, int sync
 
 typedef int (*set_mounts_cb_t) (void *args, libcrun_error_t *err);
 
+struct libcrun_dirfd_s
+{
+  int *dirfd;
+  bool joined;
+};
+
 pid_t libcrun_run_linux_container (libcrun_container_t *container, container_entrypoint_t entrypoint, void *args,
-                                   int *sync_socket_out, libcrun_error_t *err);
+                                   int *sync_socket_out, struct libcrun_dirfd_s *dirfd, libcrun_error_t *err);
 int get_notify_fd (libcrun_context_t *context, libcrun_container_t *container, int *notify_socket_out,
                    libcrun_error_t *err);
-int libcrun_set_mounts (struct container_entrypoint_s *args, libcrun_container_t *container, const char *rootfs, set_mounts_cb_t cb, void *cb_data, libcrun_error_t *err);
+int libcrun_set_mounts (struct container_entrypoint_s *args, libcrun_container_t *container, const char *rootfs,
+                        set_mounts_cb_t cb, void *cb_data, libcrun_error_t *err);
 int libcrun_init_caps (libcrun_error_t *err);
 int libcrun_do_pivot_root (libcrun_container_t *container, bool no_pivot, const char *rootfs, libcrun_error_t *err);
 int libcrun_reopen_dev_null (libcrun_error_t *err);
@@ -80,7 +87,8 @@ int libcrun_linux_container_update (libcrun_container_status_t *status, const ch
 int libcrun_create_keyring (const char *name, const char *label, libcrun_error_t *err);
 int libcrun_container_pause_linux (libcrun_container_status_t *status, libcrun_error_t *err);
 int libcrun_container_unpause_linux (libcrun_container_status_t *status, libcrun_error_t *err);
-int libcrun_container_do_bind_mount (libcrun_container_t *container, char *mount_source, char *mount_destination, char **mount_options, size_t mount_options_len, libcrun_error_t *err);
+int libcrun_container_do_bind_mount (libcrun_container_t *container, char *mount_source, char *mount_destination,
+                                     char **mount_options, size_t mount_options_len, libcrun_error_t *err);
 int libcrun_container_enter_cgroup_ns (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_personality (runtime_spec_schema_defs_linux_personality *p, libcrun_error_t *err);
 int libcrun_configure_network (libcrun_container_t *container, libcrun_error_t *err);
@@ -104,6 +112,7 @@ int libcrun_create_dev (libcrun_container_t *container, int devfd,
                         struct device_s *device, bool binds,
                         bool ensure_parent_dir, libcrun_error_t *err);
 
-int parse_idmapped_mount_option (runtime_spec_schema_config_schema *def, bool is_uids, char *option, char **out, size_t *len, libcrun_error_t *err);
+int parse_idmapped_mount_option (runtime_spec_schema_config_schema *def, bool is_uids, char *option, char **out,
+                                 size_t *len, libcrun_error_t *err);
 
 #endif


### PR DESCRIPTION
on cgroupfs, grab a pidfd to the destination cgroup, if the cgroup can be already created.                                                                                                                                 
                                                                                                                                                                              
Pass the cgroup dirfd to libcrun_run_linux_container, that will attempt to use the dirfd with clone3(CLONE_INTO_CGROUP) so that the container process is created directly in the target cgroup.                                                                                                                   
                                                                                                                                                                              
If the clone3 syscall fails, then fallback to the existing mechanism based on clone.                                                                                                                                                               
                                                                                                                                                                              
It is currently supported only with cgroupfs since systemd doesn't allow to create a cgroup if a PID to move there is not already present.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>                                                                                                                        
