### PR TITLE
contrib, seccomp-notify-plugin: free `args` on error to prevent memory leak

### DIFF
--- a/contrib/seccomp-notify-plugin-example/full.c
+++ b/contrib/seccomp-notify-plugin-example/full.c
@@ -58,24 +58,29 @@ handle_async (struct seccomp_notif_sizes *sizes, struct seccomp_notif *sreq, int
 
   args->resp = malloc (sizes->seccomp_notif_resp);
   if (args->resp == NULL)
-    return -errno;
+    goto exit_error;
 
   args->id = sreq->id;
   args->seccomp_fd = seccomp_fd;
 
   if (pthread_attr_init (&attr) < 0)
-    return -errno;
+    goto exit_error;
 
   if (pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_DETACHED) < 0)
-    return -errno;
+    goto exit_error;
 
   if (pthread_create (&thread, &attr, start_routine, args) < 0)
-    return -errno;
+    goto exit_error;
 
   if (pthread_attr_destroy (&attr) < 0)
-    return -errno;
+    goto exit_error;
 
   return 0;
+
+exit_error:
+  free (args->resp);
+  free (args);
+  return -errno;
 }
 
 int


### PR DESCRIPTION
Found a small leak while running static check on codebase, free(args) on error to prevent memory leak.