### PR TITLE
When attempting to kill a dead processes, do not return failure

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5374,6 +5374,10 @@ libcrun_kill_linux (libcrun_container_status_t *status, int signal, libcrun_erro
       if (errno == ENOSYS)
         return libcrun_kill_linux_no_pidfd (status, true, signal, err);
 
+      /* when pidfd_open fails with ESRCH the process is already dead */
+      if (errno == ESRCH)
+	      return 0
+
       return crun_make_error (err, errno, "open pidfd");
     }
 


### PR DESCRIPTION
A race exists where a container engine tells crun to kill a container, process, where the process already died. In this case do not return an error.

Fixes: https://github.com/containers/podman/issues/18452