### PR TITLE
tests: more compatibility fixes

### DIFF
--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -43,6 +43,9 @@ def test_uid_tty():
     if is_rootless():
         return 77
 
+    if os.isatty(1) == False:
+        return 77
+
     conf = base_config()
     conf['process']['args'] = ['/init', 'pause']
     conf['process']['terminal'] = True

--- a/tests/test_oci_features.py
+++ b/tests/test_oci_features.py
@@ -27,7 +27,7 @@ def is_seccomp_enabled():
 
 def get_crun_commit():
     try:
-        output = subprocess.check_output(["./crun", "--version"]).decode()
+        output = subprocess.check_output([get_crun_path(), "--version"]).decode()
         commit_match = re.search(r"commit: ([\w]+)", output)
 
         if commit_match:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -237,6 +237,7 @@ def test_resources_cpu_weight_systemd():
 
     conf['linux']['resources'] = {}
     conf['linux']['resources']['unified'] = {
+
             "cpu.weight": "1234"
     }
     cid = None
@@ -251,6 +252,10 @@ def test_resources_cpu_weight_systemd():
         scope = json.loads(state)['systemd-scope']
 
         out = subprocess.check_output(['systemctl', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
+        # try once more against the user manager, as if one exists, crun will prefer it; see bug #1197
+        if out != "1234":
+            out = subprocess.check_output(['systemctl', '--user', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
+
         if out != "1234":
             sys.stderr.write("found wrong CPUWeight for the systemd scope\n")
             return 1
@@ -265,6 +270,10 @@ def test_resources_cpu_weight_systemd():
             return -1
 
         out = subprocess.check_output(['systemctl', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
+        # as above
+        if out != expected_weight:
+            out = subprocess.check_output(['systemctl', '--user', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
+
         if out != expected_weight:
             sys.stderr.write("found wrong CPUWeight for the systemd scope\n")
             return 1


### PR DESCRIPTION
I'm still pursuing the goal of running the upstream test suite as part of the Debian CI process (as outlined in #1197; also see prior work in #1194 & #1196). Below you'll find a few fixes to bugs I encountered in the process. With this PR everything except one test, sd-notify-proxy[1], runs in both rootful and rootless configurations.

Let me know what you think - thanks!

1: I'm still trying to track that down and I'm already seeing a few things in the test that don't make sense to me. A retroactive review and/or suggestions on what could possibly be going wrong are more than welcome :)