### PR TITLE
cgroup: rmdir the entire systemd scope

### DIFF
--- a/src/libcrun/cgroup-systemd.h
+++ b/src/libcrun/cgroup-systemd.h
@@ -23,6 +23,8 @@
 
 int parse_sd_array (char *s, char **out, char **next, libcrun_error_t *err);
 
+char *get_cgroup_scope_path (const char *cgroup_path, const char *scope);
+
 extern struct libcrun_cgroup_manager cgroup_manager_systemd;
 
 #endif

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2485,7 +2485,14 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   return ret;
 
 fail:
-  return cleanup_watch (context, def, cgroup_status, pid, sync_socket, terminal_fd, err);
+  ret = cleanup_watch (context, def, cgroup_status, pid, sync_socket, terminal_fd, err);
+  if (cgroup_status)
+    {
+      libcrun_error_t tmp_err = NULL;
+      libcrun_cgroup_destroy (cgroup_status, &tmp_err);
+      crun_error_release (&tmp_err);
+    }
+  return ret;
 }
 
 static int

--- a/tests/tests_libcrun_utils.c
+++ b/tests/tests_libcrun_utils.c
@@ -398,6 +398,30 @@ test_parse_sd_array ()
   }
   return 0;
 }
+
+static int
+test_get_scope_path ()
+{
+#  define CHECK(x, y)                                      \
+    {                                                      \
+      cleanup_free char *r = x;                            \
+      if (strcmp (r, y))                                   \
+        {                                                  \
+          fprintf (stderr, "expected %s, got %s\n", y, r); \
+          return -1;                                       \
+        }                                                  \
+    }
+
+  CHECK (get_cgroup_scope_path ("foo.scope", "foo.scope"), "foo.scope");
+  CHECK (get_cgroup_scope_path ("/foo/bar/user.slice/foo.scope/a/b/c", "foo.scope"), "/foo/bar/user.slice/foo.scope");
+  CHECK (get_cgroup_scope_path ("/foo/bar-foo.scope/user.slice/foo.scope/a/b/c", "foo.scope"), "/foo/bar-foo.scope/user.slice/foo.scope");
+  CHECK (get_cgroup_scope_path ("/foo/foo.scope-bar/user.slice/foo.scope/a/b/c", "foo.scope"), "/foo/foo.scope-bar/user.slice/foo.scope");
+  CHECK (get_cgroup_scope_path ("////foo.scope", "foo.scope"), "////foo.scope");
+
+#  undef CHECK
+  return 0;
+}
+
 #endif
 
 static void
@@ -423,7 +447,7 @@ main ()
 {
   int id = 1;
 #ifdef HAVE_SYSTEMD
-  printf ("1..9\n");
+  printf ("1..10\n");
 #else
   printf ("1..8\n");
 #endif
@@ -437,6 +461,7 @@ main ()
   RUN_TEST (test_path_is_slash_dev);
 #ifdef HAVE_SYSTEMD
   RUN_TEST (test_parse_sd_array);
+  RUN_TEST (test_get_scope_path);
 #endif
   return 0;
 }


### PR DESCRIPTION
commit 7ea76174986bf5e19715a43cdffff1724ee27236 caused a regression on cgroup v1, and some directories that are created manually are not cleaned up on container termination causing a cgroup leak.
    
Fix it by deleting the entire systemd scope directory instead of deleting only the final cgroup.

Closes: https://github.com/containers/crun/issues/1144

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
