### PR TITLE
cgroup: reset systemd unit if start fails

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -729,6 +729,8 @@ enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *resource
       goto exit;
     }
 
+  sd_err = sd_bus_message_append (m, "(sv)", "DefaultDependencies", "b", 0);
+
   for (i = 0; boolean_opts[i]; i++)
     {
       sd_err = sd_bus_message_append (m, "(sv)", boolean_opts[i], "b", 1);


### PR DESCRIPTION
if the unit could not be started, attempt to reset it first, and then start it again.

Closes: https://github.com/containers/crun/issues/1138

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
