### PR TITLE
linux: open mounts before setgroups if in a userns

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -4068,6 +4068,18 @@ prepare_and_send_mount_mounts (libcrun_container_t *container, pid_t pid, int sy
   if (def->mounts_len == 0)
     return 0;
 
+  if (! has_userns)
+    {
+      int is_in_userns;
+
+      is_in_userns = check_running_in_user_namespace (err);
+      if (UNLIKELY (is_in_userns < 0))
+        return is_in_userns;
+
+      if (is_in_userns > 0)
+        has_userns = true;
+    }
+
   mount_fds = make_libcrun_fd_map (def->mounts_len);
 
   for (i = 0; i < def->mounts_len; i++)


### PR DESCRIPTION
extend the condition for opening bind mounts in the parent process to the case where the crun process itself is running inside a user namespace.  In this way the source path is opened before doing the setgroups(2) syscall and potentially losing access to directories that are accessible only by group permission.

Closes: https://github.com/containers/crun/issues/1320