### PR TITLE
Fix features formatting and implement OCI runtime-spec 1.1.0

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3886,7 +3886,7 @@ libcrun_container_get_features (libcrun_context_t *context, struct features_info
 
   // Hardcoded feature information
   (*info)->oci_version_min = xstrdup ("1.0.0");
-  (*info)->oci_version_max = xstrdup ("1.1.0-rc.3");
+  (*info)->oci_version_max = xstrdup ("1.1.0");
 
   // Populate hooks
   populate_array_field (&((*info)->hooks), hooks, num_hooks);

--- a/src/oci_features.c
+++ b/src/oci_features.c
@@ -68,6 +68,23 @@ add_bool_to_json (yajl_gen json_gen, const char *key, int value)
 }
 
 void
+add_bool_str_to_json (yajl_gen json_gen, const char *key, int value)
+{
+  char *val = "";
+  if (value)
+    {
+      val = "true";
+    }
+  else
+    {
+      val = "false";
+    }
+
+  yajl_gen_string (json_gen, (const unsigned char *) key, strlen (key));
+  yajl_gen_string (json_gen, (const unsigned char *) val, strlen (val));
+}
+
+void
 add_array_to_json (yajl_gen json_gen, const char *key, char **array)
 {
   size_t i;
@@ -177,13 +194,13 @@ crun_features_add_annotations_info (yajl_gen json_gen, const struct annotations_
 
   add_string_to_json (json_gen, "io.github.seccomp.libseccomp.version", annotation->io_github_seccomp_libseccomp_version);
 
-  add_bool_to_json (json_gen, "org.opencontainers.runc.checkpoint.enabled", annotation->run_oci_crun_checkpoint_enabled);
-  add_bool_to_json (json_gen, "run.oci.crun.checkpoint.enabled", annotation->run_oci_crun_checkpoint_enabled);
+  add_bool_str_to_json (json_gen, "org.opencontainers.runc.checkpoint.enabled", annotation->run_oci_crun_checkpoint_enabled);
+  add_bool_str_to_json (json_gen, "run.oci.crun.checkpoint.enabled", annotation->run_oci_crun_checkpoint_enabled);
 
   add_string_to_json (json_gen, "run.oci.crun.commit", annotation->run_oci_crun_commit);
   add_string_to_json (json_gen, "run.oci.crun.version", annotation->run_oci_crun_version);
 
-  add_bool_to_json (json_gen, "run.oci.crun.wasm", annotation->run_oci_crun_wasm);
+  add_bool_str_to_json (json_gen, "run.oci.crun.wasm", annotation->run_oci_crun_wasm);
 
   yajl_gen_map_close (json_gen);
 }

--- a/tests/test_oci_features.py
+++ b/tests/test_oci_features.py
@@ -45,7 +45,7 @@ def test_crun_features():
         features = json.loads(output)
         expected_features = {
             "ociVersionMin": "1.0.0",
-            "ociVersionMax": "1.1.0-rc.3",
+            "ociVersionMax": "1.1.0",
             "hooks": [
                 "prestart",
                 "createRuntime",
@@ -158,8 +158,8 @@ def test_crun_features():
                 }
             },
             "annotations": {
-                "org.opencontainers.runc.checkpoint.enabled": True,
-                "run.oci.checkpoint.enabled": True,
+                "org.opencontainers.runc.checkpoint.enabled": "true",
+                "run.oci.checkpoint.enabled": "true",
                 "run.oci.commit": get_crun_commit(),
             }
         }
@@ -194,15 +194,15 @@ def test_crun_features():
                     return -1
 
                 if ('WASM' in get_crun_feature_string()
-                    and annotations.get("run.oci.crun.wasm") is not True):
+                    and annotations.get("run.oci.crun.wasm") != "true"):
                     sys.stderr.write("wrong value for run.oci.crun.wasm\n")
                     return -1
 
                 if 'CRIU' in get_crun_feature_string():
-                    if annotations.get("org.opencontainers.runc.checkpoint.enabled") is not True:
+                    if annotations.get("org.opencontainers.runc.checkpoint.enabled") != "true":
                         sys.stderr.write("wrong value for org.opencontainers.runc.checkpoint.enabled\n")
                         return -1
-                    if annotations.get("run.oci.crun.checkpoint.enabled") is not True:
+                    if annotations.get("run.oci.crun.checkpoint.enabled") != "true":
                         sys.stderr.write("wrong value for run.oci.crun.checkpoint.enabled\n")
                         return -1
             else:


### PR DESCRIPTION
Hi!

While trying to use the output of the features subcommand with [go-runc](https://github.com/containerd/go-runc/) it fails to parse it. The failure is:

```
cannot unmarshal bool into Go struct field Features.annotations of type string: unknown
```

This patch just writes a string instead of a bool, and the output is parse fine. As I pointed out in the commit msg, it is worth to notice that the spec wording also mentions that a string is expected (i.e. is not a bug in the go-bindings in the runtime-spec).