### PR TITLE
src/crun.c: fix build without dlfcn.h

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -23,7 +23,9 @@
 #include <string.h>
 #include <libgen.h>
 
+#ifdef HAVE_DLOPEN
 #include <dlfcn.h>
+#endif
 
 #include "crun.h"
 #include "libcrun/utils.h"


### PR DESCRIPTION
Fix the following build failure without `dlfcn.h` raised since version 1.7 and https://github.com/containers/crun/commit/5837234e9840cd067edd9f6cd2ed9cae9a0e6570:

```
src/crun.c:26:10: fatal error: dlfcn.h: No such file or directory
   26 | #include <dlfcn.h>
      |          ^~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/a5f52a7ee757c92c9571261c0ed884d05caeaf2f

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>