### PR TITLE
cgroup-resources,cgroupv2: allow setting `memory.swap.max` to `0`

### DIFF
--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -720,7 +720,10 @@ write_memory_swap (int dirfd, bool cgroup2, runtime_spec_schema_config_linux_res
     return 0;
 
   swap = memory->swap;
-  if (cgroup2 && memory->swap != -1)
+  // Cgroupv2 apply limit must check if swap > 0, since `0` and `-1` are special case
+  // 0: This means process will not be able to use any swap space.
+  // -1: This means that the process can use as much swap as it needs.
+  if (cgroup2 && memory->swap > 0)
     {
       if (! memory->limit_present)
         return crun_make_error (err, 0, "cannot set swap limit without the memory limit");


### PR DESCRIPTION
Runc accepts `0` value of `swap` from config as an exception case
* See: https://github.com/opencontainers/runc/blob/main/libcontainer/cgroups/fs2/memory.go#L36
* See: https://github.com/opencontainers/runc/blob/main/libcontainer/cgroups/utils.go#L431

As per the documentation here: https://facebookmicrosites.github.io/cgroup2/docs/memory-controller.html#using-swap Setting `memory.swap.max` to `0` is treated as `swap` being disabled hence allow `crun` to do the same.

Closes: https://github.com/containers/crun/issues/1001