### PR TITLE
lua: fix the directory structure for the luarocks package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,17 +92,11 @@ python_crun_la_LIBADD = libcrun.la $(PYTHON_LIBS) $(FOUND_LIBS) $(maybe_libyajl.
 endif
 
 if LUA_BINDINGS
-noinst_LTLIBRARIES = libcrun-bundled.la
 luaexec_LTLIBRARIES = luacrun.la
 luacrun_la_SOURCES = lua/lua_crun.c
 luacrun_la_CFLAGS = -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/libocispec/src -I $(abs_top_builddir)/src $(LUA_INCLUDE)
 luacrun_la_LDFLAGS = -avoid-version -module
-luacrun_la_LIBADD = libcrun-bundled.la $(LUA_LIB) $(FOUND_LIBS)
-
-libcrun_bundled_la_SOURCES = $(libcrun_SOURCES)
-libcrun_bundled_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -fvisibility=hidden
-libcrun_bundled_la_LIBADD = libocispec/libocispec.la $(FOUND_LIBS) $(maybe_libyajl.la)
-libcrun_bundled_la_LDFLAGS = -Wl,--version-script=$(abs_top_srcdir)/libcrun.lds
+luacrun_la_LIBADD = libcrun.la $(LUA_LIB) $(FOUND_LIBS)
 
 LUACRUN_CLEAN_VERSION = $(shell git describe --tags | sed 's/-g[0-9a-f]\{7,9\}//')
 

--- a/configure.ac
+++ b/configure.ac
@@ -201,10 +201,26 @@ AS_IF([test "x$with_python_bindings" = "xyes"], [
 
 AC_ARG_WITH([lua-bindings], AS_HELP_STRING([--with-lua-bindings], [build the Lua bindings]))
 
+AC_ARG_ENABLE(
+	[lua-path-guessing],
+	AS_HELP_STRING([--enable-lua-path-guessing], [guessing lua module path based on variables (default: yes), disable to use libdir as luaexecdir]),
+[
+case "${enableval}" in
+	yes) enable_lua_path_guessing=true ;;
+	no) enable_lua_path_guessing=false ;;
+	*) AC_MSG_ERROR(bad value ${enablevaal} for --enable-lua-path-guessing) ;;
+esac
+],
+[enable_lua_path_guessing=true]
+)
+
 AS_IF([test "x$with_lua_bindings" = "xyes"], [
 	AX_PROG_LUA([5.4], [5.5], [], [AC_MSG_ERROR([*** lua interpreter not found])])
 	AX_LUA_HEADERS([], [AC_MSG_ERROR([*** lua headers not found])])
 	AX_LUA_LIBS([], [AC_MSG_ERROR([*** lua libs not found])])
+	AS_IF([test "x$enable_lua_path_guessing" = "xfalse"], [
+		AC_SUBST([luaexecdir], [$libdir])
+	])
 	use_fPIC=yes
 ])
 

--- a/lua/README.md
+++ b/lua/README.md
@@ -4,54 +4,58 @@ Bare libcrun interface for Lua.
 
 There are some problems still and the API is a subject to change.
 
-## Build
+## LuaRocks build
 
-Only build static archive, to be bundled with another program:
+To build luacrun luarocks package, you must have:
 
-````sh
-./configure --with-lua-bindings
+- Dependencies for building libcrun
+- Lua 5.4 and its development files
+- LuaRocks 3.x
+- `sed`, `git` and `zip`
+
+Started by `./configure`:
+
+```
+./autogen.sh && ./configure --with-lua-bindings
+```
+
+This is only to enable the option to build source rocks. The options to build the rocks is hard-coded at "lua/luacrun.rockspec".
+
+Create the source rock:
+
+```
+make dist-luarock
+```
+
+You can find the new rock file as `luacrun-x.x.x-xx.src.rock`.
+
+If you want the binary rock, use luarocks:
+```
+luarocks build <the-rock-file-name> --pack-binary-rock
+```
+
+## Regular build
+
+Requirements:
+- Dependencies for building libcrun
+- Lua 5.4 and its development files
+
+You can still build this module for regular directory structure, like:
+
+```
+./autogen.sh && ./configure --with-lua-bindings --disable-libcrun --disable-crun --enable-shared
+```
+
+The options here for `./configure` will affect the final output.
+
+```
 make && make install
-````
+```
 
