### PR TITLE
src: uniform the quoting style

### DIFF
--- a/src/libcrun/cgroup-setup.c
+++ b/src/libcrun/cgroup-setup.c
@@ -247,7 +247,7 @@ copy_owner (const char *from, const char *to, libcrun_error_t *err)
 
   ret = get_file_owner (from, &uid, &gid);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "cannot get file owner for %s", from);
+    return crun_make_error (err, errno, "cannot get file owner for `%s`", from);
 
   if (uid == 0 && gid == 0)
     return 0;
@@ -271,7 +271,7 @@ read_unified_cgroup_pid (pid_t pid, char **path, libcrun_error_t *err)
 
   from = strstr (content, "0::");
   if (UNLIKELY (from == NULL))
-    return crun_make_error (err, -1, "cannot find cgroup2 for the process %d", pid);
+    return crun_make_error (err, -1, "cannot find cgroup2 for the process `%d`", pid);
 
   from += 3;
 

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -65,7 +65,7 @@ libcrun_cgroups_create_symlinks (int dirfd, libcrun_error_t *err)
         {
           if (errno == ENOENT || errno == EEXIST)
             continue;
-          return crun_make_error (err, errno, "symlinkat %s", cgroup_symlinks[i].name);
+          return crun_make_error (err, errno, "symlinkat `%s`", cgroup_symlinks[i].name);
         }
     }
   return 0;

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -206,14 +206,14 @@ detect_cgroup_mode (libcrun_error_t *err)
 
   ret = statfs (CGROUP_ROOT, &stat);
   if (ret < 0)
-    return crun_make_error (err, errno, "statfs '" CGROUP_ROOT "'");
+    return crun_make_error (err, errno, "statfs `" CGROUP_ROOT "`");
   if (stat.f_type == CGROUP2_SUPER_MAGIC)
     return CGROUP_MODE_UNIFIED;
   if (stat.f_type != TMPFS_MAGIC)
-    return crun_make_error (err, 0, "invalid file system type on '" CGROUP_ROOT "'");
+    return crun_make_error (err, 0, "invalid file system type on `" CGROUP_ROOT "`");
   ret = statfs (CGROUP_ROOT "/unified", &stat);
   if (ret < 0 && errno != ENOENT)
