### PR TITLE
handlers: set selinux/apparmor profile

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1047,7 +1047,7 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
       if (UNLIKELY (ret < 0))
         return ret;
 
-      ret = libcrun_set_apparmor_profile (def->process, err);
+      ret = libcrun_set_apparmor_profile (def->process, false, err);
       if (UNLIKELY (ret < 0))
         return ret;
     }
@@ -3122,7 +3122,7 @@ exec_process_entrypoint (libcrun_context_t *context,
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = libcrun_set_apparmor_profile (process, err);
+  ret = libcrun_set_apparmor_profile (process, false, err);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1043,7 +1043,7 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
 
   if (def->process)
     {
-      ret = libcrun_set_selinux_exec_label (def->process, err);
+      ret = libcrun_set_selinux_label (def->process, false, err);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -3118,7 +3118,7 @@ exec_process_entrypoint (libcrun_context_t *context,
         }
     }
 
-  ret = libcrun_set_selinux_exec_label (process, err);
+  ret = libcrun_set_selinux_label (process, false, err);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1437,6 +1437,14 @@ container_init (void *args, char *notify_socket, int sync_socket, libcrun_error_
           entrypoint_args->context = NULL;
         }
 
+      ret = libcrun_set_selinux_label (def->process, true, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+
+      ret = libcrun_set_apparmor_profile (def->process, true, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+
       ret = entrypoint_args->custom_handler->exec_func (entrypoint_args->handler_cookie,
                                                         entrypoint_args->container,
                                                         exec_path,

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1274,10 +1274,14 @@ rewrite_argv (char **argv, int argc, const char *name, char **args, size_t args_
   new_argv = xmalloc0 (needed + 1);
   strcpy (new_argv, decorated_name);
   so_far = strlen (decorated_name) + 1;
-  for (i = 0; i < args_len; i++)
+
+  if (available_len >= needed)
     {
-      strcpy (new_argv + so_far, args[i]);
-      so_far += strlen (args[i]) + 1;
+      for (i = 0; i < args_len; i++)
+        {
+          strcpy (new_argv + so_far, args[i]);
+          so_far += strlen (args[i]) + 1;
+        }
     }
 
   if (so_far >= available_len)

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3010,10 +3010,10 @@ read_caps (unsigned long caps[2], char **values, size_t len)
 }
 
 int
-libcrun_set_selinux_exec_label (runtime_spec_schema_config_schema_process *proc, libcrun_error_t *err)
+libcrun_set_selinux_label (runtime_spec_schema_config_schema_process *proc, bool now, libcrun_error_t *err)
 {
   if (proc->selinux_label)
-    return set_selinux_exec_label (proc->selinux_label, err);
+    return set_selinux_label (proc->selinux_label, now, err);
 
   return 0;
 }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3019,10 +3019,10 @@ libcrun_set_selinux_label (runtime_spec_schema_config_schema_process *proc, bool
 }
 
 int
-libcrun_set_apparmor_profile (runtime_spec_schema_config_schema_process *proc, libcrun_error_t *err)
+libcrun_set_apparmor_profile (runtime_spec_schema_config_schema_process *proc, bool now, libcrun_error_t *err)
 {
   if (proc->apparmor_profile)
-    return set_apparmor_profile (proc->apparmor_profile, err);
+    return set_apparmor_profile (proc->apparmor_profile, now, err);
   return 0;
 }
 

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -74,7 +74,7 @@ int libcrun_set_caps (runtime_spec_schema_config_schema_process_capabilities *ca
 int libcrun_set_rlimits (runtime_spec_schema_config_schema_process_rlimits_element **rlimits, size_t len,
                          libcrun_error_t *err);
 int libcrun_set_selinux_label (runtime_spec_schema_config_schema_process *proc, bool now, libcrun_error_t *err);
-int libcrun_set_apparmor_profile (runtime_spec_schema_config_schema_process *proc, libcrun_error_t *err);
+int libcrun_set_apparmor_profile (runtime_spec_schema_config_schema_process *proc, bool now, libcrun_error_t *err);
 int libcrun_set_hostname (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_domainname (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_oom (libcrun_container_t *container, libcrun_error_t *err);

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -73,7 +73,7 @@ int libcrun_set_caps (runtime_spec_schema_config_schema_process_capabilities *ca
                       int no_new_privileges, libcrun_error_t *err);
 int libcrun_set_rlimits (runtime_spec_schema_config_schema_process_rlimits_element **rlimits, size_t len,
                          libcrun_error_t *err);
-int libcrun_set_selinux_exec_label (runtime_spec_schema_config_schema_process *proc, libcrun_error_t *err);
+int libcrun_set_selinux_label (runtime_spec_schema_config_schema_process *proc, bool now, libcrun_error_t *err);
 int libcrun_set_apparmor_profile (runtime_spec_schema_config_schema_process *proc, libcrun_error_t *err);
 int libcrun_set_hostname (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_domainname (libcrun_container_t *container, libcrun_error_t *err);

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -838,7 +838,7 @@ libcrun_is_apparmor_enabled (libcrun_error_t *err)
 }
 
 int
-set_apparmor_profile (const char *profile, libcrun_error_t *err)
+set_apparmor_profile (const char *profile, bool now, libcrun_error_t *err)
 {
   int ret;
 
@@ -847,11 +847,12 @@ set_apparmor_profile (const char *profile, libcrun_error_t *err)
     return ret;
   if (ret)
     {
+      const char *fname = now ? "/proc/thread-self/attr/current" : "/proc/thread-self/attr/exec";
       cleanup_free char *buf = NULL;
 
       xasprintf (&buf, "exec %s", profile);
 
-      ret = write_file_and_check_fs_type ("/proc/thread-self/attr/exec", buf, strlen (buf), PROC_SUPER_MAGIC, "procfs",
+      ret = write_file_and_check_fs_type (fname, buf, strlen (buf), PROC_SUPER_MAGIC, "procfs",
                                           err);
       if (UNLIKELY (ret < 0))
         return ret;

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -809,7 +809,7 @@ write_file_and_check_fs_type (const char *file, const char *data, size_t len, un
 }
 
 int
-set_selinux_exec_label (const char *label, libcrun_error_t *err)
+set_selinux_label (const char *label, bool now, libcrun_error_t *err)
 {
   int ret;
 
@@ -819,7 +819,9 @@ set_selinux_exec_label (const char *label, libcrun_error_t *err)
 
   if (ret)
     {
-      ret = write_file_and_check_fs_type ("/proc/thread-self/attr/exec", label, strlen (label), PROC_SUPER_MAGIC,
+      const char *fname = now ? "/proc/thread-self/attr/current" : "/proc/thread-self/attr/exec";
+      ret = write_file_and_check_fs_type (fname, label,
+                                          strlen (label), PROC_SUPER_MAGIC,
                                           "procfs", err);
       if (UNLIKELY (ret < 0))
         return ret;

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -289,7 +289,7 @@ int create_file_if_missing_at (int dirfd, const char *file, libcrun_error_t *err
 
 int check_running_in_user_namespace (libcrun_error_t *err);
 
-int set_selinux_exec_label (const char *label, libcrun_error_t *err);
+int set_selinux_label (const char *label, bool now, libcrun_error_t *err);
 
 int add_selinux_mount_label (char **ret, const char *data, const char *label, libcrun_error_t *err);
 

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -293,7 +293,7 @@ int set_selinux_label (const char *label, bool now, libcrun_error_t *err);
 
 int add_selinux_mount_label (char **ret, const char *data, const char *label, libcrun_error_t *err);
 
-int set_apparmor_profile (const char *profile, libcrun_error_t *err);
+int set_apparmor_profile (const char *profile, bool now, libcrun_error_t *err);
 
 int read_all_fd (int fd, const char *description, char **out, size_t *len, libcrun_error_t *err);
 


### PR DESCRIPTION
since we do not exec the container process when using a custom handler, we need to set the selinux label and the apparmor profile for the current process.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>