### PR TITLE
tests: fix idmap mount test

### DIFF
--- a/tests/cri-o/Dockerfile
+++ b/tests/cri-o/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 RUN yum install -y python git gcc automake autoconf libcap-devel \
     systemd-devel yajl-devel libseccomp-devel go-md2man conntrack-tools which \
     glibc-static python3-libmount libtool make podman xz nmap-ncat jq bats \
-    libgcrypt-devel iproute openssl iputils socat criu-libs && \
+    libgcrypt-devel iproute openssl iputils socat criu-libs irqbalance && \
     dnf install -y 'dnf-command(builddep)' && dnf builddep -y podman && \
     dnf remove -y golang && \
     sudo dnf update -y && \

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -384,27 +384,13 @@ def test_idmapped_mounts():
                 return True
             return False
 
-        # first test with the custom crun annotation
-        if check("idmap", None, None, "0:0"):
-            return 1
-
-        if check("idmap=uids=0-1-10;gids=0-1-10", None, None, "0:0"):
-            return 1
-
-        if check("idmap=uids=0-2-10#10-100-10;gids=0-1-10", None, None, "1:0"):
-            return 1
-
-        os.chown(target, 1, 2)
-        if check("idmap=uids=@0-1-10;gids=+0-1-10", None, None, "2:2"):
-            return 1
-
         # and now test with uidMappings and gidMappings
         os.chown(target, 0, 0)
 
         mountMappings = [
             {
-                "hostID": 0,
-                "containerID": 1,
+                "containerID": 0,
+                "hostID": 1,
                 "size": 10
             }
         ]
@@ -413,8 +399,8 @@ def test_idmapped_mounts():
 
         mountMappings = [
             {
-                "hostID": 0,
-                "containerID": 2,
+                "containerID": 0,
+                "hostID": 2,
                 "size": 10
             }
         ]


### PR DESCRIPTION
adapt the test to follow the new semantic where the mapping used is the same as the user namespace.

Also drop the custom annotation tests, since now the feature is in the OCI specs.