### PR TITLE
tests/test_exec: don't fail on PIDs < 10000

### DIFF
--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -357,7 +357,7 @@ def test_exec_write_pid_file():
         if not os.path.exists(pid_file):
             return -1
 
-        regu_cont = re.compile(r'\d{5}')
+        regu_cont = re.compile(r'\d+')
         with open(pid_file, 'r') as fp:
             contents = fp.read()
             fp.close()


### PR DESCRIPTION
test_exec_write_pid_file() currently fails if the PID doesn't match a 5-character number ('\d{5}'). This can fail if the resulting PID is e.g. a 4-digit one. Accept any number of digits instead.