### PR TITLE
handlers: add an alias field

### DIFF
--- a/src/libcrun/custom-handler.c
+++ b/src/libcrun/custom-handler.c
@@ -195,8 +195,12 @@ handler_by_name (struct custom_handler_manager_s *manager, const char *name)
   size_t i;
 
   for (i = 0; i < manager->handlers_len; i++)
-    if (strcmp (manager->handlers[i]->name, name) == 0)
-      return manager->handlers[i];
+    {
+      if (strcmp (manager->handlers[i]->name, name) == 0)
+        return manager->handlers[i];
+      if (manager->handlers[i]->alias && strcmp (manager->handlers[i]->alias, name) == 0)
+        return manager->handlers[i];
+    }
   return NULL;
 }
 

--- a/src/libcrun/custom-handler.h
+++ b/src/libcrun/custom-handler.h
@@ -27,6 +27,8 @@ struct custom_handler_s
   const char *name;
   const char *feature_string;
 
+  const char *alias;
+
   int (*load) (void **cookie, libcrun_error_t *err);
   int (*unload) (void *cookie, libcrun_error_t *err);
 

--- a/src/libcrun/handlers/handler-utils.c
+++ b/src/libcrun/handlers/handler-utils.c
@@ -27,7 +27,12 @@ int
 wasm_can_handle_container (libcrun_container_t *container, libcrun_error_t *err arg_unused)
 {
   const char *annotation;
-  const char *entrypoint_executable = container->container_def->process->args[0];
+  const char *entrypoint_executable;
+
+  if (container->container_def->process == NULL || container->container_def->process->args == NULL)
+    return 0;
+
+  entrypoint_executable = container->container_def->process->args[0];
 
   annotation = find_annotation (container, "run.oci.handler");
   if (annotation)

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -270,6 +270,7 @@ libkrun_unload (void *cookie, libcrun_error_t *err arg_unused)
 
 struct custom_handler_s handler_libkrun = {
   .name = "krun",
+  .alias = NULL,
   .feature_string = "LIBKRUN",
   .load = libkrun_load,
   .unload = libkrun_unload,

--- a/src/libcrun/handlers/mono.c
+++ b/src/libcrun/handlers/mono.c
@@ -165,6 +165,7 @@ mono_can_handle_container (libcrun_container_t *container, libcrun_error_t *err 
 
 struct custom_handler_s handler_mono = {
   .name = "dotnet",
+  .alias = NULL,
   .feature_string = ".NET:mono",
   .load = mono_load,
   .unload = mono_unload,

--- a/src/libcrun/handlers/wasmedge.c
+++ b/src/libcrun/handlers/wasmedge.c
@@ -164,6 +164,7 @@ wasmedge_can_handle_container (libcrun_container_t *container, libcrun_error_t *
 
 struct custom_handler_s handler_wasmedge = {
   .name = "wasmedge",
+  .alias = "wasm",
   .feature_string = "WASM:wasmedge",
   .load = libwasmedge_load,
   .unload = libwasmedge_unload,

--- a/src/libcrun/handlers/wasmer.c
+++ b/src/libcrun/handlers/wasmer.c
@@ -280,6 +280,7 @@ libwasmer_can_handle_container (libcrun_container_t *container, libcrun_error_t 
 
 struct custom_handler_s handler_wasmer = {
   .name = "wasmer",
+  .alias = "wasm",
   .feature_string = "WASM:wasmer",
   .load = libwasmer_load,
   .unload = libwasmer_unload,

--- a/src/libcrun/handlers/wasmtime.c
+++ b/src/libcrun/handlers/wasmtime.c
@@ -288,6 +288,7 @@ libwasmtime_can_handle_container (libcrun_container_t *container, libcrun_error_
 
 struct custom_handler_s handler_wasmtime = {
   .name = "wasmtime",
+  .alias = "wasm",
   .feature_string = "WASM:wasmtime",
   .load = libwasmtime_load,
   .unload = libwasmtime_unload,


### PR DESCRIPTION
add an alias field to the handlers so that a different name can be
specified.  It is useful with the different handlers for wasm, so that
we can use a single name instead of the specific backend to use.
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>