### PR TITLE
ps: fix segfault with pids=NULL

### DIFF
--- a/src/ps.c
+++ b/src/ps.c
@@ -114,14 +114,14 @@ crun_command_ps (struct crun_global_arguments *global_args, int argc, char **arg
     {
     case PS_JSON:
       printf ("[\n");
-      for (i = 0; pids[i]; i++)
+      for (i = 0; pids && pids[i]; i++)
         printf ("  %d%s\n", pids[i], pids[i + 1] ? "," : "");
       printf ("]\n");
       break;
 
     case PS_TABLE:
       printf ("PID\n");
-      for (i = 0; pids[i]; i++)
+      for (i = 0; pids && pids[i]; i++)
         printf ("%d\n", pids[i]);
       break;
     }


### PR DESCRIPTION
When pids is NULL, we should not try to access it.

Closes: https://github.com/containers/crun/issues/1239