### PR TITLE
container: rewrite argv when using a handler

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -96,6 +96,8 @@ init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global
   con->force_no_cgroup = glob->option_force_no_cgroup;
   con->notify_socket = getenv ("NOTIFY_SOCKET");
   con->fifo_exec_wait_fd = -1;
+  con->argc = glob->argc;
+  con->argv = glob->argv;
 
   ret = libcrun_init_logging (&con->output_handler, &con->output_handler_arg, id, glob->log, err);
   if (UNLIKELY (ret < 0))
@@ -361,6 +363,9 @@ main (int argc, char **argv)
 {
   libcrun_error_t err = NULL;
   int ret, first_argument = 0;
+
+  arguments.argc = argc;
+  arguments.argv = argv;
 
 #ifdef DYNLOAD_LIBCRUN
   if (ensure_cloned_binary () < 0)

--- a/src/crun.h
+++ b/src/crun.h
@@ -27,6 +27,9 @@ struct crun_global_arguments
   char *log_format;
   const char *handler;
 
+  int argc;
+  char **argv;
+
   bool command;
   bool debug;
   bool option_systemd_cgroup;

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -58,6 +58,9 @@ struct libcrun_context_s
   bool force_no_cgroup;
   bool no_pivot;
 
+  char **argv;
+  int argc;
+
   struct custom_handler_manager_s *handler_manager;
 };
 


### PR DESCRIPTION
when a handler is used, rewrite the current process argv so that "ps auxw" shows more useful information instead of the command line used to launch the crun process.

e.g. when using the wasmedge handler with the michaelirwin244/wasm-example image, I see:

```
$ bin/podman --runtime crun-wasmedge run --rm -d michaelirwin244/wasm-example
5024ba547a40363de5a7c90d0d5f2748e56a5af6977aa8b9f06e0899493aa2a9
$ pgrep -fa libcrun
62149 [libcrun:wasmedge] hello_world.wasm
```

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
