### PR TITLE
copr: enable wasmedge on all active envs

### DIFF
--- a/rpm/crun.spec.in
+++ b/rpm/crun.spec.in
@@ -10,13 +10,10 @@
 %endif
 %endif
 
-# wasmedge available on Fedora 36 and EPEL 9
-%if 0%{?fedora} >= 36 || 0%{?rhel} >= 9
 %ifarch aarch64 || x86_64
 %global wasm_support enabled
 %global wasmedge_support enabled
 %global wasmedge_opts --with-wasmedge
-%endif
 %endif
 
 # FIXME: wasmtime builds for rhel are currently broken on copr probably


### PR DESCRIPTION
wasmedge is now available on epel8 so that means all active Fedora and
EPEL versions are covered.

Fedora 35 has been disabled on the copr, so we can simply remove this
extra conditional.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


