### PR TITLE
linux: set PR_SET_DUMPABLE

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3399,6 +3399,10 @@ libcrun_container_exec_with_options (libcrun_context_t *context, const char *id,
   if (UNLIKELY (ret < 0))
     return ret;
 
+  ret = prctl (PR_SET_DUMPABLE, 0, 0, 0, 0);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "prctl (PR_SET_DUMPABLE)");
+
   pid = libcrun_join_process (container, status.pid, &status, opts->cgroup, context->detach,
                               process->terminal ? &terminal_fd : NULL, err);
   if (UNLIKELY (pid < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -4145,6 +4145,10 @@ init_container (libcrun_container_t *container, int sync_socket_container, struc
   int ret;
   const char success = 0;
 
+  ret = prctl (PR_SET_DUMPABLE, 0, 0, 0, 0);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "prctl (PR_SET_DUMPABLE)");
+
   if (init_status->idx_pidns_to_join_immediately >= 0 || init_status->idx_timens_to_join_immediately >= 0)
     {
       pid_t new_pid;


### PR DESCRIPTION
it should not be needed anymore as the kernel takes care of it, in fact I could not find any way to access the process /proc from within the container, but better play safe and enable it.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>