### PR TITLE
cgroup: cgroupfs attempt new sibling cgroup

### DIFF
--- a/src/libcrun/cgroup-cgroupfs.c
+++ b/src/libcrun/cgroup-cgroupfs.c
@@ -40,15 +40,14 @@
 static char *
 make_cgroup_path (const char *path, const char *id)
 {
-  const char *cgroup_path = path;
   char *ret;
 
-  if (cgroup_path == NULL)
+  if (path == NULL)
     xasprintf (&ret, "/%s", id);
-  else if (cgroup_path[0] == '/')
-    ret = xstrdup (cgroup_path);
+  else if (path[0] == '/')
+    ret = xstrdup (path);
   else
-    xasprintf (&ret, "/%s", cgroup_path);
+    xasprintf (&ret, "/%s", path);
 
   return ret;
 }

--- a/src/libcrun/cgroup-cgroupfs.c
+++ b/src/libcrun/cgroup-cgroupfs.c
@@ -87,6 +87,23 @@ libcrun_precreate_cgroup_cgroupfs (struct libcrun_cgroup_args *args, int *dirfd,
 }
 
 static int
+make_new_sibling_cgroup (char **out, const char *id, libcrun_error_t *err)
+{
+  cleanup_free char *current_cgroup = NULL;
+  char *dir;
+  int ret;
+
+  ret = libcrun_get_current_unified_cgroup (&current_cgroup, false, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  dir = dirname (current_cgroup);
+
+  append_paths (out, err, dir, id, NULL);
+  return 0;
+}
+
+static int
 libcrun_cgroup_enter_cgroupfs (struct libcrun_cgroup_args *args, struct libcrun_cgroup_status *out, libcrun_error_t *err)
 {
   pid_t pid = args->pid;
@@ -104,7 +121,30 @@ libcrun_cgroup_enter_cgroupfs (struct libcrun_cgroup_args *args, struct libcrun_
 
       ret = enable_controllers (out->path, err);
       if (UNLIKELY (ret < 0))
-        return ret;
+        {
+          /* If the generated path cannot be used attempt to create the new cgroup
+             as a sibling of the current one.  */
+          if (args->cgroup_path == NULL)
+            {
+              libcrun_error_t tmp_err = NULL;
+              int tmp_ret;
+
+              free (out->path);
+              out->path = NULL;
+
+              tmp_ret = make_new_sibling_cgroup (&out->path, args->id, &tmp_err);
+              if (UNLIKELY (tmp_ret < 0))
+                {
+                  crun_error_release (&tmp_err);
+                  return ret;
+                }
+
+              crun_error_release (err);
+              ret = enable_controllers (out->path, err);
+            }
+          if (UNLIKELY (ret < 0))
+            return ret;
+        }
     }
 
   /* The cgroup was already joined, nothing more left to do.  */

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -151,7 +151,7 @@ move_process_to_cgroup (pid_t pid, const char *subsystem, const char *path, libc
 }
 
 int
-libcrun_get_current_unified_cgroup (char **path, libcrun_error_t *err)
+libcrun_get_current_unified_cgroup (char **path, bool absolute, libcrun_error_t *err)
 {
   cleanup_free char *content = NULL;
   size_t content_size;
@@ -172,7 +172,11 @@ libcrun_get_current_unified_cgroup (char **path, libcrun_error_t *err)
     return crun_make_error (err, 0, "cannot parse /proc/self/cgroup");
   *to = '\0';
 
-  return append_paths (path, err, CGROUP_ROOT, from, NULL);
+  if (absolute)
+    return append_paths (path, err, CGROUP_ROOT, from, NULL);
+
+  *path = xstrdup (from);
+  return 0;
 }
 
 #ifndef CGROUP2_SUPER_MAGIC

--- a/src/libcrun/cgroup-utils.h
+++ b/src/libcrun/cgroup-utils.h
@@ -26,7 +26,7 @@ int libcrun_move_process_to_cgroup (pid_t pid, pid_t init_pid, char *path, libcr
 
 int libcrun_cgroups_create_symlinks (int dirfd, libcrun_error_t *err);
 
-int libcrun_get_current_unified_cgroup (char **path, libcrun_error_t *err);
+int libcrun_get_current_unified_cgroup (char **path, bool absolute, libcrun_error_t *err);
 
 int libcrun_get_cgroup_mode (libcrun_error_t *err);
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2529,7 +2529,7 @@ libcrun_set_mounts (struct container_entrypoint_s *entrypoint_args, libcrun_cont
   if (cgroup_mode == CGROUP_MODE_UNIFIED)
     {
       /* Read the cgroup path before we enter the cgroupns.  */
-      ret = libcrun_get_current_unified_cgroup (&unified_cgroup_path, err);
+      ret = libcrun_get_current_unified_cgroup (&unified_cgroup_path, true, err);
       if (UNLIKELY (ret < 0))
         return ret;
     }


### PR DESCRIPTION
when using cgroupfs, if there was no cgroup path specified in the OCI configuration and using the absolute path failed, e.g. because we are rootless and don't have access to it, then attempt to create a sibling cgroup.

Closes: https://github.com/containers/crun/issues/1173
