### PR TITLE
fix cgroups mounting in legacy mode

### DIFF
--- a/src/libcrun/cgroup-setup.c
+++ b/src/libcrun/cgroup-setup.c
@@ -322,6 +322,11 @@ enter_cgroup_v1 (pid_t pid, const char *path, bool create_if_missing, libcrun_er
 
       subsystem = controller[0] == '\0' ? "unified" : controller;
 
+      if (strcmp (subsystem, "net_prio,net_cls") == 0)
+        subsystem = "net_cls,net_prio";
+      if (strcmp (subsystem, "cpuacct,cpu") == 0)
+        subsystem = "cpu,cpuacct";
+
       snprintf (subsystem_path, sizeof (subsystem_path), CGROUP_ROOT "/%s", subsystem);
       ret = crun_path_exists (subsystem_path, err);
       if (UNLIKELY (ret < 0))

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2298,7 +2298,6 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   cg.id = context->id;
   cg.resources = def->linux ? def->linux->resources : NULL;
   cg.annotations = def->annotations;
-  cg.cgroup_path = def->linux ? def->linux->cgroups_path : "";
   cg.manager = cgroup_manager;
   cg.root_uid = root_uid;
   cg.root_gid = root_gid;


### PR DESCRIPTION
When mounting cgroups in legacy mode, flip the subsystems for `cpu/cpuacct` and `net_cls/net_prio` the same way it's done in [do_mount_cgroup_v1](https://github.com/containers/crun/blob/1.7.2/src/libcrun/linux.c#L1345-L1348). Otherwise it is not possible to create containers on older kernels (e.g. RHEL 7.9 with kernel 3.10.x):

```
117m        Warning   FailedCreatePodSandBox    Pod    Failed create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: open `/sys/fs/cgroup/cpu/kubepods/besteffort/pod32bebd55-7cc2-11ed-ac44-12842d37de17/8df53f6b7a0e16995e0ce70fe4ea47465f3bbe41c3e107d814db59036d71dea4`: No such file or directory: unknown
```

I apologize if the change is not something `crun` aims to support but it looks like a bug rather than an explicit omission - let me know if that's actually intended.