### PR TITLE
fix: correctly handle unknow signal string

### DIFF
--- a/src/libcrun/signals.c
+++ b/src/libcrun/signals.c
@@ -595,13 +595,18 @@ str2sig (const char *name)
     {
       long int value;
 
+      if (!isdigit(name[0]))
+        {
+          errno = EINVAL;
+          return -1;
+        }
+
       errno = 0;
       value = strtol (name, NULL, 10);
-      if (errno == 0)
-        return value;
+      if (errno != 0)
+        return -1;
 
-      errno = ENOENT;
-      return -1;
+      return value;
     }
 
   return s->value;

--- a/src/libcrun/signals.perf
+++ b/src/libcrun/signals.perf
@@ -106,13 +106,18 @@ str2sig (const char *name)
     {
       long int value;
 
+      if (!isdigit(name[0]))
+        {
+          errno = EINVAL;
+          return -1;
+        }
+
       errno = 0;
       value = strtol (name, NULL, 10);
-      if (errno == 0)
-        return value;
+      if (errno != 0)
+        return -1;
 
-      errno = ENOENT;
-      return -1;
+      return value;
     }
 
   return s->value;


### PR DESCRIPTION
`strtol` will return 0 and not set errno
when handling a string which is not started with digital characters.

The old str2sig function failed to report invalid signal string input
and return signal 0.

I fix this little mistake.

Signed-off-by: black-desk <me@black-desk.cn>
