### PR TITLE
linux: do not join already joined namespaces

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -4953,6 +4953,8 @@ join_process_namespaces (libcrun_container_t *container, pid_t pid_to_join, libc
     }
   for (i = 0; namespaces[i].ns_file; i++)
     {
+      if (fds_joined[i])
+        continue;
       ret = setns (fds[i], 0);
       if (ret == 0)
         fds_joined[i] = 1;


### PR DESCRIPTION
I don't know if this PR is correct. I'm doing a lot of guessing here.

I'm guessing that the array `joined_fds` is used to keep track of which namespaces have already been joined:
https://github.com/containers/crun/blob/3dc4ce9e2e9a83f7a6033dcb6b908aa2c3279f24/src/libcrun/linux.c#L4906-L4908
When an element is equal to `1`, `setns()` could be skipped.