### PR TITLE
ci: temporarily disable `cri-o` tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,7 @@ jobs:
           - test: disable-systemd
           - test: check
           - test: podman
-          - test: cri-o
+          #- test: cri-o
           - test: containerd
           - test: oci-validation
           - test: alpine-build
@@ -123,11 +123,11 @@ jobs:
                   sudo docker build -t crun-podman tests/podman
                   sudo docker run --cgroupns=host --privileged --rm -v /var/tmp:/var/tmp:rw -v /var/lib/containers:/var/lib/containers:rw -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave -v ${PWD}:/crun crun-podman
                   ;;
-              cri-o)
-                  sudo mkdir -p /var/lib/var-crio/tmp /var/lib/tmp-crio /var/lib/var-tmp-crio
-                  sudo docker build -t crun-cri-o tests/cri-o
-                  sudo docker run --cgroupns=host  --net host --privileged --rm -v /dev/zero:/sys/module/apparmor/parameters/enabled -v /var/lib/tmp-crio:/tmp:rw -v /var/lib/var-tmp-crio:/var/tmp -v /var/lib/var-crio:/var/lib/containers:rw -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave -v ${PWD}:/crun crun-cri-o
-                  ;;
+              #cri-o)
+              #    sudo mkdir -p /var/lib/var-crio/tmp /var/lib/tmp-crio /var/lib/var-tmp-crio
+              #    sudo docker build -t crun-cri-o tests/cri-o
+              #    sudo docker run --cgroupns=host  --net host --privileged --rm -v /dev/zero:/sys/module/apparmor/parameters/enabled -v /var/lib/tmp-crio:/tmp:rw -v /var/lib/var-tmp-crio:/var/tmp -v /var/lib/var-crio:/var/lib/containers:rw -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave -v ${PWD}:/crun crun-cri-o
+              #    ;;
               containerd)
                   sudo mkdir -p /var/lib/var-containerd
                   sudo docker build -t crun-containerd tests/containerd


### PR DESCRIPTION
`cri-o` tests are timing out due to unknown reason, disable it till we fix it.