### PR TITLE
linux: set label for pre-created devices

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1134,6 +1134,18 @@ do_masked_or_readonly_path (libcrun_container_t *container, const char *rel_path
   return 0;
 }
 
+static inline const char *
+get_selinux_context_type (libcrun_container_t *container)
+{
+  const char *context_type;
+
+  context_type = find_annotation (container, "run.oci.mount_context_type");
+  if (context_type)
+    return context_type;
+
+  return "context";
+}
+
 static int
 do_mount (libcrun_container_t *container, const char *source, int targetfd,
           const char *target, const char *fstype, unsigned long mountflags, const void *data,
@@ -1165,9 +1177,7 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
 
   if (label_how == LABEL_MOUNT)
     {
-      const char *context_type = find_annotation (container, "run.oci.mount_context_type");
-      if (! context_type)
-        context_type = "context";
+      const char *context_type = get_selinux_context_type (container);
 
       ret = add_selinux_mount_label (&data_with_label, data, label, context_type, err);
       if (ret < 0)

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3986,6 +3986,8 @@ prepare_and_send_dev_mounts (libcrun_container_t *container, int sync_socket_hos
   cleanup_free char *devs_path = NULL;
   cleanup_close int devs_mountfd = -1;
   cleanup_close int targetfd = -1;
+  const char *context_type = NULL;
+  const char *label = NULL;
   size_t how_many = 0;
   size_t i;
   int ret;
@@ -4025,7 +4027,13 @@ prepare_and_send_dev_mounts (libcrun_container_t *container, int sync_socket_hos
       goto restore_mountns;
     }
 
-  devs_mountfd = fsopen_mount ("tmpfs", NULL, NULL);
+  if (container->container_def->linux && container->container_def->linux->mount_label)
+    {
+      label = container->container_def->linux->mount_label;
+      context_type = get_selinux_context_type (container);
+    }
+
+  devs_mountfd = fsopen_mount ("tmpfs", context_type, label);
   if (UNLIKELY (devs_mountfd < 0))
     {
       ret = crun_make_error (err, errno, "fsopen_mount `tmpfs`");


### PR DESCRIPTION
ensure that the SELinux label for pre-created devices in the tmpfs matches the label specified in the OCI container configuration.  This is necessary when using a new user namespace since it prevents the direct creation of devices in the target environment.

commit 234d77c96fc4aebb46d35fdcf820a00e4dd79e77 introduced the issue.
