### PR TITLE
cgroup: support cpuset mounted with noprefix

### DIFF
--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -962,14 +962,34 @@ write_cpuset_resources (int dirfd_cpuset, int cgroup2, runtime_spec_schema_confi
       ret = write_file_and_check_controllers_at (cgroup2, dirfd_cpuset, "cpuset.cpus", cpu->cpus, strlen (cpu->cpus),
                                                  err);
       if (UNLIKELY (ret < 0))
-        return ret;
+        {
+          if (! cgroup2 && errno == ENOENT)
+            {
+              crun_error_release (err);
+
+              ret = write_file_and_check_controllers_at (cgroup2, dirfd_cpuset, "cpus", cpu->cpus, strlen (cpu->cpus),
+                                                         err);
+            }
+          if (UNLIKELY (ret < 0))
+            return ret;
+        }
     }
   if (cpu->mems)
     {
       ret = write_file_and_check_controllers_at (cgroup2, dirfd_cpuset, "cpuset.mems", cpu->mems, strlen (cpu->mems),
                                                  err);
       if (UNLIKELY (ret < 0))
-        return ret;
+        {
+          if (! cgroup2 && errno == ENOENT)
+            {
+              crun_error_release (err);
+
+              ret = write_file_and_check_controllers_at (cgroup2, dirfd_cpuset, "mems", cpu->mems, strlen (cpu->mems),
+                                                         err);
+            }
+          if (UNLIKELY (ret < 0))
+            return ret;
+        }
     }
   return 0;
 }

--- a/src/libcrun/cgroup-setup.c
+++ b/src/libcrun/cgroup-setup.c
@@ -53,12 +53,14 @@ initialize_cpuset_subsystem_rec (char *path, size_t path_len, char *cpus, char *
   if (cpus[0] == '\0')
     {
       cpus_fd = openat (dirfd, "cpuset.cpus", O_RDWR);
+      if (UNLIKELY (cpus_fd < 0 && errno == ENOENT))
+        cpus_fd = openat (dirfd, "cpus", O_RDWR);
       if (UNLIKELY (cpus_fd < 0))
-        return crun_make_error (err, errno, "open '%s/%s'", path, "cpuset.cpus");
+        return crun_make_error (err, errno, "open `%s/%s`", path, "cpuset.cpus");
 
       b_len = TEMP_FAILURE_RETRY (read (cpus_fd, cpus, 256));
       if (UNLIKELY (b_len < 0))
-        return crun_make_error (err, errno, "read from 'cpuset.cpus'");
+        return crun_make_error (err, errno, "read from `cpuset.cpus`");
       cpus[b_len] = '\0';
       if (cpus[0] == '\n')
         cpus[0] = '\0';
@@ -67,12 +69,14 @@ initialize_cpuset_subsystem_rec (char *path, size_t path_len, char *cpus, char *
   if (mems[0] == '\0')
     {
       mems_fd = openat (dirfd, "cpuset.mems", O_RDWR);
+      if (UNLIKELY (mems_fd < 0 && errno == ENOENT))
+        mems_fd = openat (dirfd, "mems", O_RDWR);
       if (UNLIKELY (mems_fd < 0))
-        return crun_make_error (err, errno, "open '%s/%s'", path, "cpuset.mems");
+        return crun_make_error (err, errno, "open `%s/%s`", path, "cpuset.mems");
 
       b_len = TEMP_FAILURE_RETRY (read (mems_fd, mems, 256));
       if (UNLIKELY (b_len < 0))
-        return crun_make_error (err, errno, "read from 'cpuset.mems'");
+        return crun_make_error (err, errno, "read from `cpuset.mems`");
       mems[b_len] = '\0';
       if (mems[0] == '\n')
         mems[0] = '\0';
@@ -103,14 +107,14 @@ initialize_cpuset_subsystem_rec (char *path, size_t path_len, char *cpus, char *
     {
       b_len = TEMP_FAILURE_RETRY (write (cpus_fd, cpus, strlen (cpus)));
       if (UNLIKELY (b_len < 0))
-        return crun_make_error (err, errno, "write 'cpuset.cpus'");
+        return crun_make_error (err, errno, "write `cpuset.cpus`");
     }
 
   if (mems_fd >= 0)
     {
       b_len = TEMP_FAILURE_RETRY (write (mems_fd, mems, strlen (mems)));
       if (UNLIKELY (b_len < 0))
-        return crun_make_error (err, errno, "write 'cpuset.mems'");
+        return crun_make_error (err, errno, "write `cpuset.mems`");
     }
 
   return 0;


### PR DESCRIPTION
on cgroup v1, it is possible to pass the "noprefix" option for the cpuset mount and that causes the "cpuset." prefix to be dropped from the cgroup files.

To support this case, attempt to open the file without the prefix when the cpuset.$FILE version fails with ENOENT.

Closes: https://github.com/containers/crun/issues/1115

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>