### PR TITLE
crun: automatically pick handler from argv0

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1688,13 +1688,6 @@ parse_json_file (yajl_val *out, const char *jsondata, struct parser_context *ctx
   return 0;
 }
 
-int
-has_prefix (const char *str, const char *prefix)
-{
-  size_t prefix_len = strlen (prefix);
-  return strlen (str) >= prefix_len && memcmp (str, prefix, prefix_len) == 0;
-}
-
 static int
 check_access (const char *path)
 {

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -336,7 +336,12 @@ int set_blocking_fd (int fd, int blocking, libcrun_error_t *err);
 
 int parse_json_file (yajl_val *out, const char *jsondata, struct parser_context *ctx, libcrun_error_t *err);
 
-int has_prefix (const char *str, const char *prefix);
+static inline int
+has_prefix (const char *str, const char *prefix)
+{
+  size_t prefix_len = strlen (prefix);
+  return strlen (str) >= prefix_len && memcmp (str, prefix, prefix_len) == 0;
+}
 
 char *find_executable (const char *executable_path, const char *cwd);
 


### PR DESCRIPTION
if the crun executable file has the form crun-$HANDLER then automatically use $HANDLER as the handler to use.

e.g.

will automatically use the wasmedge handler to run the container.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>