### PR TITLE
utils: shrink read buffer if necessary

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -900,6 +900,14 @@ read_all_fd (int fd, const char *description, char **out, size_t *len, libcrun_e
           buf = xrealloc (buf, allocated + 1);
         }
     }
+  if (nread + 1 < allocated)
+    {
+      /* shrink the buffer to the used size if it was allocated a bigger block.  */
+      char *tmp = realloc (buf, nread + 1);
+      if (tmp)
+        buf = tmp;
+    }
+
   buf[nread] = '\0';
   *out = buf;
   buf = NULL;


### PR DESCRIPTION
another optimization for `read_all_fd`.  If the allocated buffer is bigger than what is actually used with the file data, then shrink its size before returning it so to reduce wasted memory.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>