### PR TITLE
tests: abstract tests/init to get_init_path()

### DIFF
--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -347,7 +347,7 @@ def test_idmapped_mounts():
             f.write("")
         os.chown(target, 0, 0)
 
-        idmapped_mounts_status = subprocess.call(["./tests/init", "check-feature", "idmapped-mounts", source_dir])
+        idmapped_mounts_status = subprocess.call([get_init_path(), "check-feature", "idmapped-mounts", source_dir])
         if idmapped_mounts_status != 0:
             return 77
 

--- a/tests/test_seccomp.py
+++ b/tests/test_seccomp.py
@@ -24,7 +24,7 @@ import array
 from tests_utils import *
 
 def is_seccomp_listener_supported():
-    r = subprocess.call(["./tests/init", "check-feature", "open_tree"])
+    r = subprocess.call([get_init_path(), "check-feature", "open_tree"])
     return r == 0
 
 # taken from https://docs.python.org/3/library/socket.html#socket.socket.recvmsg

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -369,8 +369,8 @@ def test_sd_notify_proxy():
     if is_rootless():
         return 77
 
-    has_open_tree_status = subprocess.call(["./tests/init", "check-feature", "open_tree"])
-    has_move_mount_status = subprocess.call(["./tests/init", "check-feature", "move_mount"])
+    has_open_tree_status = subprocess.call([get_init_path(), "check-feature", "open_tree"])
+    has_move_mount_status = subprocess.call([get_init_path(), "check-feature", "move_mount"])
     if has_open_tree_status != 0 or has_move_mount_status != 0:
         return 77
 

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -198,6 +198,9 @@ def get_tests_root():
 def get_tests_root_status():
     return os.path.join(get_tests_root(), "root")
 
+def get_init_path():
+    return os.path.abspath(os.getenv("INIT") or "tests/init")
+
 def get_crun_path():
     cwd = os.getcwd()
     return os.getenv("OCI_RUNTIME") or os.path.join(cwd, "crun")
@@ -234,7 +237,7 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
         conf = json.dumps(config)
         config_file.write(conf)
 
-    init = os.getenv("INIT") or "tests/init"
+    init = get_init_path()
     crun = get_crun_path()
 
     os.makedirs(os.path.join(rootfs, "sbin"))


### PR DESCRIPTION
In the Python tests, while there some support for setting a custom init path through the INIT environmental variable, there were a few places where this was hardcoded to "./tests/init".

Abstract it away into a new test_utils function, get_init_path(), mimicking the existing get_crun_path().