### PR TITLE
criu: drop loading unused functions

### DIFF
--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -56,145 +56,49 @@ static const char *console_socket = NULL;
 struct libcriu_wrapper_s
 {
   void *handle;
-  int (*criu_set_service_address) (const char *path);
-  void (*criu_set_service_fd) (int fd);
-  int (*criu_set_service_binary) (const char *path);
-  int (*criu_init_opts) (void);
-  void (*criu_free_opts) (void);
-  void (*criu_set_pid) (int pid);
-  void (*criu_set_images_dir_fd) (int fd); /* must be set for dump/restore */
-  int (*criu_set_parent_images) (const char *path);
-  void (*criu_set_work_dir_fd) (int fd);
-  void (*criu_set_leave_running) (bool leave_running);
-  void (*criu_set_ext_unix_sk) (bool ext_unix_sk);
-  int (*criu_add_unix_sk) (unsigned int inode);
-  void (*criu_set_tcp_established) (bool tcp_established);
-  void (*criu_set_tcp_skip_in_flight) (bool tcp_skip_in_flight);
-  void (*criu_set_tcp_close) (bool tcp_close);
-  void (*criu_set_weak_sysctls) (bool val);
-  void (*criu_set_evasive_devices) (bool evasive_devices);
-  void (*criu_set_shell_job) (bool shell_job);
-  void (*criu_set_orphan_pts_master) (bool orphan_pts_master);
-  void (*criu_set_file_locks) (bool file_locks);
-  void (*criu_set_track_mem) (bool track_mem);
-  void (*criu_set_auto_dedup) (bool auto_dedup);
-  void (*criu_set_force_irmap) (bool force_irmap);
-  void (*criu_set_link_remap) (bool link_remap);
-  void (*criu_set_log_level) (int log_level);
-  int (*criu_set_log_file) (const char *log_file);
-  void (*criu_set_cpu_cap) (unsigned int cap);
-  int (*criu_set_root) (const char *root);
-  void (*criu_set_manage_cgroups) (bool manage);
-  void (*criu_set_manage_cgroups_mode) (enum criu_cg_mode mode);
-  int (*criu_set_freeze_cgroup) (const char *name);
-  int (*criu_set_lsm_profile) (const char *name);
-  int (*criu_set_lsm_mount_context) (const char *name);
-  void (*criu_set_timeout) (unsigned int timeout);
-  void (*criu_set_auto_ext_mnt) (bool val);
-  void (*criu_set_ext_sharing) (bool val);
-  void (*criu_set_ext_masters) (bool val);
-  int (*criu_set_exec_cmd) (int argc, char *argv[]);
   int (*criu_add_ext_mount) (const char *key, const char *val);
-  int (*criu_add_veth_pair) (const char *in, const char *out);
-  int (*criu_add_cg_root) (const char *ctrl, const char *path);
-  int (*criu_add_enable_fs) (const char *fs);
-  int (*criu_add_skip_mnt) (const char *mnt);
-  void (*criu_set_ghost_limit) (unsigned int limit);
-  int (*criu_add_irmap_path) (const char *path);
-  int (*criu_add_inherit_fd) (int fd, const char *key);
   int (*criu_add_external) (const char *key);
-  int (*criu_set_page_server_address_port) (const char *address, int port);
-  int (*criu_set_pre_dump_mode) (enum criu_pre_dump_mode mode);
-  void (*criu_set_pidfd_store_sk) (int sk);
-#  ifdef CRIU_PRE_DUMP_SUPPORT
-  int (*criu_set_network_lock) (enum criu_network_lock_method method);
-#  endif
-  int (*criu_join_ns_add) (const char *ns, const char *ns_file, const char *extra_opt);
-  void (*criu_set_mntns_compat_mode) (bool val);
-  void (*criu_set_notify_cb) (int (*cb) (char *action, criu_notify_arg_t na));
-  int (*criu_notify_pid) (criu_notify_arg_t na);
-  int (*criu_get_orphan_pts_master_fd) (void);
-  int (*criu_check) (void);
-  int (*criu_dump) (void);
-  int (*criu_pre_dump) (void);
-  int (*criu_restore) (void);
-  int (*criu_restore_child) (void);
-  int (*criu_dump_iters) (int (*more) (criu_predump_info pi));
-  int (*criu_get_version) (void);
+  int (*criu_add_inherit_fd) (int fd, const char *key);
   int (*criu_check_version) (int minimum);
-  int (*criu_local_init_opts) (criu_opts **opts);
-  void (*criu_local_free_opts) (criu_opts *opts);
-  int (*criu_local_set_service_address) (criu_opts *opts, const char *path);
-  void (*criu_local_set_service_fd) (criu_opts *opts, int fd);
-  void (*criu_local_set_pid) (criu_opts *opts, int pid);
-  void (*criu_local_set_images_dir_fd) (criu_opts *opts, int fd); /* must be set for dump/restore */
-  int (*criu_local_set_parent_images) (criu_opts *opts, const char *path);
-  int (*criu_local_set_service_binary) (criu_opts *opts, const char *path);
-  void (*criu_local_set_work_dir_fd) (criu_opts *opts, int fd);
-  void (*criu_local_set_leave_running) (criu_opts *opts, bool leave_running);
-  void (*criu_local_set_ext_unix_sk) (criu_opts *opts, bool ext_unix_sk);
-  int (*criu_local_add_unix_sk) (criu_opts *opts, unsigned int inode);
-  void (*criu_local_set_tcp_established) (criu_opts *opts, bool tcp_established);
-  void (*criu_local_set_tcp_skip_in_flight) (criu_opts *opts, bool tcp_skip_in_flight);
-  void (*criu_local_set_tcp_close) (criu_opts *opts, bool tcp_close);
-  void (*criu_local_set_weak_sysctls) (criu_opts *opts, bool val);
-  void (*criu_local_set_evasive_devices) (criu_opts *opts, bool evasive_devices);
-  void (*criu_local_set_shell_job) (criu_opts *opts, bool shell_job);
-  void (*criu_local_set_orphan_pts_master) (criu_opts *opts, bool orphan_pts_master);
-  void (*criu_local_set_file_locks) (criu_opts *opts, bool file_locks);
-  void (*criu_local_set_track_mem) (criu_opts *opts, bool track_mem);
-  void (*criu_local_set_auto_dedup) (criu_opts *opts, bool auto_dedup);
-  void (*criu_local_set_force_irmap) (criu_opts *opts, bool force_irmap);
-  void (*criu_local_set_link_remap) (criu_opts *opts, bool link_remap);
-  void (*criu_local_set_log_level) (criu_opts *opts, int log_level);
-  int (*criu_local_set_log_file) (criu_opts *opts, const char *log_file);
-  void (*criu_local_set_cpu_cap) (criu_opts *opts, unsigned int cap);
-  int (*criu_local_set_root) (criu_opts *opts, const char *root);
-  void (*criu_local_set_manage_cgroups) (criu_opts *opts, bool manage);
-  void (*criu_local_set_manage_cgroups_mode) (criu_opts *opts, enum criu_cg_mode mode);
-  int (*criu_local_set_freeze_cgroup) (criu_opts *opts, const char *name);
-  int (*criu_local_set_lsm_profile) (criu_opts *opts, const char *name);
-  int (*criu_local_set_lsm_mount_context) (criu_opts *opts, const char *name);
-  void (*criu_local_set_timeout) (criu_opts *opts, unsigned int timeout);
-  void (*criu_local_set_auto_ext_mnt) (criu_opts *opts, bool val);
-  void (*criu_local_set_ext_sharing) (criu_opts *opts, bool val);
-  void (*criu_local_set_ext_masters) (criu_opts *opts, bool val);
-  int (*criu_local_set_exec_cmd) (criu_opts *opts, int argc, char *argv[]);
-  int (*criu_local_add_ext_mount) (criu_opts *opts, const char *key, const char *val);
-  int (*criu_local_add_veth_pair) (criu_opts *opts, const char *in, const char *out);
-  int (*criu_local_add_cg_root) (criu_opts *opts, const char *ctrl, const char *path);
-  int (*criu_local_add_enable_fs) (criu_opts *opts, const char *fs);
-  int (*criu_local_add_skip_mnt) (criu_opts *opts, const char *mnt);
-  void (*criu_local_set_ghost_limit) (criu_opts *opts, unsigned int limit);
-  int (*criu_local_add_irmap_path) (criu_opts *opts, const char *path);
-  int (*criu_local_add_cg_props) (criu_opts *opts, const char *stream);
-  int (*criu_local_add_cg_props_file) (criu_opts *opts, const char *path);
-  int (*criu_local_add_cg_dump_controller) (criu_opts *opts, const char *name);
-  int (*criu_local_add_cg_yard) (criu_opts *opts, const char *path);
-  int (*criu_local_add_inherit_fd) (criu_opts *opts, int fd, const char *key);
-  int (*criu_local_add_external) (criu_opts *opts, const char *key);
-  int (*criu_local_set_page_server_address_port) (criu_opts *opts, const char *address, int port);
-  int (*criu_local_set_pre_dump_mode) (criu_opts *opts, enum criu_pre_dump_mode mode);
-  void (*criu_local_set_pidfd_store_sk) (criu_opts *opts, int sk);
-#  ifdef CRIU_PRE_DUMP_SUPPORT
-  int (*criu_local_set_network_lock) (criu_opts *opts, enum criu_network_lock_method method);
-#  endif
-  int (*criu_local_join_ns_add) (criu_opts *opts, const char *ns, const char *ns_file, const char *extra_opt);
-  void (*criu_local_set_mntns_compat_mode) (criu_opts *opts, bool val);
-  void (*criu_local_set_notify_cb) (criu_opts *opts, int (*cb) (char *action, criu_notify_arg_t na));
-  int (*criu_local_check) (criu_opts *opts);
-  int (*criu_local_dump) (criu_opts *opts);
-  int (*criu_local_pre_dump) (criu_opts *opts);
-  int (*criu_local_restore) (criu_opts *opts);
-  int (*criu_local_restore_child) (criu_opts *opts);
-  int (*criu_local_dump_iters) (criu_opts *opts, int (*more) (criu_predump_info pi));
-  int (*criu_local_get_version) (criu_opts *opts);
-  int (*criu_local_check_version) (criu_opts *opts, int minimum);
+  int (*criu_dump) (void);
+  int (*criu_get_orphan_pts_master_fd) (void);
+  int (*criu_init_opts) (void);
+  int (*criu_join_ns_add) (const char *ns, const char *ns_file, const char *extra_opt);
 #  ifdef CRIU_PRE_DUMP_SUPPORT
   int (*criu_feature_check) (struct criu_feature_check *features, size_t size);
-  int (*criu_local_feature_check) (criu_opts *opts, struct criu_feature_check *features, size_t size);
+  int (*criu_pre_dump) (void);
 #  endif
+  int (*criu_restore_child) (void);
+  int (*criu_set_freeze_cgroup) (const char *name);
+  void (*criu_set_file_locks) (bool file_locks);
+  void (*criu_set_ext_unix_sk) (bool ext_unix_sk);
+  int (*criu_set_log_file) (const char *log_file);
+  void (*criu_set_log_level) (int log_level);
+  void (*criu_set_leave_running) (bool leave_running);
+  void (*criu_set_manage_cgroups) (bool manage);
+  void (*criu_set_manage_cgroups_mode) (enum criu_cg_mode mode);
+  void (*criu_set_notify_cb) (int (*cb) (char *action, criu_notify_arg_t na));
+  void (*criu_set_orphan_pts_master) (bool orphan_pts_master);
+  void (*criu_set_images_dir_fd) (int fd);
+  int (*criu_set_parent_images) (const char *path);
+  void (*criu_set_pid) (int pid);
+  int (*criu_set_root) (const char *root);
+  void (*criu_set_shell_job) (bool shell_job);
+  void (*criu_set_tcp_established) (bool tcp_established);
+  void (*criu_set_track_mem) (bool track_mem);
+  void (*criu_set_work_dir_fd) (int fd);
 };
