### PR TITLE
[1.8.2][CentOS 7] Missing `#include <linux/sched.h>`

### DIFF
--- a/src/libcrun/scheduler.c
+++ b/src/libcrun/scheduler.c
@@ -22,6 +22,7 @@
 #include "linux.h"
 #include "utils.h"
 #include <sched.h>
+#include <linux/sched.h>
 #include <sys/sysmacros.h>
 #include <limits.h>
 #include <inttypes.h>


### PR DESCRIPTION
The newly introduced `src/libcrun/scheduler.c` by https://github.com/containers/crun/pull/1166 missing `#include <linux/sched.h>` for CentOS 7, which result with missing `SCHED_DEADLINE`.

Moreover, for CentOS 7 build we also need to enable `-std=c99`, or upgrade build tools to gcc 11 with `. /opt/rh/devtoolset-11/enable` before build.

See https://stackoverflow.com/a/50085457
See https://github.com/alvistack/containers-crun/blob/alvistack/1.8.2/crun.spec