### PR TITLE
scheduler: use sched_setattr

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ libcrun_SOURCES = src/libcrun/utils.c \
 			src/libcrun/custom-handler.c \
 			src/libcrun/linux.c \
 			src/libcrun/seccomp.c \
+			src/libcrun/scheduler.c \
 			src/libcrun/ebpf.c \
 			src/libcrun/error.c \
 			src/libcrun/status.c \
@@ -109,7 +110,7 @@ EXTRA_DIST = COPYING COPYING.libcrun README.md NEWS SECURITY.md rpm/crun.spec.in
 	src/libcrun/custom-handler.h \
 	src/libcrun/handlers/handler-utils.h \
 	src/libcrun/linux.h src/libcrun/utils.h src/libcrun/error.h src/libcrun/criu.h \
-	src/libcrun/status.h src/libcrun/terminal.h src/libcrun/mount_flags.h \
+	src/libcrun/scheduler.h src/libcrun/status.h src/libcrun/terminal.h src/libcrun/mount_flags.h \
 	crun.1.md crun.1 libcrun.lds
 
 UNIT_TESTS = tests/tests_libcrun_utils tests/tests_libcrun_errors

--- a/crun.1
+++ b/crun.1
@@ -687,6 +687,65 @@ wasm module is relayed back via crun.
 
 .SH \fB\fCrun.oci.scheduler\fR
 .PP
