### PR TITLE
lua: added luarocks packing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ compile_commands.json
 /luarocks
 /lua_modules
 /.luarocks
+*.rock

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,11 @@ rpm: srpm
 	rpmbuild -ba $(RPM_OPTS) rpm/crun.spec
 	$(MAKE) clean-global-gitconfig
 
+if ENABLE_LIBCRUN
 lib_LTLIBRARIES = libcrun.la
+else
+noinst_LTLIBRARIES = libcrun.la
+endif
 
 check_LIBRARIES = libcrun_testing.a
 
@@ -99,6 +103,30 @@ libcrun_bundled_la_SOURCES = $(libcrun_SOURCES)
 libcrun_bundled_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -fvisibility=hidden
 libcrun_bundled_la_LIBADD = libocispec/libocispec.la $(FOUND_LIBS) $(maybe_libyajl.la)
 libcrun_bundled_la_LDFLAGS = -Wl,--version-script=$(abs_top_srcdir)/libcrun.lds
+
+LUACRUN_CLEAN_VERSION = $(shell git describe --tags | sed 's/-g[0-9a-f]\{7,9\}//')
+
+LUACRUN_RELEASE_VERSION = $(shell git describe --tags | sed 's/-[0-9]*-g[0-9a-f]\{7,9\}//')
+
+LUACRUN_ROCKSPEC = luacrun-$(LUACRUN_CLEAN_VERSION).rockspec
+
+$(LUACRUN_ROCKSPEC): lua/luacrun.rockspec
+	sed -e 's/@RELEASEVERSION/$(LUACRUN_RELEASE_VERSION)/g' < lua/luacrun.rockspec | \
+	sed -e 's/@CLEANVERSION/$(LUACRUN_CLEAN_VERSION)/g' > $@
+
+LUACRUN_ROCK = luacrun-$(LUACRUN_CLEAN_VERSION).src.rock
+
+$(LUACRUN_ROCK): dist-gzip $(LUACRUN_ROCKSPEC)
+	rm -f $(LUACRUN_ROCK)
+	mv "$(distdir).tar.gz" "crun-$(LUACRUN_RELEASE_VERSION).tar.gz"
+	tar -xzf "crun-$(LUACRUN_RELEASE_VERSION).tar.gz" --transform="s/crun-$(VERSION)\(.*\)$$/crun-$(LUACRUN_RELEASE_VERSION)\1/"
+	tar -czf "crun-$(LUACRUN_RELEASE_VERSION).tar.gz" "crun-$(LUACRUN_RELEASE_VERSION)"
+	rm -rf "crun-$(LUACRUN_RELEASE_VERSION)"
+	zip -j $(LUACRUN_ROCK) $(LUACRUN_ROCKSPEC) "crun-$(LUACRUN_RELEASE_VERSION).tar.gz"
+	rm -f "crun-$(LUACRUN_RELEASE_VERSION).tar.gz"
+
+dist-luarock: $(LUACRUN_ROCK)
+
 endif
 
 crun_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -D CRUN_LIBDIR="\"$(CRUN_LIBDIR)\""
@@ -126,12 +154,19 @@ EXTRA_DIST = COPYING COPYING.libcrun README.md NEWS SECURITY.md rpm/crun.spec.in
 	src/libcrun/handlers/handler-utils.h \
 	src/libcrun/linux.h src/libcrun/utils.h src/libcrun/error.h src/libcrun/criu.h \
 	src/libcrun/scheduler.h src/libcrun/status.h src/libcrun/terminal.h src/libcrun/mount_flags.h \
-	crun.1.md crun.1 libcrun.lds
+	crun.1.md crun.1 libcrun.lds \
+	lua/luacrun.rockspec
 
 UNIT_TESTS = tests/tests_libcrun_utils tests/tests_libcrun_errors
 
+if ENABLE_CRUN
 bin_PROGRAMS = crun
-noinst_PROGRAMS = tests/init $(UNIT_TESTS) tests/tests_libcrun_fuzzer
+noinst_PROGRAMS =
+else
+noinst_PROGRAMS = crun
+endif
+
+noinst_PROGRAMS += tests/init $(UNIT_TESTS) tests/tests_libcrun_fuzzer
 
 TESTS_LDADD = libcrun_testing.a $(FOUND_LIBS) $(maybe_libyajl.la)
 
@@ -207,9 +242,11 @@ dist-hook:
 EXTRA_DIST += $(PYTHON_TESTS) tests/Makefile.tests tests/run_all_tests.sh tests/tests_utils.py build-aux/git-version-gen src/libcrun/signals.perf src/libcrun/mount_flags.perf
 BUILT_SOURCES = .version git-version.h
 
