### PR TITLE
copr: enable wasmedge on epel9

### DIFF
--- a/rpm/crun.spec.in
+++ b/rpm/crun.spec.in
@@ -10,7 +10,8 @@
 %endif
 %endif
 
-%if 0%{?fedora} >= 36
+# wasmedge available on Fedora 36 and EPEL 9
+%if 0%{?fedora} >= 36 || 0%{?rhel} >= 9
 %ifarch aarch64 || x86_64
 %global wasm_support enabled
 %global wasmedge_support enabled


### PR DESCRIPTION
wasmedge is now available in the default epel9 repositories, so we're ok
to enable it here.
Ref: https://src.fedoraproject.org/rpms/wasmedge

Epel8 is currently WIP, and will hopefully get enabled soon.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@giuseppe @flouthoc @rhatdan PTAL