### PR TITLE
crun.1.md: fix typo

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -521,7 +521,7 @@ it is supported in the OCI runtime specs.  It must be an absolute path.
 If the annotation \fB\fCrun.oci.seccomp.plugins=PLUGIN1[:PLUGIN2]...\fR is specified, the
 seccomp listener fd is handled through the specified plugins.  The
 plugin must either be an absolute path or a file name that is looked
-up by \fB\fCldopen(3)\fR\&.  More information on how the lookup is performed
+up by \fB\fCdlopen(3)\fR\&.  More information on how the lookup is performed
 are available on the \fB\fCld.so(8)\fR man page.
 
 .SH \fB\fCrun.oci.seccomp_fail_unknown_syscall=1\fR

--- a/crun.1.md
+++ b/crun.1.md
@@ -413,7 +413,7 @@ it is supported in the OCI runtime specs.  It must be an absolute path.
 If the annotation `run.oci.seccomp.plugins=PLUGIN1[:PLUGIN2]...` is specified, the
 seccomp listener fd is handled through the specified plugins.  The
 plugin must either be an absolute path or a file name that is looked
-up by `ldopen(3)`.  More information on how the lookup is performed
+up by `dlopen(3)`.  More information on how the lookup is performed
 are available on the `ld.so(8)` man page.
 
 ## `run.oci.seccomp_fail_unknown_syscall=1`


### PR DESCRIPTION
Fix a small typo (ldopen vs. dlopen) I stumbled upon in the man page.