### PR TITLE
utils: fix applying AppArmor profile

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -850,7 +850,7 @@ set_apparmor_profile (const char *profile, bool now, libcrun_error_t *err)
       const char *fname = now ? "/proc/thread-self/attr/current" : "/proc/thread-self/attr/exec";
       cleanup_free char *buf = NULL;
 
-      xasprintf (&buf, "exec %s", profile);
+      xasprintf (&buf, "%s %s", now ? "changeprofile" : "exec", profile);
 
       ret = write_file_and_check_fs_type (fname, buf, strlen (buf), PROC_SUPER_MAGIC, "procfs",
                                           err);


### PR DESCRIPTION
commit 0efbe561afb40023872bcc2db84c701a73dc4dc9 introduced the regression.  When we change the current AppArmor profile, it is necessary to use the command "changeprofile" instead of "exec".

Closes: https://github.com/containers/crun/issues/1093

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>