### PR TITLE
cgroup: fix error return value

### DIFF
--- a/src/libcrun/cgroup-setup.c
+++ b/src/libcrun/cgroup-setup.c
@@ -271,13 +271,13 @@ read_unified_cgroup_pid (pid_t pid, char **path, libcrun_error_t *err)
 
   from = strstr (content, "0::");
   if (UNLIKELY (from == NULL))
-    return crun_make_error (err, -1, "cannot find cgroup2 for the process `%d`", pid);
+    return crun_make_error (err, 0, "cannot find cgroup2 for the process `%d`", pid);
 
   from += 3;
 
   to = strchr (from, '\n');
   if (UNLIKELY (to == NULL))
-    return crun_make_error (err, -1, "cannot parse `%s`", cgroup_path);
+    return crun_make_error (err, 0, "cannot parse `%s`", cgroup_path);
   *to = '\0';
 
   *path = xstrdup (from);


### PR DESCRIPTION
It looks the number `-1` should be something else so that it can be  avoided that
 _crun_make_error()_ returns `0`. Is that a correct analysis?

 I don't know which number would be a good replacement. 