-CLEANFILES = crun.spec .version git-version.h
+CLEANFILES = crun.spec .version git-version.h $(LUACRUN_ROCKSPEC)
 
+if ENABLE_CRUN
 man1_MANS = crun.1
+endif
 
 crun.1: $(abs_srcdir)/crun.1.md
 if HAVE_MD2MAN

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,29 @@ AC_CHECK_TYPES([atomic_bool], [], [], [[#include <stdatomic.h>]])
 
 AC_CHECK_FUNCS(copy_file_range fgetxattr statx fgetpwent_r issetugid)
 
+AC_ARG_ENABLE(crun,
+AS_HELP_STRING([--enable-crun], [Include crun executable in installation (default: yes)]),
+[
+case "${enableval}" in
+	yes) enable_crun=true ;;
+	no) enable_crun=false ;;
+	*) AC_MSG_ERROR(bad value $(enableval) for --disable-crun) ;;
+esac],
+[enable_crun=true])
+AM_CONDITIONAL([ENABLE_CRUN], [test "x${enable_crun}" = xtrue])
+
+AC_ARG_ENABLE(libcrun,
+AS_HELP_STRING([--enable-libcrun], [Include libcrun in installation (default: yes)]),
+[
+case "${enableval}" in
+	yes) enable_libcrun=true ;;
+	no) enable_libcrun=false ;;
+	*) AC_MSG_ERROR(bad value ${enablevaal} for --enable-libcrun) ;;
+esac
+],
+[enable_libcrun=true])
+AM_CONDITIONAL([ENABLE_LIBCRUN], [test "x${enable_libcrun}" = xtrue])
+
 dnl embedded yajl
 AC_ARG_ENABLE(embedded-yajl,
 AS_HELP_STRING([--enable-embedded-yajl], [Statically link a modified yajl version]),

--- a/lua/README.md
+++ b/lua/README.md
@@ -30,10 +30,27 @@ See `luacrun.d.tl`.
 
 ## Works with your LuaRocks project
 
-You can configure the prefix as your `lua_modules` to access this library in your project.
+You can build rocks (in luarocks) if lua bindings is enabled.
+
+````sh
+./configure --with-lua-bindings
+make dist-luarock
+````
+
+The options here for `./configure` won't affect the final output, see `luacrun.rockspec` for the building options.
+
+`dist-luarock` target packs a source rock. You can use `luarocks build luacrun-xxx.src.rock --pack-binary-rock` to pack binary rocks.
+
+````sh
+# Assume the filename is luacrun-1.8.4-0.src.rock
+luarocks build luacrun-1.8.4-0.src.rock --pack-binary-rock
+````
+
+Another way is, configure the prefix to your `lua_modules` to access this library in your project.
 
 ````sh
 ./configure --with-lua-bindings --enable-shared --prefix $(pwd)/lua_modules
+make && make install
 ````
 
 ## Interpreter may restart?

--- a/lua/luacrun.rockspec
+++ b/lua/luacrun.rockspec
@@ -1,0 +1,31 @@
+--[[ This file is part of crun. SPDX: GPL-2.0-or-later
+
+Please don't use this rockspec to make source rocks.
+The generated rocks does not include files for a success build.
+Use `make dist-luarock` instead.
+]]
+rockspec_format = "3.0"
+package = "luacrun"
+version = "@CLEANVERSION"
+source = {
+    url = "https://github.com/containers/crun/releases/download/@RELEASEVERSION/crun-@RELEASEVERSION.tar.gz",
+}
+supported_platforms = {'linux'}
+description = {
+    summary = "A Lua binding for libcrun, a fast and lightweight fully featured OCI runtime and C library for running containers.",
+    detailed = [[
+       libcrun is a fast and low-memory footprint OCI container runtime.
+       This library bundles the binding for libcrun and a working libcrun.
+    ]],
+    homepage = "http://github.com/containers/crun/",
+    license = "GPL-2.0-or-later"
+}
+dependencies = {"lua >= 5.4"}
+build = {
+    type = "command",
+    build_command = [[
+        rm -rf libocispec/yajl/src/api && ln -s ./headers/yajl libocispec/yajl/src/api &&
+        ./configure --prefix=$(PREFIX) --libdir=$(LIBDIR) --disable-crun --disable-libcrun --enable-shared --with-lua-bindings --enable-embedded-yajl LUA=$(LUA) LUA_INCLUDE=-I$(LUA_INCDIR) &&
+        make -j]],
+    install_command = "make install",
+}


### PR DESCRIPTION
This PR includes changes for packing the lua binding library in luarocks, a popular package manager in lua world.

What's included in this PR:
- configure: `--enable-crun` and `--enable-libcrun` to control the installation of crun executable and libcrun (both are enabled by default)
- Makefile: added target `dist-luarock` to build source rocks for luarocks