### PR TITLE
linux: mount cgroup ro on /sys bind mount fallback

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1220,6 +1220,8 @@ do_mount_cgroup_v2 (libcrun_container_t *container, int targetfd, const char *ta
       errno = crun_error_get_errno (err);
       if (errno == EPERM || errno == EBUSY)
         {
+          const char *src_cgroup;
+
           crun_error_release (err);
 
           if (errno == EBUSY)
@@ -1242,7 +1244,8 @@ do_mount_cgroup_v2 (libcrun_container_t *container, int targetfd, const char *ta
             }
 
           /* If everything else failed, bind mount from the current cgroup.  */
-          return do_mount (container, unified_cgroup_path ?: CGROUP_ROOT, targetfd, target, NULL,
+          src_cgroup = unified_cgroup_path && container_has_cgroupns (container) ? unified_cgroup_path : CGROUP_ROOT;
+          return do_mount (container, src_cgroup, targetfd, target, NULL,
                            MS_BIND | mountflags, NULL, LABEL_NONE, err);
         }
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -419,7 +419,7 @@ get_bind_mount (int dirfd, const char *src, libcrun_error_t *err)
   open_tree_fd = syscall_open_tree (dirfd, src,
                                     AT_NO_AUTOMOUNT | OPEN_TREE_CLOEXEC | OPEN_TREE_CLONE);
   if (UNLIKELY (open_tree_fd < 0))
-    return crun_make_error (err, errno, "open `%s`", src);
+    return crun_make_error (err, errno, "open_tree `%s`", src);
 
   ret = syscall_mount_setattr (open_tree_fd, "", AT_EMPTY_PATH, &attr);
   if (UNLIKELY (ret < 0))


### PR DESCRIPTION
when it is not possible to mount a fresh sysfs, we fall back to bind mounting /sys.
    
If a /sys/fs/cgroup is not present, just mask the path.
    
Otherwise restrict the usage of the fallback to the case where /sys is mounted read-only so we can take advantage of the new mount API and use 'rro'.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>