### PR TITLE
utils: improve error message for ensure_dir

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -546,9 +546,10 @@ crun_safe_ensure_at (bool do_open, bool dir, int dirfd, const char *dirpath,
             return crun_make_error (err, errno, "mkdir `/%s`", npath);
         }
 
-      cwd = safe_openat (dirfd, dirpath, dirpath_len, npath, O_CLOEXEC | O_PATH, 0, err);
+      cwd = safe_openat (dirfd, dirpath, dirpath_len, npath,
+                         ((dir || ! last_component) ? O_DIRECTORY : 0) | O_CLOEXEC | O_PATH, 0, err);
       if (UNLIKELY (cwd < 0))
-        return cwd;
+        return crun_error_wrap (err, "creating `/%s`", path);
 
       close_and_replace (&wd_cleanup, cwd);
 


### PR DESCRIPTION
when creating a directory, if any component of the path is not a directory, report it as part of the error message.

Forcing O_DIRECTORY for any component that we expect to be a directory, will force the kernel to report the error earlier instead of failing at the next mkdir(2) call.

Closes: https://github.com/containers/crun/issues/1307