### PR TITLE
container: add custom annotation to specify the scheduler

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -685,6 +685,21 @@ wasm module is relayed back via crun.
 
 .RE
 
+.SH \fB\fCrun.oci.scheduler\fR
+.PP
+The \fB\fCrun.oci.scheduler\fR annotation allows you to set the scheduling
+policy for the container process.  The value of the annotation should
+be in the format \fB\fCPOLICY[|OPTION][#PRIORITY]\fR, where \fB\fCPOLICY\fR is the
+name of the scheduling policy, \fB\fCOPTION\fR can be \fB\fCSCHED_RESET_ON_FORK\fR
+and \fB\fCPRIORITY\fR is an optional integer priority value.
+
+.PP
+It is an experimental feature and will be removed once the feature is in the
+OCI runtime specs.
+
+.PP
+Please refer to \fB\fCsched_setscheduler(2)\fR for more information.
+
 .SH tmpcopyup mount options
 .PP
 If the \fB\fCtmpcopyup\fR option is specified for a tmpfs, then the path that
@@ -814,8 +829,8 @@ For example, the mapping: \fB\fCuids=@1-3-10\fR, given a configuration like
 
 .PP
 will be converted to the absolute value \fB\fCuids=1-4-10\fR, where 4 is
-calculated by adding 3 (container ID in the \fB\fCuids=\fR mapping)
-+ 1 (\fB\fChostID - containerID\fR for the user namespace mapping where
+calculated by adding 3 (container ID in the \fB\fCuids=\fR mapping) and 1
+(\fB\fChostID - containerID\fR for the user namespace mapping where
 \fB\fCcontainerID = 1\fR is found).
 
 .PP

--- a/crun.1.md
+++ b/crun.1.md
@@ -541,6 +541,19 @@ workload natively. Accepts a `.wasm` binary as input and if `.wat` is
 provided it will be automatically compiled into a wasm module. Stdout of
 wasm module is relayed back via crun.
 
+## `run.oci.scheduler`
+
+The `run.oci.scheduler` annotation allows you to set the scheduling
+policy for the container process.  The value of the annotation should
+be in the format `POLICY[|OPTION][#PRIORITY]`, where `POLICY` is the
+name of the scheduling policy, `OPTION` can be `SCHED_RESET_ON_FORK`
+and `PRIORITY` is an optional integer priority value.
+
+It is an experimental feature and will be removed once the feature is in the
+OCI runtime specs.
+
+Please refer to `sched_setscheduler(2)` for more information.
+
 ## tmpcopyup mount options
 
 If the `tmpcopyup` option is specified for a tmpfs, then the path that

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -129,7 +129,6 @@ setup_rt_runtime (runtime_spec_schema_config_linux_resources *resources,
   return 0;
 }
 
-
 static int
 systemd_finalize (struct libcrun_cgroup_args *args, char **path_out,
                   int cgroup_mode, const char *suffix, libcrun_error_t *err)

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2376,6 +2376,10 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   if (UNLIKELY (ret < 0))
     goto fail;
 
+  ret = libcrun_set_scheduler (pid, container, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   /* The container is waiting that we write back.  In this phase we can launch the
      prestart hooks.  */
   if (def->hooks && def->hooks->prestart_len)

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -116,4 +116,6 @@ int libcrun_create_dev (libcrun_container_t *container, int devfd,
 int parse_idmapped_mount_option (runtime_spec_schema_config_schema *def, bool is_uids, char *option, char **out,
                                  size_t *len, libcrun_error_t *err);
 
+int libcrun_set_scheduler (pid_t pid, libcrun_container_t *container, libcrun_error_t *err);
+
 #endif


### PR DESCRIPTION
add a new feature to the container runtime that allows users to set the scheduling policy of the container process.

The new feature is implemented as a custom annotation.  To set the scheduling policy and priority, users can add a `run.oci.scheduler` annotation with a value in the format POLICY[#PRIORITY].

If no scheduling policy or priority is specified, the container process will use the current scheduling policy and priority.