### PR TITLE
linux: fix check for oom_score_adj

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3176,7 +3176,7 @@ libcrun_set_oom (libcrun_container_t *container, libcrun_error_t *err)
   cleanup_close int fd = -1;
   int ret;
   char oom_buffer[16];
-  if (def->process == NULL || def->process->oom_score_adj == 0)
+  if (def->process == NULL || ! def->process->oom_score_adj_present)
     return 0;
   sprintf (oom_buffer, "%i", def->process->oom_score_adj);
   fd = open ("/proc/self/oom_score_adj", O_RDWR);


### PR DESCRIPTION
do not write to the oom_score_adj only when the oom_score_adj value is not present in the spec file.