### PR TITLE
libcrun: return with no-op when `io_priority` is NULL

### DIFF
--- a/src/libcrun/io_priority.c
+++ b/src/libcrun/io_priority.c
@@ -82,6 +82,11 @@ libcrun_set_io_priority (pid_t pid, runtime_spec_schema_config_schema_process *p
 
   return 0;
 #else
+  // If io_priority is not set then return without doing
+  // anything.
+  if (process == NULL || process->io_priority == NULL)
+    return 0;
+
   (void) pid;
   (void) process;
   return crun_make_error (err, 0, "io priority not supported");


### PR DESCRIPTION
container.c (https://github.com/containers/crun/blob/main/src/libcrun/container.c#L2385 ) calls `libcrun_set_io_priority` even for users who built crun without the support of `io_priority` i.e when `autoconf ` fails to detect `linux/ioprio.h` and does not set `HAVE_LINUX_IOPRIO_H` and it returns error even when user has no intention of using it.

Following PR makes function no-op for such use cases.

Alternative patch could be
```diff
diff --git a/src/libcrun/container.c b/src/libcrun/container.c
index ff621bb..c5e53c9 100644
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2382,9 +2382,12 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   if (UNLIKELY (ret < 0))
     goto fail;

-  ret = libcrun_set_io_priority (pid, def->process, err);
-  if (UNLIKELY (ret < 0))
-    goto fail;
+  if (def->process != NULL && def->process->io_priority != NULL)
+    {
+      ret = libcrun_set_io_priority (pid, def->process, err);
+      if (UNLIKELY (ret < 0))
+        goto fail;
+    }

   /* The container is waiting that we write back.  In this phase we can launch the
      prestart hooks.  */
```