### PR TITLE
RPM: include criu dependencies

### DIFF
--- a/rpm/crun.spec
+++ b/rpm/crun.spec
@@ -61,6 +61,10 @@ BuildRequires: yajl-devel
 BuildRequires: libseccomp-devel
 BuildRequires: python3-libmount
 BuildRequires: libtool
+BuildRequires: protobuf-c-devel
+BuildRequires: criu-devel >= 3.17.1-2
+Recommends: criu >= 3.17.1
+Recommends: criu-libs
 BuildRequires: %{_bindir}/go-md2man
 %if %{defined wasmedge_support}
 BuildRequires: wasmedge-devel


### PR DESCRIPTION
These dependencies were already included in the official Fedora package but were not included in rpm/crun.spec currently used by copr and soon to be used for the official Fedora package.

Fixes: #1255