### PR TITLE
Support passing an attribute to change the mount_context_type

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -494,6 +494,20 @@ Specify which CRIU manage cgroup mode should be used. Permitted values are
 
 
 .SH Extensions to OCI
+.SH \fB\fCrun.oci.mount_context_type=context\fR
+.PP
+Set the mount context type on volumes mounted with SELinux labels.
+
+.PP
+Valid context types are:
+  context (default)
+  fscontext
+  defcontext
+  rootcontext
+
+.PP
+More information on how the context mount flags works see the \fB\fCmount(8)\fR man page.
+
 .SH \fB\fCrun.oci.seccomp.receiver=PATH\fR
 .PP
 If the annotation \fB\fCrun.oci.seccomp.receiver=PATH\fR is specified, the

--- a/crun.1.md
+++ b/crun.1.md
@@ -64,7 +64,6 @@ Checkpoint a running container using CRIU
 
 **restore**
 Restore a container from a checkpoint
-
 # STATE
 
 By default, when running as root user, crun saves its state under the
@@ -388,6 +387,18 @@ Specify which CRIU manage cgroup mode should be used. Permitted values are
 **soft**, **ignore**, **full** or **strict**. Default is **soft**.
 
 # Extensions to OCI
+
+## `run.oci.mount_context_type=context`
+
+Set the mount context type on volumes mounted with SELinux labels.
+
+Valid context types are:
+  context (default)
+  fscontext
+  defcontext
+  rootcontext
+
+More information on how the context mount flags works see the `mount(8)` man page.
 
 ## `run.oci.seccomp.receiver=PATH`
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1143,7 +1143,11 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
 
   if (label_how == LABEL_MOUNT)
     {
-      ret = add_selinux_mount_label (&data_with_label, data, label, err);
+      const char *context_type = find_annotation (container, "run.oci.mount_context_type");
+      if (! context_type)
+        context_type = "context";
+
+      ret = add_selinux_mount_label (&data_with_label, data, label, context_type, err);
       if (ret < 0)
         return ret;
       data = data_with_label;

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -767,7 +767,7 @@ libcrun_is_selinux_enabled (libcrun_error_t *err)
 }
 
 int
-add_selinux_mount_label (char **retlabel, const char *data, const char *label, libcrun_error_t *err arg_unused)
+add_selinux_mount_label (char **retlabel, const char *data, const char *label, const char *context_type, libcrun_error_t *err arg_unused)
 {
   int ret;
 
@@ -778,9 +778,9 @@ add_selinux_mount_label (char **retlabel, const char *data, const char *label, l
   if (label && ret)
     {
       if (data && *data)
-        xasprintf (retlabel, "%s,context=\"%s\"", data, label);
+        xasprintf (retlabel, "%s,%s=\"%s\"", data, context_type, label);
       else
-        xasprintf (retlabel, "context=\"%s\"", label);
+        xasprintf (retlabel, "%s=\"%s\"", context_type, label);
       return 0;
     }
   *retlabel = xstrdup (data);

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -291,7 +291,7 @@ int check_running_in_user_namespace (libcrun_error_t *err);
 
 int set_selinux_label (const char *label, bool now, libcrun_error_t *err);
 
-int add_selinux_mount_label (char **ret, const char *data, const char *label, libcrun_error_t *err);
+int add_selinux_mount_label (char **ret, const char *data, const char *label, const char *context_type, libcrun_error_t *err);
 
 int set_apparmor_profile (const char *profile, bool now, libcrun_error_t *err);
 


### PR DESCRIPTION
Currently all containers with SELinux run with the context= mount option. This option prevents confined containers from running within a container. Changing this flag to fscontext= would allow confined containers within a container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>