### PR TITLE
handlers: add new hook to modify the OCI configuration

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -121,8 +121,6 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
 
   crun_context.preserve_fds = 0;
   crun_context.listen_fds = 0;
-  /* Check if global handler is configured and pass it down to crun context */
-  crun_context.handler = global_args->handler;
 
   argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &crun_context);
 

--- a/src/crun.c
+++ b/src/crun.c
@@ -101,6 +101,9 @@ init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global
   con->argc = glob->argc;
   con->argv = glob->argv;
 
+  /* Check if global handler is configured and pass it down to crun context */
+  con->handler = glob->handler;
+
   ret = libcrun_init_logging (&con->output_handler, &con->output_handler_arg, id, glob->log, err);
   if (UNLIKELY (ret < 0))
     return ret;

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1439,7 +1439,7 @@ container_init (void *args, char *notify_socket, int sync_socket, libcrun_error_
       if (UNLIKELY (ret < 0))
         return ret;
 
-      ret = entrypoint_args->custom_handler->vtable->exec_func (entrypoint_args->custom_handler->cookie,
+      ret = entrypoint_args->custom_handler->vtable->run_func (entrypoint_args->custom_handler->cookie,
                                                                 entrypoint_args->container,
                                                                 exec_path,
                                                                 def->process->args);

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2309,6 +2309,16 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   if (UNLIKELY (ret < 0))
     return ret;
 
+  if (container_args.custom_handler && container_args.custom_handler->modify_oci_configuration)
+    {
+      ret = container_args.custom_handler->modify_oci_configuration (container_args.handler_cookie,
+                                                                     container_args.context,
+                                                                     container->container_def,
+                                                                     err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+    }
+
   pid = libcrun_run_linux_container (container, container_init, &container_args, &sync_socket, &cgroup_dirfd_s, err);
   if (UNLIKELY (pid < 0))
     return pid;

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -977,15 +977,6 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
   cleanup_free char *rootfs = NULL;
   int no_new_privs;
 
-  ret = libcrun_configure_handler (entrypoint_args->context->handler_manager,
-                                   entrypoint_args->context,
-                                   container,
-                                   &(entrypoint_args->custom_handler),
-                                   &(entrypoint_args->handler_cookie),
-                                   err);
-  if (UNLIKELY (ret < 0))
-    return ret;
-
   ret = initialize_security (def->process, err);
   if (UNLIKELY (ret < 0))
     return ret;
@@ -2308,6 +2299,15 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
   cgroup_dirfd_s.dirfd = &cgroup_dirfd;
   cgroup_dirfd_s.joined = false;
+
+  ret = libcrun_configure_handler (container_args.context->handler_manager,
+                                   container_args.context,
+                                   container,
+                                   &(container_args.custom_handler),
+                                   &(container_args.handler_cookie),
+                                   err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   pid = libcrun_run_linux_container (container, container_init, &container_args, &sync_socket, &cgroup_dirfd_s, err);
   if (UNLIKELY (pid < 0))

--- a/src/libcrun/custom-handler.h
+++ b/src/libcrun/custom-handler.h
@@ -40,6 +40,10 @@ struct custom_handler_s
                               const char *rootfs, libcrun_error_t *err);
 
   int (*can_handle_container) (libcrun_container_t *container, libcrun_error_t *err);
+
+  int (*modify_oci_configuration) (void *cookie, libcrun_context_t *context,
+                                   runtime_spec_schema_config_schema *def,
+                                   libcrun_error_t *err);
 };
 
 struct custom_handler_manager_s;

--- a/src/libcrun/custom-handler.h
+++ b/src/libcrun/custom-handler.h
@@ -55,11 +55,17 @@ LIBCRUN_PUBLIC void handler_manager_free (struct custom_handler_manager_s *manag
 LIBCRUN_PUBLIC struct custom_handler_s *handler_by_name (struct custom_handler_manager_s *manager, const char *name);
 LIBCRUN_PUBLIC void libcrun_handler_manager_print_feature_tags (struct custom_handler_manager_s *manager, FILE *out);
 
+struct custom_handler_instance_s
+{
+  struct custom_handler_s *vtable;
+  void *cookie;
+};
+
 LIBCRUN_PUBLIC int libcrun_configure_handler (struct custom_handler_manager_s *manager,
                                               libcrun_context_t *context,
                                               libcrun_container_t *container,
-                                              struct custom_handler_s **out,
-                                              void **cookie, libcrun_error_t *err);
+                                              struct custom_handler_instance_s **out,
+                                              libcrun_error_t *err);
 
 typedef struct custom_handler_s *(*run_oci_get_handler_cb) ();
 

--- a/src/libcrun/custom-handler.h
+++ b/src/libcrun/custom-handler.h
@@ -33,7 +33,7 @@ struct custom_handler_s
   int (*load) (void **cookie, libcrun_error_t *err);
   int (*unload) (void *cookie, libcrun_error_t *err);
 
-  int (*exec_func) (void *cookie, libcrun_container_t *container,
+  int (*run_func) (void *cookie, libcrun_container_t *container,
                     const char *pathname, char *const argv[]);
 
   int (*configure_container) (void *cookie, enum handler_configure_phase phase,

--- a/src/libcrun/custom-handler.h
+++ b/src/libcrun/custom-handler.h
@@ -34,6 +34,9 @@ struct custom_handler_s
   int (*unload) (void *cookie, libcrun_error_t *err);
 
   int (*run_func) (void *cookie, libcrun_container_t *container,
+                   const char *pathname, char *const argv[]);
+
+  int (*exec_func) (void *cookie, libcrun_container_t *container,
                     const char *pathname, char *const argv[]);
 
   int (*configure_container) (void *cookie, enum handler_configure_phase phase,

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -353,7 +353,7 @@ struct custom_handler_s handler_libkrun = {
   .feature_string = "LIBKRUN",
   .load = libkrun_load,
   .unload = libkrun_unload,
-  .exec_func = libkrun_exec,
+  .run_func = libkrun_exec,
   .configure_container = libkrun_configure_container,
   .modify_oci_configuration = libkrun_modify_oci_configuration,
 };

--- a/src/libcrun/handlers/mono.c
+++ b/src/libcrun/handlers/mono.c
@@ -169,7 +169,7 @@ struct custom_handler_s handler_mono = {
   .feature_string = ".NET:mono",
   .load = mono_load,
   .unload = mono_unload,
-  .exec_func = mono_exec,
+  .run_func = mono_exec,
   .can_handle_container = mono_can_handle_container,
   .configure_container = mono_configure_container,
 };

--- a/src/libcrun/handlers/wasmedge.c
+++ b/src/libcrun/handlers/wasmedge.c
@@ -168,7 +168,7 @@ struct custom_handler_s handler_wasmedge = {
   .feature_string = "WASM:wasmedge",
   .load = libwasmedge_load,
   .unload = libwasmedge_unload,
-  .exec_func = libwasmedge_exec,
+  .run_func = libwasmedge_exec,
   .can_handle_container = wasmedge_can_handle_container,
 };
 

--- a/src/libcrun/handlers/wasmer.c
+++ b/src/libcrun/handlers/wasmer.c
@@ -284,7 +284,7 @@ struct custom_handler_s handler_wasmer = {
   .feature_string = "WASM:wasmer",
   .load = libwasmer_load,
   .unload = libwasmer_unload,
-  .exec_func = libwasmer_exec,
+  .run_func = libwasmer_exec,
   .can_handle_container = libwasmer_can_handle_container,
 };
 

--- a/src/libcrun/handlers/wasmtime.c
+++ b/src/libcrun/handlers/wasmtime.c
@@ -292,7 +292,7 @@ struct custom_handler_s handler_wasmtime = {
   .feature_string = "WASM:wasmtime",
   .load = libwasmtime_load,
   .unload = libwasmtime_unload,
-  .exec_func = libwasmtime_exec,
+  .run_func = libwasmtime_exec,
   .can_handle_container = libwasmtime_can_handle_container,
 };
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5046,39 +5046,13 @@ exit:
 }
 
 int
-libcrun_linux_container_update (libcrun_container_status_t *status, const char *content, size_t len arg_unused,
-                                libcrun_error_t *err)
+libcrun_linux_container_update (libcrun_container_status_t *status, runtime_spec_schema_config_linux_resources *resources, libcrun_error_t *err)
 {
-  int ret;
-  yajl_val tree = NULL;
-  parser_error parser_err = NULL;
-  runtime_spec_schema_config_linux_resources *resources = NULL;
-  struct parser_context ctx = { 0, stderr };
   cleanup_cgroup_status struct libcrun_cgroup_status *cgroup_status = NULL;
-
-  ret = parse_json_file (&tree, content, &ctx, err);
-  if (UNLIKELY (ret < 0))
-    return -1;
-
-  resources = make_runtime_spec_schema_config_linux_resources (tree, &ctx, &parser_err);
-  if (UNLIKELY (resources == NULL))
-    {
-      ret = crun_make_error (err, errno, "cannot parse resources");
-      goto cleanup;
-    }
 
   cgroup_status = libcrun_cgroup_make_status (status);
 
-  ret = libcrun_update_cgroup_resources (cgroup_status, resources, err);
-
-cleanup:
-  if (tree)
-    yajl_tree_free (tree);
-  free (parser_err);
-  if (resources)
-    free_runtime_spec_schema_config_linux_resources (resources);
-
-  return ret;
+  return libcrun_update_cgroup_resources (cgroup_status, resources, err);
 }
 
 static int

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -82,8 +82,8 @@ int libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_set_terminal (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_join_process (libcrun_container_t *container, pid_t pid_to_join, libcrun_container_status_t *status,
                           const char *cgroup, int detach, int *terminal_fd, libcrun_error_t *err);
-int libcrun_linux_container_update (libcrun_container_status_t *status, const char *content, size_t len,
-                                    libcrun_error_t *err);
+int libcrun_linux_container_update (libcrun_container_status_t *status,
+                                    runtime_spec_schema_config_linux_resources *resources, libcrun_error_t *err);
 int libcrun_create_keyring (const char *name, const char *label, libcrun_error_t *err);
 int libcrun_container_pause_linux (libcrun_container_status_t *status, libcrun_error_t *err);
 int libcrun_container_unpause_linux (libcrun_container_status_t *status, libcrun_error_t *err);

--- a/tests/cri-o/Dockerfile
+++ b/tests/cri-o/Dockerfile
@@ -32,7 +32,7 @@ RUN yum install -y python git gcc automake autoconf libcap-devel \
     git clone https://github.com/kubernetes-sigs/cri-tools && \
     cd /root/go/src/github.com/kubernetes-sigs/cri-tools && \
     make && \
-    cp build/bin/crictl /usr/local/bin/)
+    cp build/bin/linux/*/crictl /usr/local/bin/)
 
 COPY run-tests.sh /usr/local/bin
 WORKDIR /root/go/src/github.com/cri-o/cri-o


### PR DESCRIPTION
so that it can be used from krun to always add /dev/kvm.

Closes: https://github.com/containers/crun/issues/1130

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