+The \fB\fCrun.oci.scheduler\fR annotation is used to specify the scheduling
+policy and attributes of a process within a container.
+
+.PP
+The \fB\fCrun.oci.scheduler\fR annotation has the following format: \fB\fCPOLICY[#OPTION:VALUE]#...]\fR
+
+.PP
+Where \fB\fCPOLICY\fR is the scheduling policy to set and \fB\fCOPTION\fR is an
+optional scheduling attribute to set.
+
+.PP
+The following scheduling policies are supported:
+
+.RS
+.IP \(bu 2
+SCHED_OTHER
+.IP \(bu 2
+SCHED_BATCH
+.IP \(bu 2
+SCHED_IDLE
+.IP \(bu 2
+SCHED_FIFO
+.IP \(bu 2
+SCHED_RR
+.IP \(bu 2
+SCHED_DEADLINE
+
+.RE
+
+.PP
+The following attributes can be set:
+
+.RS
+.IP \(bu 2
+runtime=VALUE.
+.IP \(bu 2
+deadline=VALUE.
+.IP \(bu 2
+period=VALUE.
+.IP \(bu 2
+prio=VALUE.
+.IP \(bu 2
+flag_reset_on_fork=1.
+.IP \(bu 2
+flag_reclaim=1.
+.IP \(bu 2
+flag_dl_overrun=1.
+.IP \(bu 2
+flag_keep_policy=1.
+.IP \(bu 2
+flag_keep_params=1.
+.IP \(bu 2
+flag_util_clamp_min=1.
+.IP \(bu 2
+flag_util_clamp_max=1.
+
+.RE
+
+.PP
 The \fB\fCrun.oci.scheduler\fR annotation allows you to set the scheduling
 policy for the container process.  The value of the annotation should
 be in the format \fB\fCPOLICY[|OPTION][#PRIORITY]\fR, where \fB\fCPOLICY\fR is the
@@ -698,7 +757,7 @@ It is an experimental feature and will be removed once the feature is in the
 OCI runtime specs.
 
 .PP
-Please refer to \fB\fCsched_setscheduler(2)\fR for more information.
+Please refer to \fB\fCsched_setattr(2)\fR for more information.
 
 .SH tmpcopyup mount options
 .PP

--- a/crun.1.md
+++ b/crun.1.md
@@ -543,6 +543,38 @@ wasm module is relayed back via crun.
 
 ## `run.oci.scheduler`
 
+The `run.oci.scheduler` annotation is used to specify the scheduling
+policy and attributes of a process within a container.
+
+The `run.oci.scheduler` annotation has the following format: `POLICY[#OPTION:VALUE]#...]`
+
+Where `POLICY` is the scheduling policy to set and `OPTION` is an
+optional scheduling attribute to set.
+
+The following scheduling policies are supported:
+
+- SCHED_OTHER
+- SCHED_BATCH
+- SCHED_IDLE
+- SCHED_FIFO
+- SCHED_RR
+- SCHED_DEADLINE
+
+The following attributes can be set:
+
+- runtime=VALUE.
+- deadline=VALUE.
+- period=VALUE.
+- prio=VALUE.
+- flag_reset_on_fork=1.
+- flag_reclaim=1.
+- flag_dl_overrun=1.
+- flag_keep_policy=1.
+- flag_keep_params=1.
+- flag_util_clamp_min=1.
+- flag_util_clamp_max=1.
+
+
 The `run.oci.scheduler` annotation allows you to set the scheduling
 policy for the container process.  The value of the annotation should
 be in the format `POLICY[|OPTION][#PRIORITY]`, where `POLICY` is the
@@ -552,7 +584,7 @@ and `PRIORITY` is an optional integer priority value.
 It is an experimental feature and will be removed once the feature is in the
 OCI runtime specs.
 
-Please refer to `sched_setscheduler(2)` for more information.
+Please refer to `sched_setattr(2)` for more information.
 
 ## tmpcopyup mount options
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -23,6 +23,7 @@
 #include "container.h"
 #include "utils.h"
 #include "seccomp.h"
+#include "scheduler.h"
 #include "seccomp_notify.h"
 #include "custom-handler.h"
 #include <stdbool.h>

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -116,6 +116,4 @@ int libcrun_create_dev (libcrun_container_t *container, int devfd,
 int parse_idmapped_mount_option (runtime_spec_schema_config_schema *def, bool is_uids, char *option, char **out,
                                  size_t *len, libcrun_error_t *err);
 
-int libcrun_set_scheduler (pid_t pid, libcrun_container_t *container, libcrun_error_t *err);
-
 #endif

--- a/src/libcrun/scheduler.c
+++ b/src/libcrun/scheduler.c
@@ -1,0 +1,204 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE
+
+#include <config.h>
+#include "linux.h"
+#include "utils.h"
+#include <sched.h>
+#include <sys/sysmacros.h>
+#include <limits.h>
+#include <inttypes.h>
+
+#ifndef SCHED_FLAG_RESET_ON_FORK
+#  define SCHED_FLAG_RESET_ON_FORK 0x01
+#endif
+#ifndef SCHED_FLAG_RECLAIM
+#  define SCHED_FLAG_RECLAIM 0x02
+#endif
+#ifndef SCHED_FLAG_DL_OVERRUN
+#  define SCHED_FLAG_DL_OVERRUN 0x04
+#endif
+#ifndef SCHED_FLAG_KEEP_POLICY
+#  define SCHED_FLAG_KEEP_POLICY 0x08
+#endif
+#ifndef SCHED_FLAG_KEEP_PARAMS
+#  define SCHED_FLAG_KEEP_PARAMS 0x10
+#endif
+#ifndef SCHED_FLAG_UTIL_CLAMP_MIN
+#  define SCHED_FLAG_UTIL_CLAMP_MIN 0x20
+#endif
+#ifndef SCHED_FLAG_UTIL_CLAMP_MAX
+#  define SCHED_FLAG_UTIL_CLAMP_MAX 0x40
+#endif
+
+struct sched_attr_s
+{
+  uint32_t size;
+  uint32_t sched_policy;
+  uint64_t sched_flags;
+  int32_t sched_nice;
+
+  uint32_t sched_priority;
+
+  uint64_t sched_runtime;
+  uint64_t sched_deadline;
+  uint64_t sched_period;
+};
+
+static int
+syscall_sched_setattr (pid_t pid, struct sched_attr_s *attr, unsigned int flags)
+{
+#ifdef __NR_sched_setattr
+  return syscall (__NR_sched_setattr, pid, attr, flags);
+#else
+  (void) pid;
+  (void) attr;
+  (void) flags;
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+
+int
+libcrun_set_scheduler (pid_t pid, libcrun_container_t *container, libcrun_error_t *err)
+{
+  cleanup_free char *copy = NULL;
+  struct sched_attr_s attr;
+  const char *annotation;
+  char *v, *v_options;
+  int ret, policy;
+  char *sptr;
+  struct
+  {
+    const char *name;
+    int value;
+  } policies[] = {
+    { "SCHED_OTHER", SCHED_OTHER },
+    { "SCHED_BATCH", SCHED_BATCH },
+    { "SCHED_IDLE", SCHED_IDLE },
+    { "SCHED_FIFO", SCHED_FIFO },
+    { "SCHED_RR", SCHED_RR },
+    { "SCHED_DEADLINE", SCHED_DEADLINE },
+    { NULL, 0 },
+  };
+
+  memset (&attr, 0, sizeof (attr));
+  attr.size = sizeof (attr);
+
+  annotation = find_annotation (container, "run.oci.scheduler");
+  if (LIKELY (annotation == NULL))
+    return 0;
+
+  copy = xstrdup (annotation);
+  v_options = strchr (copy, '#');
+  if (v_options)
+    *v_options = '\0';
+
+  policy = -1;
+  for (int i = 0; policies[i].name; i++)
+    if (strcmp (copy, policies[i].name) == 0)
+      {
+        policy = policies[i].value;
+        break;
+      }
+  if (UNLIKELY (policy == -1))
+    return crun_make_error (err, 0, "invalid scheduler `%s`", copy);
+
+  attr.sched_policy = policy;
+
+  if (v_options)
+    {
+      v_options++;
+      for (v = strtok_r (v_options, "#", &sptr); v; v = strtok_r (NULL, "#", &sptr))
+        {
+          char *key = v;
+          char *value;
+          char *ep = NULL;
+
+          value = strchr (v, ':');
+          if (UNLIKELY (value == NULL))
+            return crun_make_error (err, 0, "invalid scheduler option `%s`", v);
+          *value++ = '\0';
+
+          if (strcmp (key, "flag_reset_on_fork") == 0)
+            attr.sched_flags |= SCHED_FLAG_RESET_ON_FORK;
+          else if (strcmp (key, "flag_reclaim") == 0)
+            attr.sched_flags |= SCHED_FLAG_RECLAIM;
+          else if (strcmp (key, "flag_dl_overrun") == 0)
+            attr.sched_flags |= SCHED_FLAG_DL_OVERRUN;
+          else if (strcmp (key, "flag_keep_policy") == 0)
+            attr.sched_flags |= SCHED_FLAG_KEEP_POLICY;
+          else if (strcmp (key, "flag_keep_params") == 0)
+            attr.sched_flags |= SCHED_FLAG_KEEP_PARAMS;
+          else if (strcmp (key, "flag_util_clamp_min") == 0)
+            attr.sched_flags |= SCHED_FLAG_UTIL_CLAMP_MIN;
+          else if (strcmp (key, "flag_util_clamp_max") == 0)
+            attr.sched_flags |= SCHED_FLAG_UTIL_CLAMP_MAX;
+          else if (strcmp (key, "prio") == 0)
+            {
+
+              errno = 0;
+              attr.sched_priority = strtoul (value, &ep, 10);
+              if (UNLIKELY (ep != NULL && *ep != '\0'))
+                return crun_make_error (err, EINVAL, "parse scheduler annotation");
+              if (UNLIKELY (errno))
+                return crun_make_error (err, errno, "parse scheduler annotation");
+
+              if (attr.sched_priority < (uint32_t) sched_get_priority_min (policy)
+                  || attr.sched_priority > (uint32_t) sched_get_priority_max (policy))
+                return crun_make_error (err, 0, "scheduler priority value `%ul` out of range", attr.sched_priority);
+            }
+          else if (strcmp (key, "runtime") == 0)
+            {
+              attr.sched_runtime = strtoull (value, &ep, 10);
+              if (UNLIKELY (ep != NULL && *ep != '\0'))
+                return crun_make_error (err, EINVAL, "parse scheduler annotation");
+              if (UNLIKELY (errno))
+                return crun_make_error (err, errno, "parse scheduler annotation");
+            }
+          else if (strcmp (key, "deadline") == 0)
+            {
+              attr.sched_deadline = strtoull (value, &ep, 10);
+              if (UNLIKELY (ep != NULL && *ep != '\0'))
+                return crun_make_error (err, EINVAL, "parse scheduler annotation");
+              if (UNLIKELY (errno))
+                return crun_make_error (err, errno, "parse scheduler annotation");
+            }
+          else if (strcmp (key, "period") == 0)
+            {
+              attr.sched_period = strtoull (value, &ep, 10);
+              if (UNLIKELY (ep != NULL && *ep != '\0'))
+                return crun_make_error (err, EINVAL, "parse scheduler annotation");
+              if (UNLIKELY (errno))
+                return crun_make_error (err, errno, "parse scheduler annotation");
+            }
+          else
+            {
+              return crun_make_error (err, 0, "invalid scheduler option `%s`", key);
+            }
+        }
+    }
+
+  ret = syscall_sched_setattr (pid, &attr, 0);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, errno, "sched_setattr");
+
+  return 0;
+}

--- a/src/libcrun/scheduler.h
+++ b/src/libcrun/scheduler.h
@@ -1,0 +1,27 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2017, 2018, 2019, 2021 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef SCHEDULER_H
+#define SCHEDULER_H
+#include <config.h>
+#include "error.h"
+#include "container.h"
+#include "status.h"
+
+int libcrun_set_scheduler (pid_t pid, libcrun_container_t *container, libcrun_error_t *err);
+
+#endif


### PR DESCRIPTION
replace sched_setscheduler() with sched_setattr().

The sched_setattr() function allows setting multiple attributes at once, including the scheduling policy, priority, runtime, deadline, period, and other scheduling options.  This feature provides more flexibility and control over the scheduling of processes within containers and can improve resource utilization and performance in specific use cases.