### PR TITLE
NEWS: tag 1.7.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+* crun-1.7.2
+
+- criu: hardcode library name to libcriu.so.2.
+- cgroup: always enable all controllers, even if the cgroup was already joined.
+  Regression caused by crun-1.7.
+
 * crun-1.7.1
 
 - criu: load libcriu dynamically.

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -26,7 +26,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <regex.h>
-#ifdef HAVE_CRIU
+#if HAVE_CRIU && HAVE_DLOPEN
 #  include <criu/criu.h>
 #endif
 
@@ -75,7 +75,7 @@ static char args_doc[] = "checkpoint CONTAINER";
 int
 crun_parse_manage_cgroups_mode (char *param arg_unused)
 {
-#ifdef HAVE_CRIU
+#if HAVE_CRIU && HAVE_DLOPEN
   if (strcmp (param, "soft") == 0)
     return CRIU_CG_MODE_SOFT;
   else if (strcmp (param, "ignore") == 0)

--- a/src/crun.c
+++ b/src/crun.c
@@ -150,7 +150,7 @@ struct commands_s commands[] = { { COMMAND_CREATE, "create", crun_command_create
                                  { COMMAND_UPDATE, "update", crun_command_update },
                                  { COMMAND_PAUSE, "pause", crun_command_pause },
                                  { COMMAND_UNPAUSE, "resume", crun_command_unpause },
-#ifdef HAVE_CRIU
+#if HAVE_CRIU && HAVE_DLOPEN
                                  { COMMAND_CHECKPOINT, "checkpoint", crun_command_checkpoint },
                                  { COMMAND_RESTORE, "restore", crun_command_restore },
 #endif
@@ -159,7 +159,7 @@ struct commands_s commands[] = { { COMMAND_CREATE, "create", crun_command_create
                                  } };
 
 static char doc[] = "\nCOMMANDS:\n"
-#ifdef HAVE_CRIU
+#if HAVE_CRIU && HAVE_DLOPEN
                     "\tcheckpoint  - checkpoint a container\n"
 #endif
                     "\tcreate      - create a container\n"
@@ -168,7 +168,7 @@ static char doc[] = "\nCOMMANDS:\n"
                     "\tlist        - list known containers\n"
                     "\tkill        - send a signal to the container init process\n"
                     "\tps          - show the processes in the container\n"
-#ifdef HAVE_CRIU
+#if HAVE_CRIU && HAVE_DLOPEN
                     "\trestore     - restore a container\n"
 #endif
                     "\trun         - run a container\n"

--- a/src/libcrun/cgroup-cgroupfs.c
+++ b/src/libcrun/cgroup-cgroupfs.c
@@ -93,10 +93,6 @@ libcrun_cgroup_enter_cgroupfs (struct libcrun_cgroup_args *args, struct libcrun_
   pid_t pid = args->pid;
   int cgroup_mode;
 
-  /* The cgroup was already joined, nothing more left to do.  */
-  if (args->joined)
-    return 0;
-
   cgroup_mode = libcrun_get_cgroup_mode (err);
   if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
@@ -111,6 +107,10 @@ libcrun_cgroup_enter_cgroupfs (struct libcrun_cgroup_args *args, struct libcrun_
       if (UNLIKELY (ret < 0))
         return ret;
     }
+
+  /* The cgroup was already joined, nothing more left to do.  */
+  if (args->joined)
+    return 0;
 
   return enter_cgroup (cgroup_mode, pid, 0, out->path, true, err);
 }

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -220,9 +220,9 @@ load_wrapper (struct libcriu_wrapper_s **wrapper_out, libcrun_error_t *err)
 {
   cleanup_free struct libcriu_wrapper_s *wrapper = xmalloc0 (sizeof (*wrapper));
 
-  wrapper->handle = dlopen ("libcriu.so", RTLD_NOW);
+  wrapper->handle = dlopen ("libcriu.so.2", RTLD_NOW);
   if (wrapper->handle == NULL)
-    return crun_make_error (err, 0, "could not load `libcriu.so`");
+    return crun_make_error (err, 0, "could not load `libcriu.so.2`");
 
 #  define LOAD_CRIU_FUNCTION(X)                                                                \
     do                                                                                         \


### PR DESCRIPTION
- criu: hardcode library name to libcriu.so.2.
- cgroup: always enable all controllers, even if the cgroup was already joined.  Regression caused by crun-1.7.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

