### PR TITLE
utils: add utils to access /proc/$PID/fd/$FD paths

### DIFF
--- a/tests/centos8-build/run-tests.sh
+++ b/tests/centos8-build/run-tests.sh
@@ -3,6 +3,8 @@
 set -e
 cd /crun
 
+git config --global --add safe.directory /crun
+
 git clean -fdx
 ./autogen.sh
 ./configure CFLAGS='-Wall -Wextra -Werror'


### PR DESCRIPTION
accessing the /proc/$PID/fd/$FD paths is a common operation so refactor this pattern into a utility function.

We avoid having to have the same pattern in multiple places with the risk of using the wrong size for the buffer.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>