-    return crun_make_error (err, errno, "statfs '" CGROUP_ROOT "/unified'");
+    return crun_make_error (err, errno, "statfs `" CGROUP_ROOT "/unified`");
   if (ret < 0)
     return CGROUP_MODE_LEGACY;
   return stat.f_type == CGROUP2_SUPER_MAGIC ? CGROUP_MODE_HYBRID : CGROUP_MODE_LEGACY;

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -304,7 +304,7 @@ libcrun_cgroup_enter (struct libcrun_cgroup_args *args, struct libcrun_cgroup_st
     {
       ret = TEMP_FAILURE_RETRY (kill (args->pid, SIGSTOP));
       if (UNLIKELY (ret < 0))
-        return crun_make_error (err, errno, "cannot stop container process '%d' with SIGSTOP", args->pid);
+        return crun_make_error (err, errno, "cannot stop container process `%d` with SIGSTOP", args->pid);
 
       /* Send SIGCONT as soon as the function exits.  */
       sigcont_cleanup = args->pid;

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1391,7 +1391,7 @@ container_init (void *args, char *notify_socket, int sync_socket, libcrun_error_
     }
 
   if (UNLIKELY (def->process == NULL))
-    return crun_make_error (err, 0, "block 'process' not found");
+    return crun_make_error (err, 0, "block `process` not found");
 
   if (UNLIKELY (exec_path == NULL))
     return crun_make_error (err, 0, "executable path not specified");
@@ -2509,14 +2509,14 @@ static int
 check_config_file (runtime_spec_schema_config_schema *def, libcrun_context_t *context, libcrun_error_t *err)
 {
   if (UNLIKELY (def->linux == NULL))
-    return crun_make_error (err, 0, "invalid config file, no 'linux' block specified");
+    return crun_make_error (err, 0, "invalid config file, no `linux` block specified");
 
   if (context->handler == NULL)
     {
       if (UNLIKELY (def->root == NULL))
-        return crun_make_error (err, 0, "invalid config file, no 'root' block specified");
+        return crun_make_error (err, 0, "invalid config file, no `root` block specified");
       if (UNLIKELY (def->mounts == NULL))
-        return crun_make_error (err, 0, "invalid config file, no 'mounts' block specified");
+        return crun_make_error (err, 0, "invalid config file, no `mounts` block specified");
     }
   return 0;
 }

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -466,7 +466,7 @@ libcrun_container_load_from_memory (const char *json, libcrun_error_t *err)
   container_def = runtime_spec_schema_config_schema_parse_data (json, NULL, &oci_error);
   if (container_def == NULL)
     {
-      crun_make_error (err, 0, "load: %s", oci_error);
+      crun_make_error (err, 0, "load: `%s`", oci_error);
       return NULL;
     }
   return make_container (container_def, NULL, json);
@@ -1657,7 +1657,7 @@ libcrun_container_kill (libcrun_context_t *context, const char *id, const char *
 
   sig = str2sig (signal);
   if (UNLIKELY (sig < 0))
-    return crun_make_error (err, 0, "unknown signal %s", signal);
+    return crun_make_error (err, 0, "unknown signal `%s`", signal);
 
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
@@ -1676,7 +1676,7 @@ libcrun_container_killall (libcrun_context_t *context, const char *id, const cha
 
   sig = str2sig (signal);
   if (UNLIKELY (sig < 0))
-    return crun_make_error (err, 0, "unknown signal %s", signal);
+    return crun_make_error (err, 0, "unknown signal `%s`", signal);
 
   ret = libcrun_read_container_status (&status, state_root, id, err);
   if (UNLIKELY (ret < 0))
@@ -3413,7 +3413,7 @@ libcrun_container_exec_with_options (libcrun_context_t *context, const char *id,
       process = make_runtime_spec_schema_config_schema_process (tree, &ctx, &parser_err);
       if (UNLIKELY (process == NULL))
         {
-          ret = crun_make_error (err, errno, "cannot parse process file: %s", parser_err);
+          ret = crun_make_error (err, errno, "cannot parse process file: `%s`", parser_err);
           free (parser_err);
           if (tree)
             yajl_tree_free (tree);

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -433,11 +433,11 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
 
   ret = mkdir (cr_options->image_path, 0700);
   if (UNLIKELY ((ret == -1) && (errno != EEXIST)))
-    return crun_make_error (err, errno, "error creating checkpoint directory %s", cr_options->image_path);
+    return crun_make_error (err, errno, "error creating checkpoint directory `%s`", cr_options->image_path);
 
   image_fd = open (cr_options->image_path, O_DIRECTORY);
   if (UNLIKELY (image_fd == -1))
-    return crun_make_error (err, errno, "error opening checkpoint directory %s", cr_options->image_path);
+    return crun_make_error (err, errno, "error opening checkpoint directory `%s`", cr_options->image_path);
 
   libcriu_wrapper->criu_set_images_dir_fd (image_fd);
 
@@ -457,7 +457,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
     {
       work_fd = open (cr_options->work_path, O_DIRECTORY);
       if (UNLIKELY (work_fd == -1))
-        return crun_make_error (err, errno, "error opening CRIU work directory %s", cr_options->work_path);
+        return crun_make_error (err, errno, "error opening CRIU work directory `%s`", cr_options->work_path);
 
       libcriu_wrapper->criu_set_work_dir_fd (work_fd);
     }
@@ -522,7 +522,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
 
   ret = libcriu_wrapper->criu_set_root (path);
   if (UNLIKELY (ret != 0))
-    return crun_make_error (err, 0, "error setting CRIU root to %s", path);
+    return crun_make_error (err, 0, "error setting CRIU root to `%s`", path);
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
   if (UNLIKELY (cgroup_mode < 0))
@@ -702,7 +702,7 @@ prepare_restore_mounts (runtime_spec_schema_config_schema *def, char *root, libc
 
       root_fd = open (root, O_RDONLY | O_CLOEXEC);
       if (UNLIKELY (root_fd == -1))
-        return crun_make_error (err, errno, "error opening container root directory %s", root);
+        return crun_make_error (err, errno, "error opening container root directory `%s`", root);
 
       if (is_dir)
         {
@@ -760,7 +760,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
 
   image_fd = open (cr_options->image_path, O_DIRECTORY);
   if (UNLIKELY (image_fd == -1))
-    return crun_make_error (err, errno, "error opening checkpoint directory %s", cr_options->image_path);
+    return crun_make_error (err, errno, "error opening checkpoint directory `%s`", cr_options->image_path);
 
   libcriu_wrapper->criu_set_images_dir_fd (image_fd);
 
@@ -787,7 +787,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
      * and stderr being correctly redirected. */
     tree = yajl_tree_parse (buffer, err_buffer, sizeof (err_buffer));
     if (UNLIKELY (tree == NULL))
-      return crun_make_error (err, 0, "cannot parse descriptors file %s", DESCRIPTORS_FILENAME);
+      return crun_make_error (err, 0, "cannot parse descriptors file `%s`", DESCRIPTORS_FILENAME);
 
     if (tree && YAJL_IS_ARRAY (tree))
       {
@@ -816,7 +816,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
     {
       work_fd = open (cr_options->work_path, O_DIRECTORY);
       if (UNLIKELY (work_fd == -1))
-        return crun_make_error (err, errno, "error opening CRIU work directory %s", cr_options->work_path);
+        return crun_make_error (err, errno, "error opening CRIU work directory `%s`", cr_options->work_path);
 
       libcriu_wrapper->criu_set_work_dir_fd (work_fd);
     }
@@ -861,12 +861,12 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
 
   ret = mkdir (root, 0755);
   if (UNLIKELY (ret == -1))
-    return crun_make_error (err, errno, "error creating restore directory %s", root);
+    return crun_make_error (err, errno, "error creating restore directory `%s`", root);
 
   ret = mount (status->rootfs, root, NULL, MS_BIND | MS_REC, NULL);
   if (UNLIKELY (ret == -1))
     {
-      ret = crun_make_error (err, errno, "error mounting restore directory %s", root);
+      ret = crun_make_error (err, errno, "error mounting restore directory `%s`", root);
       goto out;
     }
 
@@ -884,7 +884,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
   ret = libcriu_wrapper->criu_set_root (root);
   if (UNLIKELY (ret != 0))
     {
-      ret = crun_make_error (err, 0, "error setting CRIU root to %s", root);
+      ret = crun_make_error (err, 0, "error setting CRIU root to `%s`", root);
       goto out_umount;
     }
 
@@ -972,7 +972,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
   if (UNLIKELY (ret <= 0))
     {
       ret = crun_make_error (err, 0,
-                             "CRIU restoring failed %d.  Please check CRIU logfile %s/%s",
+                             "CRIU restoring failed %d.  Please check CRIU logfile `%s/%s`",
                              ret, cr_options->work_path, CRIU_RESTORE_LOG_FILE);
       goto out_umount;
     }
@@ -989,14 +989,14 @@ out_umount:
   if (UNLIKELY (ret_out == -1))
     {
       rmdir (root);
-      return crun_make_error (err, errno, "error unmounting restore directory %s", root);
+      return crun_make_error (err, errno, "error unmounting restore directory `%s`", root);
     }
 out:
   ret_out = rmdir (root);
   if (UNLIKELY (ret == -1))
     return ret;
   if (UNLIKELY (ret_out == -1))
-    return crun_make_error (err, errno, "error removing restore directory %s", root);
+    return crun_make_error (err, errno, "error removing restore directory `%s`", root);
   return ret;
 }
 #endif

--- a/src/libcrun/custom-handler.c
+++ b/src/libcrun/custom-handler.c
@@ -174,7 +174,7 @@ libcrun_handler_manager_load_directory (struct custom_handler_manager_s *manager
 
       handle = dlopen (fpath, RTLD_NOW);
       if (UNLIKELY (handle == NULL))
-        return crun_make_error (err, 0, "cannot load `%s`: %s", fpath, dlerror ());
+        return crun_make_error (err, 0, "cannot load `%s`: `%s`", fpath, dlerror ());
 
       ret = handler_manager_add_so (manager, handle, err);
       if (UNLIKELY (ret < 0))

--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -216,7 +216,7 @@ libcrun_init_logging (crun_output_handler *new_output_handler, void **new_output
       int log_type = get_log_type (log, &arg);
 
       if (log_type < 0)
-        return crun_make_error (err, errno, "unknown log type %s\n", log);
+        return crun_make_error (err, errno, "unknown log type `%s`", log);
 
       switch (log_type)
         {
@@ -224,7 +224,7 @@ libcrun_init_logging (crun_output_handler *new_output_handler, void **new_output
           *new_output_handler = log_write_to_stream;
           *new_output_handler_arg = fopen (arg, "a+");
           if (*new_output_handler_arg == NULL)
-            return crun_make_error (err, errno, "open log file %s\n", log);
+            return crun_make_error (err, errno, "open log file `%s`", log);
           if (output_verbosity >= LIBCRUN_VERBOSITY_WARNING)
             setlinebuf (*new_output_handler_arg);
           break;
@@ -440,7 +440,7 @@ libcrun_set_log_format (const char *format, libcrun_error_t *err)
   else if (strcmp (format, "json") == 0)
     log_format = LOG_FORMAT_JSON;
   else
-    return crun_make_error (err, 0, "unknown log format type %s", format);
+    return crun_make_error (err, 0, "unknown log format type `%s`", format);
 
   return 0;
 }

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -273,7 +273,7 @@ libkrun_load (void **cookie, libcrun_error_t *err arg_unused)
   if (kconf->handle == NULL && kconf->handle_sev == NULL)
     {
       free (kconf);
-      return crun_make_error (err, 0, "failed to open %s and %s for krun_config", libkrun_so, libkrun_sev_so);
+      return crun_make_error (err, 0, "failed to open `%s` and `%s` for krun_config", libkrun_so, libkrun_sev_so);
     }
 
   kconf->sev = false;
@@ -292,7 +292,7 @@ libkrun_unload (void *cookie, libcrun_error_t *err arg_unused)
     {
       r = dlclose (cookie);
       if (UNLIKELY (r < 0))
-        return crun_make_error (err, 0, "could not unload handle: %s", dlerror ());
+        return crun_make_error (err, 0, "could not unload handle: `%s`", dlerror ());
     }
   return 0;
 }

--- a/src/libcrun/handlers/mono.c
+++ b/src/libcrun/handlers/mono.c
@@ -100,7 +100,7 @@ mono_load (void **cookie, libcrun_error_t *err arg_unused)
 
   handle = dlopen ("libmono-native.so", RTLD_NOW);
   if (handle == NULL)
-    return crun_make_error (err, 0, "could not load `libmono-2.0.so`: %s", dlerror ());
+    return crun_make_error (err, 0, "could not load `libmono-2.0.so`: `%s`", dlerror ());
   *cookie = handle;
 
   return 0;
@@ -146,7 +146,7 @@ mono_unload (void *cookie, libcrun_error_t *err arg_unused)
     {
       r = dlclose (cookie);
       if (UNLIKELY (r < 0))
-        return crun_make_error (err, 0, "could not unload handle: %s", dlerror ());
+        return crun_make_error (err, 0, "could not unload handle: `%s`", dlerror ());
     }
   return 0;
 }

--- a/src/libcrun/handlers/wasmedge.c
+++ b/src/libcrun/handlers/wasmedge.c
@@ -46,7 +46,7 @@ libwasmedge_load (void **cookie, libcrun_error_t *err arg_unused)
 
   handle = dlopen ("libwasmedge.so.0", RTLD_NOW);
   if (handle == NULL)
-    return crun_make_error (err, 0, "could not load `libwasmedge.so.0`: %s", dlerror ());
+    return crun_make_error (err, 0, "could not load `libwasmedge.so.0`: `%s`", dlerror ());
   *cookie = handle;
 
   return 0;
@@ -61,7 +61,7 @@ libwasmedge_unload (void *cookie, libcrun_error_t *err arg_unused)
     {
       r = dlclose (cookie);
       if (UNLIKELY (r < 0))
-        return crun_make_error (err, 0, "could not unload handle: %s", dlerror ());
+        return crun_make_error (err, 0, "could not unload handle: `%s`", dlerror ());
     }
   return 0;
 }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1876,7 +1876,7 @@ do_pivot (libcrun_container_t *container, const char *rootfs, libcrun_error_t *e
   cleanup_close int newrootfd = open (rootfs, O_DIRECTORY | O_RDONLY);
 
   if (UNLIKELY (oldrootfd < 0))
-    return crun_make_error (err, errno, "open '/'");
+    return crun_make_error (err, errno, "open `/`");
   if (UNLIKELY (newrootfd < 0))
     return crun_make_error (err, errno, "open `%s`", rootfs);
 
@@ -2663,7 +2663,7 @@ move_root (const char *rootfs, libcrun_error_t *err)
 
   ret = mount (rootfs, "/", "", MS_MOVE, "");
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "mount MS_MOVE to '/'");
+    return crun_make_error (err, errno, "mount MS_MOVE to `/`");
 
   ret = chroot (".");
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3252,10 +3252,10 @@ libcrun_set_oom (libcrun_container_t *container, libcrun_error_t *err)
   sprintf (oom_buffer, "%i", def->process->oom_score_adj);
   fd = open ("/proc/self/oom_score_adj", O_RDWR);
   if (fd < 0)
-    return crun_make_error (err, errno, "open /proc/self/oom_score_adj");
+    return crun_make_error (err, errno, "open `/proc/self/oom_score_adj`");
   ret = TEMP_FAILURE_RETRY (write (fd, oom_buffer, strlen (oom_buffer)));
   if (ret < 0)
-    return crun_make_error (err, errno, "write to /proc/self/oom_score_adj");
+    return crun_make_error (err, errno, "write to `/proc/self/oom_score_adj`");
   return 0;
 }
 

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -741,7 +741,7 @@ libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_err
 #  ifdef SECCOMP_ARCH_RESOLVE_NAME
       arch_token = seccomp_arch_resolve_name (lowercase_arch);
       if (arch_token == 0)
-        return crun_make_error (err, 0, "seccomp unknown architecture %s", arch);
+        return crun_make_error (err, 0, "seccomp unknown architecture `%s`", arch);
 #  else
       arch_token = SCMP_ARCH_NATIVE;
 #  endif
@@ -801,7 +801,7 @@ libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_err
 
                   index = seccomp->syscalls[i]->args[k]->index;
                   if (index >= 6)
-                    return crun_make_error (err, 0, "invalid seccomp index %zu", i);
+                    return crun_make_error (err, 0, "invalid seccomp index `%zu`", i);
 
                   count[index]++;
                   if (count[index] > 1)

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -353,7 +353,7 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
     const char *pid_path[] = { "pid", NULL };
     tmp = yajl_tree_get (tree, pid_path, yajl_t_number);
     if (UNLIKELY (tmp == NULL))
-      return crun_make_error (err, 0, "'pid' missing in %s", file);
+      return crun_make_error (err, 0, "`pid` missing in `%s`", file);
     status->pid = strtoull (YAJL_GET_NUMBER (tmp), NULL, 10);
   }
   {
@@ -368,7 +368,7 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
     const char *cgroup_path[] = { "cgroup-path", NULL };
     tmp = yajl_tree_get (tree, cgroup_path, yajl_t_string);
     if (UNLIKELY (tmp == NULL))
-      return crun_make_error (err, 0, "'cgroup-path' missing in %s", file);
+      return crun_make_error (err, 0, "`cgroup-path` missing in `%s`", file);
     status->cgroup_path = xstrdup (YAJL_GET_STRING (tmp));
   }
   {
@@ -380,7 +380,7 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
     const char *rootfs[] = { "rootfs", NULL };
     tmp = yajl_tree_get (tree, rootfs, yajl_t_string);
     if (UNLIKELY (tmp == NULL))
-      return crun_make_error (err, 0, "'rootfs' missing in %s", file);
+      return crun_make_error (err, 0, "`rootfs` missing in `%s`", file);
     status->rootfs = xstrdup (YAJL_GET_STRING (tmp));
   }
   {
@@ -391,14 +391,14 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
     const char *bundle[] = { "bundle", NULL };
     tmp = yajl_tree_get (tree, bundle, yajl_t_string);
     if (UNLIKELY (tmp == NULL))
-      return crun_make_error (err, 0, "'bundle' missing in %s", file);
+      return crun_make_error (err, 0, "`bundle` missing in `%s`", file);
     status->bundle = xstrdup (YAJL_GET_STRING (tmp));
   }
   {
     const char *created[] = { "created", NULL };
     tmp = yajl_tree_get (tree, created, yajl_t_string);
     if (UNLIKELY (tmp == NULL))
-      return crun_make_error (err, 0, "'created' missing in %s", file);
+      return crun_make_error (err, 0, "`created` missing in `%s`", file);
     status->created = xstrdup (YAJL_GET_STRING (tmp));
   }
   {
@@ -510,7 +510,7 @@ libcrun_container_delete_status (const char *state_root, const char *id, libcrun
 
   dfd = openat (rundir_dfd, id, O_DIRECTORY | O_RDONLY);
   if (UNLIKELY (dfd < 0))
-    return crun_make_error (err, errno, "cannot open directory '%s/%s'", dir, id);
+    return crun_make_error (err, errno, "cannot open directory `%s/%s`", dir, id);
 
   ret = rmdirfd (dir, dfd, err);
 

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -124,7 +124,7 @@ read_pid_stat (pid_t pid, struct pid_stat *st, libcrun_error_t *err)
           memset (st, 0, sizeof (*st));
           return 0;
         }
-      return crun_make_error (err, errno, "open state file %s", pid_stat_file);
+      return crun_make_error (err, errno, "open state file `%s`", pid_stat_file);
     }
 
   ret = read_all_fd (fd, pid_stat_file, &buffer, NULL, err);
@@ -347,7 +347,7 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
 
   tree = yajl_tree_parse (buffer, err_buffer, sizeof (err_buffer));
   if (UNLIKELY (tree == NULL))
-    return crun_make_error (err, 0, "cannot parse status file: %s", err_buffer);
+    return crun_make_error (err, 0, "cannot parse status file: `%s`", err_buffer);
 
   {
     const char *pid_path[] = { "pid", NULL };

--- a/src/libcrun/terminal.c
+++ b/src/libcrun/terminal.c
@@ -98,7 +98,7 @@ libcrun_set_stdio (char *pty, libcrun_error_t *err)
   cleanup_close int fd = open (pty, O_RDWR);
 
   if (UNLIKELY (fd < 0))
-    return crun_make_error (err, errno, "open %s", pty);
+    return crun_make_error (err, errno, "open `%s`", pty);
 
   for (i = 0; i < 3; i++)
     {

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1164,7 +1164,7 @@ epoll_helper (int *fds, int *levelfds, libcrun_error_t *err)
       ev.data.fd = *it;
       ret = epoll_ctl (epollfd, EPOLL_CTL_ADD, *it, &ev);
       if (UNLIKELY (ret < 0))
-        return crun_make_error (err, errno, "epoll_ctl add '%d'", *it);
+        return crun_make_error (err, errno, "epoll_ctl add `%d`", *it);
     }
   for (it = levelfds; *it >= 0; it++)
     {
@@ -1172,7 +1172,7 @@ epoll_helper (int *fds, int *levelfds, libcrun_error_t *err)
       ev.data.fd = *it;
       ret = epoll_ctl (epollfd, EPOLL_CTL_ADD, *it, &ev);
       if (UNLIKELY (ret < 0))
-        return crun_make_error (err, errno, "epoll_ctl add '%d'", *it);
+        return crun_make_error (err, errno, "epoll_ctl add `%d`", *it);
     }
 
   ret = epollfd;


### PR DESCRIPTION
we were using a mix of '%s' and `%s`.  Convert any instance of the former style to use `%s` instead.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
