### PR TITLE
docs: remove `module.wasm.image/variant=compat` annotation from `podman` example.

### DIFF
--- a/docs/wasm-wasi-example.md
+++ b/docs/wasm-wasi-example.md
@@ -42,9 +42,9 @@ This is from a main function from a wasm module
 COPY hello.wasm /
 CMD ["/hello.wasm"]
  ```
-* Build wasm image using buildah with annotation `module.wasm.image/variant=compat`
+* Build wasm image using buildah
 ```console
-$ buildah build --annotation "module.wasm.image/variant=compat" -t mywasm-image .
+$ buildah build --platform=wasi/wasm -t mywasm-image .
 ```
 * Make sure your podman points to oci runtime `crun` build with `wasm` support.
 * Run image using podman


### PR DESCRIPTION
After https://github.com/containers/podman/pull/18542 does not include image annotations when building spec , podman does not propagates annotations while running the image hence use `--platform wasi/wasm`.