### PR TITLE
wasm, wasmedge: add current directory to `preopen` paths

### DIFF
--- a/src/libcrun/handlers/wasmedge.c
+++ b/src/libcrun/handlers/wasmedge.c
@@ -81,7 +81,7 @@ libwasmedge_exec (void *cookie, __attribute__ ((unused)) libcrun_container_t *co
   WasmEdge_String (*WasmEdge_StringCreateByCString) (const char *Str);
   uint32_t argn = 0;
   uint32_t envn = 0;
-  const char *dirs[1] = { "/:/" };
+  const char *dirs[2] = { "/:/", ".:." };
   WasmEdge_ConfigureContext *configure;
   WasmEdge_VMContext *vm;
   WasmEdge_Result result;


### PR DESCRIPTION
A similar feature was added to crun `wasmtime` (
https://github.com/containers/crun/pull/985 ) where we decided to `preopen` current directory for all the instances, this PR attempts same for `wasmedge`.

There is no generic external method so users can pass this to handler as discussed here: https://github.com/containers/crun/pull/985 but there is no need shown till now so idea is to proceed `.` as a default directory which whill be pre-opened.

Closes: https://github.com/containers/crun/issues/1170