### PR TITLE
linux: do not precreate devs with euid > 0

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3997,7 +3997,7 @@ prepare_and_send_dev_mounts (libcrun_container_t *container, int sync_socket_hos
 
   dev_fds = make_libcrun_fd_map (def->linux->devices_len);
 
-  if (! has_userns || is_empty_string (container->context->id))
+  if (! has_userns || is_empty_string (container->context->id) || geteuid () > 0)
     return send_mounts (sync_socket_host, dev_fds, how_many, def->linux->devices_len, err);
 
   state_dir = libcrun_get_state_directory (container->context->state_root, container->context->id);

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -79,6 +79,31 @@ def test_deny_devices():
             return 0
     return -1
 
+def test_create_or_bind_mount_device():
+    try:
+        os.stat("/dev/fuse")
+    except:
+        return 77
+
+    conf = base_config()
+    add_all_namespaces(conf)
+    conf['process']['args'] = ['/init', 'access', '/dev/fuse']
+    conf['linux']['devices'] = [{ "path": "/dev/fuse",
+                                 "type": "c",
+                                 "major": 10,
+                                 "minor": 229,
+                                 "fileMode": 0o775,
+                                 "uid": 0,
+                                 "gid": 0
+                                }]
+    try:
+        run_and_get_output(conf)
+    except Exception as e:
+        sys.stderr.write(str(e) + "\n")
+        return -1
+    return 0
+
+
 def test_allow_device():
     if is_rootless():
         return 77
@@ -161,6 +186,7 @@ all_tests = {
     "allow-device" : test_allow_device,
     "allow-access" : test_allow_access,
     "mknod-device" : test_mknod_device,
+    "create-or-bind-mount-device" : test_create_or_bind_mount_device,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
if the process is running with euid > 0 it is not possible for the user to create device nodes, so there is no point in attempting that.

The error message was also confusing, because it says that it is not possible to create the mount namespace.

Closes: https://github.com/containers/crun/issues/1198