### PR TITLE
linux: create parent dir with 0755

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1500,7 +1500,7 @@ libcrun_create_dev (libcrun_container_t *container, int devfd, struct device_s *
         {
           const char *rel_path = consume_slashes (device->path);
 
-          fd = crun_safe_create_and_open_ref_at (false, rootfsfd, rootfs, rootfs_len, rel_path, 0700, err);
+          fd = crun_safe_create_and_open_ref_at (false, rootfsfd, rootfs, rootfs_len, rel_path, 0755, err);
           if (UNLIKELY (fd < 0))
             return fd;
         }


### PR DESCRIPTION
create the parent directory for devices nodes with mode 0755 so that the device file can be accessed when the container runs as non-root.

Closes: https://github.com/containers/crun/issues/1047

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>