### PR TITLE
copr: enable wasmedge support for f36 and higher

### DIFF
--- a/rpm/crun.spec.in
+++ b/rpm/crun.spec.in
@@ -10,7 +10,7 @@
 %endif
 %endif
 
-%if 0%{?fedora} >= 37
+%if 0%{?fedora} >= 36
 %ifarch aarch64 || x86_64
 %global wasm_support enabled
 %global wasmedge_support enabled
@@ -19,7 +19,7 @@
 %endif
 
 # FIXME: wasmtime builds for rhel are currently broken on copr probably
-# because of an older golang
+# because of an older rust compiler.
 %if 0%{?fedora}
 %ifnarch %{ix86} || ppc64le
 %global wasm_support enabled


### PR DESCRIPTION
wasmedge is available on f36, so build crun with wasmedge support for f36 and higher.

Also fix a comment about broken wasmtime copr build on rhel envs.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@giuseppe @rhatdan @flouthoc PTAL. 