### PR TITLE
features: Support mountExtensions

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3886,7 +3886,7 @@ libcrun_container_get_features (libcrun_context_t *context, struct features_info
 
   // Hardcoded feature information
   (*info)->oci_version_min = xstrdup ("1.0.0");
-  (*info)->oci_version_max = xstrdup ("1.1.0");
+  (*info)->oci_version_max = xstrdup ("1.1.0+dev");
 
   // Populate hooks
   populate_array_field (&((*info)->hooks), hooks, num_hooks);
@@ -3924,6 +3924,9 @@ libcrun_container_get_features (libcrun_context_t *context, struct features_info
   // Put values for apparmor and selinux
   (*info)->linux.apparmor.enabled = true;
   (*info)->linux.selinux.enabled = true;
+
+  // Put the values for mount extensions
+  (*info)->linux.mount_ext.idmap.enabled = true;
 
   // Populate the values for annotations
 #ifdef HAVE_SECCOMP

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -121,6 +121,16 @@ struct selinux_info_s
   bool enabled;
 };
 
+struct idmap_info_s
+{
+  bool enabled;
+};
+
+struct mount_ext_info_s
+{
+  struct idmap_info_s idmap;
+};
+
 struct linux_info_s
 {
   char **namespaces;
@@ -129,6 +139,7 @@ struct linux_info_s
   struct seccomp_info_s seccomp;
   struct apparmor_info_s apparmor;
   struct selinux_info_s selinux;
+  struct mount_ext_info_s mount_ext;
 };
 
 struct annotations_info_s

--- a/src/oci_features.c
+++ b/src/oci_features.c
@@ -171,6 +171,20 @@ crun_features_add_selinux_info (yajl_gen json_gen, const struct linux_info_s *li
 }
 
 void
+crun_features_add_mount_ext_info (yajl_gen json_gen, const struct linux_info_s *linux)
+{
+  yajl_gen_string (json_gen, (const unsigned char *) "mountExtensions", strlen ("mountExtensions"));
+  yajl_gen_map_open (json_gen);
+
+  yajl_gen_string (json_gen, (const unsigned char *) "idmap", strlen ("idmap"));
+  yajl_gen_map_open (json_gen);
+  add_bool_to_json (json_gen, "enabled", linux->mount_ext.idmap.enabled);
+  yajl_gen_map_close (json_gen);
+
+  yajl_gen_map_close (json_gen);
+}
+
+void
 crun_features_add_linux_info (yajl_gen json_gen, const struct linux_info_s *linux)
 {
   yajl_gen_string (json_gen, (const unsigned char *) "linux", strlen ("linux"));
@@ -182,6 +196,7 @@ crun_features_add_linux_info (yajl_gen json_gen, const struct linux_info_s *linu
   crun_features_add_seccomp_info (json_gen, linux);
   crun_features_add_apparmor_info (json_gen, linux);
   crun_features_add_selinux_info (json_gen, linux);
+  crun_features_add_mount_ext_info (json_gen, linux);
 
   yajl_gen_map_close (json_gen);
 }

--- a/tests/test_oci_features.py
+++ b/tests/test_oci_features.py
@@ -45,7 +45,7 @@ def test_crun_features():
         features = json.loads(output)
         expected_features = {
             "ociVersionMin": "1.0.0",
-            "ociVersionMax": "1.1.0",
+            "ociVersionMax": "1.1.0+dev",
             "hooks": [
                 "prestart",
                 "createRuntime",
@@ -155,6 +155,11 @@ def test_crun_features():
                 },
                 "selinux": {
                     "enabled": True
+                },
+                "mountExtensions": {
+                    "idmap": {
+                        "enabled": True,
+                    },
                 }
             },
             "annotations": {


### PR DESCRIPTION
This PR upstream added the spec for the mountExtensions feature field:
	https://github.com/opencontainers/runtime-spec/pull/1219

This commit just implements that and updates the OCI max version implemented to the one currently used in the spec (an unreleased version).

It is not clear if in the future, the version of unreleased specs will be changed to something else:
	https://github.com/opencontainers/runtime-spec/pull/1221

But this is what is currently accepted.

---

Besides the tests here, I've also verified this against containerd integration tests.

cc @giuseppe 