### PR TITLE
utils: Improve debug message

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -524,7 +524,7 @@ crun_safe_ensure_at (bool do_open, bool dir, int dirfd, const char *dirpath,
               /* If the previous openat fails, attempt to open the file in O_PATH mode.  */
               ret = openat (cwd, cur, O_CLOEXEC | O_PATH, 0);
               if (ret < 0)
-                return crun_make_error (err, errno, "open `%s/%s`", dirpath, cur);
+                return crun_make_error (err, errno, "open `%s/%s`", dirpath, npath);
             }
 
           if (do_open)
@@ -538,7 +538,7 @@ crun_safe_ensure_at (bool do_open, bool dir, int dirfd, const char *dirpath,
       if (ret < 0)
         {
           if (errno != EEXIST)
-            return crun_make_error (err, errno, "mkdir `%s`", cur);
+            return crun_make_error (err, errno, "mkdir `/%s`", npath);
         }
 
       cwd = safe_openat (dirfd, dirpath, dirpath_len, npath, O_CLOEXEC | O_PATH, 0, err);


### PR DESCRIPTION
This print the full directory path up to and including cur, because after each iteration we restore the slash.

I had some problems with /dev/vboxusb permissions and an error message like

crun: mkdir `009`: Permission denied: OCI permission denied

isn't too useful while

crun: mkdir `dev/vboxusb/009`: Permission denied: OCI permission denied

actually pointed me where to look.