### PR TITLE
ci, wasmedge: use `--platform=wasi/wasm`

### DIFF
--- a/tests/wasmedge-build/Dockerfile
+++ b/tests/wasmedge-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:rawhide
+FROM fedora:latest
 ARG WASM_EDGE_VERSION="0.11.0"
 
 # Install the deps for building crun

--- a/tests/wasmedge-build/run-tests.sh
+++ b/tests/wasmedge-build/run-tests.sh
@@ -15,6 +15,8 @@ make install
 # Remove the installed crun to make sure the built crun is used
 rm -rf /usr/bin/crun
 ln -s /usr/local/bin/crun /usr/bin/crun
+ln -s /usr/local/bin/crun /usr/local/bin/crun-wasm
+ln -s /usr/local/bin/crun /usr/bin/crun-wasm
 
 # Test crun is used in podman
 if [[ $(podman info | grep SYSTEMD) != *WASM:wasmedge* ]]; then
@@ -25,7 +27,7 @@ fi
 # Build hellowasm image
 cd /hello_wasm && \
 	chmod +x ./hello.wasm && \
-	buildah build --annotation "module.wasm.image/variant=compat-smart" -t hellowasm-image .
+	buildah build --platform wasi/wasm -t hellowasm-image .
 
 # Run hello.wasm with crun
 OUTPUT=$(podman run hellowasm-image:latest)


### PR DESCRIPTION
* After https://github.com/containers/podman/pull/18542 , podman does not
propagates annotations while running the image hence use `--platform
wasi/wasm`

----

* `fedora:rawhide` is having issues with the default `dnf.conf` being shipped so use `fedora:latest`.

```console
Config error: Parsing file "/etc/dnf/dnf.conf" failed: Parsing
file '/etc/dnf/dnf.conf' failed: IniParser: Missing section header at
line 1
```

Similar threads: https://www.spinics.net/lists/fedora-devel/msg312899.html