### PR TITLE
cgroups: fix creating cgroup under "domain threaded"

### DIFF
--- a/src/libcrun/cgroup-setup.c
+++ b/src/libcrun/cgroup-setup.c
@@ -392,7 +392,7 @@ enter_cgroup_v2 (pid_t pid, pid_t init_pid, const char *path, bool create_if_mis
     {
       crun_error_release (err);
 
-      ret = make_cgroup_threaded (path, err);
+      ret = maybe_make_cgroup_threaded (path, err);
       if (UNLIKELY (ret < 0))
         return ret;
 

--- a/src/libcrun/cgroup-utils.h
+++ b/src/libcrun/cgroup-utils.h
@@ -32,6 +32,6 @@ int libcrun_get_cgroup_mode (libcrun_error_t *err);
 
 int libcrun_get_cgroup_dirfd (struct libcrun_cgroup_status *status, const char *sub_cgroup, libcrun_error_t *err);
 
-int make_cgroup_threaded (const char *path, libcrun_error_t *err);
+int maybe_make_cgroup_threaded (const char *path, libcrun_error_t *err);
 
 #endif


### PR DESCRIPTION
fix creating a cgroup under a "domain threaded" parent.  To do so, crun doesn't attempt anymore to enable threaded mode until the root, but it will do only for parent cgroups where it is necessary.

Closes: https://github.com/containers/crun/issues/1208