### PR TITLE
libcrun_container_create(): fix memory leak

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2742,7 +2742,7 @@ libcrun_container_create (libcrun_context_t *context, libcrun_container_t *conta
             {
               libcrun_error_t tmp_err = NULL;
               libcrun_container_delete (context, def, context->id, true, &tmp_err);
-              crun_error_release (err);
+              crun_error_release (&tmp_err);
             }
           return -exit_code;
         }


### PR DESCRIPTION
Might be a typo? The `tmp_err` is never released and the `err` should be handled by the caller.