+
+#  define LOAD_CRIU_FUNCTION(X)                                                                \
+    do                                                                                         \
+      {                                                                                        \
+        wrapper->X = dlsym (wrapper->handle, #X);                                              \
+        if (wrapper->X == NULL)                                                                \
+          {                                                                                    \
+            dlclose (wrapper->handle);                                                         \
+            return crun_make_error (err, 0, "could not find symbol `%s` in `libcriu.so`", #X); \
+          }                                                                                    \
+    } while (0)
 
 static struct libcriu_wrapper_s *libcriu_wrapper;
 
@@ -224,156 +128,37 @@ load_wrapper (struct libcriu_wrapper_s **wrapper_out, libcrun_error_t *err)
   if (wrapper->handle == NULL)
     return crun_make_error (err, 0, "could not load `libcriu.so.2`");
 
-#  define LOAD_CRIU_FUNCTION(X)                                                                \
-    do                                                                                         \
-      {                                                                                        \
-        wrapper->X = dlsym (wrapper->handle, #X);                                              \
-        if (wrapper->X == NULL)                                                                \
-          {                                                                                    \
-            dlclose (wrapper->handle);                                                         \
-            return crun_make_error (err, 0, "could not find symbol `%s` in `libcriu.so`", #X); \
-          }                                                                                    \
-    } while (0)
-
-  LOAD_CRIU_FUNCTION (criu_set_service_address);
-  LOAD_CRIU_FUNCTION (criu_set_service_fd);
-  LOAD_CRIU_FUNCTION (criu_set_service_binary);
-  LOAD_CRIU_FUNCTION (criu_init_opts);
-  LOAD_CRIU_FUNCTION (criu_free_opts);
-  LOAD_CRIU_FUNCTION (criu_set_pid);
-  LOAD_CRIU_FUNCTION (criu_set_images_dir_fd);
-  LOAD_CRIU_FUNCTION (criu_set_parent_images);
-  LOAD_CRIU_FUNCTION (criu_set_work_dir_fd);
-  LOAD_CRIU_FUNCTION (criu_set_leave_running);
-  LOAD_CRIU_FUNCTION (criu_set_ext_unix_sk);
-  LOAD_CRIU_FUNCTION (criu_add_unix_sk);
-  LOAD_CRIU_FUNCTION (criu_set_tcp_established);
-  LOAD_CRIU_FUNCTION (criu_set_tcp_skip_in_flight);
-  LOAD_CRIU_FUNCTION (criu_set_tcp_close);
-  LOAD_CRIU_FUNCTION (criu_set_weak_sysctls);
-  LOAD_CRIU_FUNCTION (criu_set_evasive_devices);
-  LOAD_CRIU_FUNCTION (criu_set_shell_job);
-  LOAD_CRIU_FUNCTION (criu_set_orphan_pts_master);
-  LOAD_CRIU_FUNCTION (criu_set_file_locks);
-  LOAD_CRIU_FUNCTION (criu_set_track_mem);
-  LOAD_CRIU_FUNCTION (criu_set_auto_dedup);
-  LOAD_CRIU_FUNCTION (criu_set_force_irmap);
-  LOAD_CRIU_FUNCTION (criu_set_link_remap);
-  LOAD_CRIU_FUNCTION (criu_set_log_level);
-  LOAD_CRIU_FUNCTION (criu_set_log_file);
-  LOAD_CRIU_FUNCTION (criu_set_cpu_cap);
-  LOAD_CRIU_FUNCTION (criu_set_root);
-  LOAD_CRIU_FUNCTION (criu_set_manage_cgroups);
-  LOAD_CRIU_FUNCTION (criu_set_manage_cgroups_mode);
-  LOAD_CRIU_FUNCTION (criu_set_freeze_cgroup);
-  LOAD_CRIU_FUNCTION (criu_set_lsm_profile);
-  LOAD_CRIU_FUNCTION (criu_set_lsm_mount_context);
-  LOAD_CRIU_FUNCTION (criu_set_timeout);
-  LOAD_CRIU_FUNCTION (criu_set_auto_ext_mnt);
-  LOAD_CRIU_FUNCTION (criu_set_ext_sharing);
-  LOAD_CRIU_FUNCTION (criu_set_ext_masters);
-  LOAD_CRIU_FUNCTION (criu_set_exec_cmd);
   LOAD_CRIU_FUNCTION (criu_add_ext_mount);
-  LOAD_CRIU_FUNCTION (criu_add_veth_pair);
-  LOAD_CRIU_FUNCTION (criu_add_cg_root);
-  LOAD_CRIU_FUNCTION (criu_add_enable_fs);
-  LOAD_CRIU_FUNCTION (criu_add_skip_mnt);
-  LOAD_CRIU_FUNCTION (criu_set_ghost_limit);
-  LOAD_CRIU_FUNCTION (criu_add_irmap_path);
-  LOAD_CRIU_FUNCTION (criu_add_inherit_fd);
   LOAD_CRIU_FUNCTION (criu_add_external);
-  LOAD_CRIU_FUNCTION (criu_set_page_server_address_port);
-  LOAD_CRIU_FUNCTION (criu_set_pre_dump_mode);
-  LOAD_CRIU_FUNCTION (criu_set_pidfd_store_sk);
-#  ifdef CRIU_PRE_DUMP_SUPPORT
-  LOAD_CRIU_FUNCTION (criu_set_network_lock);
-#  endif
-  LOAD_CRIU_FUNCTION (criu_join_ns_add);
-  LOAD_CRIU_FUNCTION (criu_set_mntns_compat_mode);
-  LOAD_CRIU_FUNCTION (criu_set_notify_cb);
-  LOAD_CRIU_FUNCTION (criu_notify_pid);
-  LOAD_CRIU_FUNCTION (criu_get_orphan_pts_master_fd);
-  LOAD_CRIU_FUNCTION (criu_check);
-  LOAD_CRIU_FUNCTION (criu_dump);
-  LOAD_CRIU_FUNCTION (criu_pre_dump);
-  LOAD_CRIU_FUNCTION (criu_restore);
-  LOAD_CRIU_FUNCTION (criu_restore_child);
-  LOAD_CRIU_FUNCTION (criu_dump_iters);
-  LOAD_CRIU_FUNCTION (criu_get_version);
+  LOAD_CRIU_FUNCTION (criu_add_inherit_fd);
   LOAD_CRIU_FUNCTION (criu_check_version);
-  LOAD_CRIU_FUNCTION (criu_local_init_opts);
-  LOAD_CRIU_FUNCTION (criu_local_free_opts);
-  LOAD_CRIU_FUNCTION (criu_local_set_service_address);
-  LOAD_CRIU_FUNCTION (criu_local_set_service_fd);
-  LOAD_CRIU_FUNCTION (criu_local_set_service_fd);
-  LOAD_CRIU_FUNCTION (criu_local_set_pid);
-  LOAD_CRIU_FUNCTION (criu_local_set_images_dir_fd);
-  LOAD_CRIU_FUNCTION (criu_local_set_parent_images);
-  LOAD_CRIU_FUNCTION (criu_local_set_service_binary);
-  LOAD_CRIU_FUNCTION (criu_local_set_work_dir_fd);
-  LOAD_CRIU_FUNCTION (criu_local_set_leave_running);
-  LOAD_CRIU_FUNCTION (criu_local_set_ext_unix_sk);
-  LOAD_CRIU_FUNCTION (criu_local_add_unix_sk);
-  LOAD_CRIU_FUNCTION (criu_local_set_tcp_established);
-  LOAD_CRIU_FUNCTION (criu_local_set_tcp_skip_in_flight);
-  LOAD_CRIU_FUNCTION (criu_local_set_tcp_close);
-  LOAD_CRIU_FUNCTION (criu_local_set_weak_sysctls);
-  LOAD_CRIU_FUNCTION (criu_local_set_evasive_devices);
-  LOAD_CRIU_FUNCTION (criu_local_set_shell_job);
-  LOAD_CRIU_FUNCTION (criu_local_set_orphan_pts_master);
-  LOAD_CRIU_FUNCTION (criu_local_set_file_locks);
-  LOAD_CRIU_FUNCTION (criu_local_set_track_mem);
-  LOAD_CRIU_FUNCTION (criu_local_set_auto_dedup);
-  LOAD_CRIU_FUNCTION (criu_local_set_force_irmap);
-  LOAD_CRIU_FUNCTION (criu_local_set_link_remap);
-  LOAD_CRIU_FUNCTION (criu_local_set_log_level);
-  LOAD_CRIU_FUNCTION (criu_local_set_log_file);
-  LOAD_CRIU_FUNCTION (criu_local_set_cpu_cap);
-  LOAD_CRIU_FUNCTION (criu_local_set_root);
-  LOAD_CRIU_FUNCTION (criu_local_set_manage_cgroups);
-  LOAD_CRIU_FUNCTION (criu_local_set_manage_cgroups_mode);
-  LOAD_CRIU_FUNCTION (criu_local_set_freeze_cgroup);
-  LOAD_CRIU_FUNCTION (criu_local_set_lsm_profile);
-  LOAD_CRIU_FUNCTION (criu_local_set_lsm_mount_context);
-  LOAD_CRIU_FUNCTION (criu_local_set_timeout);
-  LOAD_CRIU_FUNCTION (criu_local_set_auto_ext_mnt);
-  LOAD_CRIU_FUNCTION (criu_local_set_ext_sharing);
-  LOAD_CRIU_FUNCTION (criu_local_set_ext_masters);
-  LOAD_CRIU_FUNCTION (criu_local_set_exec_cmd);
-  LOAD_CRIU_FUNCTION (criu_local_add_ext_mount);
-  LOAD_CRIU_FUNCTION (criu_local_add_veth_pair);
-  LOAD_CRIU_FUNCTION (criu_local_add_cg_root);
-  LOAD_CRIU_FUNCTION (criu_local_add_enable_fs);
-  LOAD_CRIU_FUNCTION (criu_local_add_skip_mnt);
-  LOAD_CRIU_FUNCTION (criu_local_set_ghost_limit);
-  LOAD_CRIU_FUNCTION (criu_local_add_irmap_path);
-  LOAD_CRIU_FUNCTION (criu_local_add_cg_props);
-  LOAD_CRIU_FUNCTION (criu_local_add_cg_props_file);
-  LOAD_CRIU_FUNCTION (criu_local_add_cg_dump_controller);
-  LOAD_CRIU_FUNCTION (criu_local_add_cg_yard);
-  LOAD_CRIU_FUNCTION (criu_local_add_inherit_fd);
-  LOAD_CRIU_FUNCTION (criu_local_add_external);
-  LOAD_CRIU_FUNCTION (criu_local_set_page_server_address_port);
-  LOAD_CRIU_FUNCTION (criu_local_set_pre_dump_mode);
-  LOAD_CRIU_FUNCTION (criu_local_set_pidfd_store_sk);
-#  ifdef CRIU_PRE_DUMP_SUPPORT
-  LOAD_CRIU_FUNCTION (criu_local_set_network_lock);
-#  endif
-  LOAD_CRIU_FUNCTION (criu_local_join_ns_add);
-  LOAD_CRIU_FUNCTION (criu_local_set_mntns_compat_mode);
-  LOAD_CRIU_FUNCTION (criu_local_set_notify_cb);
-  LOAD_CRIU_FUNCTION (criu_local_check);
-  LOAD_CRIU_FUNCTION (criu_local_dump);
-  LOAD_CRIU_FUNCTION (criu_local_pre_dump);
-  LOAD_CRIU_FUNCTION (criu_local_restore);
-  LOAD_CRIU_FUNCTION (criu_local_restore_child);
-  LOAD_CRIU_FUNCTION (criu_local_dump_iters);
-  LOAD_CRIU_FUNCTION (criu_local_get_version);
-  LOAD_CRIU_FUNCTION (criu_local_check_version);
+  LOAD_CRIU_FUNCTION (criu_dump);
+  LOAD_CRIU_FUNCTION (criu_get_orphan_pts_master_fd);
+  LOAD_CRIU_FUNCTION (criu_init_opts);
+  LOAD_CRIU_FUNCTION (criu_join_ns_add);
 #  ifdef CRIU_PRE_DUMP_SUPPORT
   LOAD_CRIU_FUNCTION (criu_feature_check);
-  LOAD_CRIU_FUNCTION (criu_local_feature_check);
+  LOAD_CRIU_FUNCTION (criu_pre_dump);
 #  endif
+  LOAD_CRIU_FUNCTION (criu_restore_child);
+  LOAD_CRIU_FUNCTION (criu_set_ext_unix_sk);
+  LOAD_CRIU_FUNCTION (criu_set_file_locks);
+  LOAD_CRIU_FUNCTION (criu_set_freeze_cgroup);
+  LOAD_CRIU_FUNCTION (criu_set_images_dir_fd);
+  LOAD_CRIU_FUNCTION (criu_set_leave_running);
+  LOAD_CRIU_FUNCTION (criu_set_log_file);
+  LOAD_CRIU_FUNCTION (criu_set_log_level);
+  LOAD_CRIU_FUNCTION (criu_set_manage_cgroups);
+  LOAD_CRIU_FUNCTION (criu_set_manage_cgroups_mode);
+  LOAD_CRIU_FUNCTION (criu_set_notify_cb);
+  LOAD_CRIU_FUNCTION (criu_set_orphan_pts_master);
+  LOAD_CRIU_FUNCTION (criu_set_parent_images);
+  LOAD_CRIU_FUNCTION (criu_set_pid);
+  LOAD_CRIU_FUNCTION (criu_set_root);
+  LOAD_CRIU_FUNCTION (criu_set_shell_job);
+  LOAD_CRIU_FUNCTION (criu_set_tcp_established);
+  LOAD_CRIU_FUNCTION (criu_set_track_mem);
+  LOAD_CRIU_FUNCTION (criu_set_work_dir_fd);
 
   libcriu_wrapper = *wrapper_out = wrapper;
   wrapper = NULL;
@@ -395,6 +180,7 @@ criu_notify (char *action, __attribute__ ((unused)) criu_notify_arg_t na)
 
       if (! console_socket)
         return 0;
+
       master_fd = libcriu_wrapper->criu_get_orphan_pts_master_fd ();
 
       console_socket_fd = open_unix_domain_client_socket (console_socket, 0, &tmp_err);
@@ -430,7 +216,6 @@ criu_check_mem_track (char *work_path, libcrun_error_t *err)
   features.mem_track = true;
 
   ret = libcriu_wrapper->criu_feature_check (&features, sizeof (features));
-
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, 0,
                             "CRIU feature checking failed %d.  Please check CRIU logfile %s/%s",


### PR DESCRIPTION
load only the functions that are actually used by crun.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2183041