### PR TITLE
utils: fix creating default userns

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2796,7 +2796,7 @@ libcrun_set_usernamespace (libcrun_container_t *container, pid_t pid, libcrun_er
     uid_map = format_mount_mappings (def->linux->uid_mappings, def->linux->uid_mappings_len, &uid_map_len, true);
   else
     {
-      uid_map_len = format_default_id_mapping (&uid_map, container->container_uid, container->host_uid, 1);
+      uid_map_len = format_default_id_mapping (&uid_map, container->container_uid, container->host_uid, container->host_uid, 1);
       if (uid_map == NULL)
         uid_map = format_mount_mapping (0, container->host_uid, container->host_uid + 1, &uid_map_len, true);
     }
@@ -2805,7 +2805,7 @@ libcrun_set_usernamespace (libcrun_container_t *container, pid_t pid, libcrun_er
     gid_map = format_mount_mappings (def->linux->gid_mappings, def->linux->gid_mappings_len, &gid_map_len, true);
   else
     {
-      gid_map_len = format_default_id_mapping (&gid_map, container->container_gid, container->host_uid, 0);
+      gid_map_len = format_default_id_mapping (&gid_map, container->container_gid, container->host_uid, container->host_gid, 0);
       if (gid_map == NULL)
         gid_map = format_mount_mapping (0, container->host_gid, container->host_gid + 1, &gid_map_len, true);
     }

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1403,7 +1403,7 @@ getsubidrange (uid_t id, int is_uid, uint32_t *from, uint32_t *len)
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 
 size_t
-format_default_id_mapping (char **ret, uid_t container_id, uid_t host_id, int is_uid)
+format_default_id_mapping (char **ret, uid_t container_id, uid_t host_uid, uid_t host_id, int is_uid)
 {
   uint32_t from, available;
   cleanup_free char *buffer = NULL;
@@ -1411,7 +1411,7 @@ format_default_id_mapping (char **ret, uid_t container_id, uid_t host_id, int is
 
   *ret = NULL;
 
-  if (getsubidrange (host_id, is_uid, &from, &available) < 0)
+  if (getsubidrange (host_uid, is_uid, &from, &available) < 0)
     return 0;
 
   /* More than enough space for all the mappings.  */

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -323,7 +323,7 @@ int copy_from_fd_to_fd (int src, int dst, int consume, libcrun_error_t *err);
 
 int run_process (char **args, libcrun_error_t *err);
 
-size_t format_default_id_mapping (char **ret, uid_t container_id, uid_t host_id, int is_uid);
+size_t format_default_id_mapping (char **ret, uid_t container_id, uid_t host_uid, uid_t host_id, int is_uid);
 
 int run_process_with_stdin_timeout_envp (char *path, char **args, const char *cwd, int timeout, char **envp,
                                          char *stdin, size_t stdin_len, int out_fd, int err_fd, libcrun_error_t *err);


### PR DESCRIPTION
fix creating the default user namespace when the GID on the host is different than the UID and there is not not already a mapping specified in the OCI configuration.

Closes: https://github.com/containers/crun/issues/1072

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>