### PR TITLE
Make the spec file parseable without copr_username defined

### DIFF
--- a/rpm/crun.spec
+++ b/rpm/crun.spec
@@ -82,8 +82,8 @@ Provides: oci-runtime
 %package krun
 Summary: %{name} with libkrun support
 Requires: libkrun
-Requires: %{name} = %{epoch}:%{version}-%{release}
-Provides: krun = %{epoch}:%{version}-%{release}
+Requires: %{name} = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides: krun = %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description krun
 krun is a symlink to the %{name} binary, with libkrun as an additional dependency.
@@ -92,7 +92,7 @@ krun is a symlink to the %{name} binary, with libkrun as an additional dependenc
 %if %{defined wasm_support}
 %package wasm
 Summary: %{name} with wasm support
-Requires: %{name} = %{epoch}:%{version}-%{release}
+Requires: %{name} = %{?epoch:%{epoch}:}%{version}-%{release}
 Requires: wasm-library
 Recommends: wasmedge
 


### PR DESCRIPTION
When `copr_username` macro is not defined, `Epoch` is not set and `%{epoch}` macro expands to an empty string, which leads to invalid `Requires` tags (because their value starts with a colon). Fix that.