-Since the final product bundle libcrun, you don't need to link libcrun at runtime.
-
-
-For the library using at runtime, add option `--enable-shared`:
-````sh
-./configure --with-lua-bindings --enable-shared
-make && make install
-````
-
-Other options to build libcrun may affect the bundled libcrun.
 
 ## Usage
 
 See `luacrun.d.tl`.
-
-## Works with your LuaRocks project
-
-You can build rocks (in luarocks) if lua bindings is enabled.
-
-````sh
-./configure --with-lua-bindings
-make dist-luarock
-````
-
-The options here for `./configure` won't affect the final output, see `luacrun.rockspec` for the building options.
-
-`dist-luarock` target packs a source rock. You can use `luarocks build luacrun-xxx.src.rock --pack-binary-rock` to pack binary rocks.
-
-````sh
-# Assume the filename is luacrun-1.8.4-0.src.rock
-luarocks build luacrun-1.8.4-0.src.rock --pack-binary-rock
-````
-
-Another way is, configure the prefix to your `lua_modules` to access this library in your project.
-
-````sh
-./configure --with-lua-bindings --enable-shared --prefix $(pwd)/lua_modules
-make && make install
-````
 
 ## Interpreter may restart?
 
@@ -135,3 +139,8 @@ The tests assume environment variable `INIT` exists. It's the `init` program com
 ````sh
 INIT=$(pwd)/tests/init lua_modules/bin/busted lua
 ````
+
+## Additional Build Options
+
+- `--with-lua-bindings` enables the building options about the lua binding
+- `--enable-lua-path-guessing`/`--disable-lua-path-guessing` enable or disable the lua module path guessing. If disabled, the install path for this module will be set to `libdir`.

--- a/lua/luacrun.rockspec
+++ b/lua/luacrun.rockspec
@@ -25,7 +25,7 @@ build = {
     type = "command",
     build_command = [[
         rm -rf libocispec/yajl/src/api && ln -s ./headers/yajl libocispec/yajl/src/api &&
-        ./configure --prefix=$(PREFIX) --libdir=$(LIBDIR) --disable-crun --disable-libcrun --enable-shared --with-lua-bindings --enable-embedded-yajl LUA=$(LUA) LUA_INCLUDE=-I$(LUA_INCDIR) &&
+        ./configure --prefix=$(PREFIX) --libdir=$(LIBDIR) --disable-lua-path-guessing --disable-crun --disable-libcrun --enable-shared --with-lua-bindings --enable-embedded-yajl LUA=$(LUA) LUA_INCLUDE=-I$(LUA_INCDIR) &&
         make -j]],
     install_command = "make install",
 }


### PR DESCRIPTION
This PR fixes the directory structure for the luarocks package .

The incorrect structure (on luarocks 3.9.4):
```
lua_modules/lib64
└── lua
    └── 5.4
        ├── lfs.so
        ├── lua
        │   └── 5.4
        │       ├── luacrun.a
        │       ├── luacrun.la
        │       └── luacrun.so
        ├── system
        │   └── core.so
        └── term
            └── core.so
```

This PR added a new build option `--disable-lua-path-guessing` to place the files directly under the `$LIBDIR` from luarocks.

Corrected:
```
lua_modules/lib64/
└── lua
    └── 5.4
        ├── lfs.so
        ├── luacrun.a
        ├── luacrun.la
        ├── luacrun.so
        ├── system
        │   └── core.so
        └── term
            └── core.so
```