### PR TITLE
linux: Fix -Wunused-result compiler warnings when run './configure' only

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -743,8 +743,10 @@ libcrun_create_keyring (const char *name, const char *label, libcrun_error_t *er
 
 out:
   /* Best effort attempt to reset the SELinux label used for new keyrings.  */
-  if (label_set)
-    (void) write (labelfd, "", 0);
+  if (label_set && write (labelfd, "", 0) < 0)
+    {
+      /* Braces around empty body, to fix warning for [-Wunused-result] and error for [-Werror=empty-body]. */
+    }
   return ret;
 }
 


### PR DESCRIPTION
On Ubuntu 22.04.3, gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0:
  CC       src/libcrun/libcrun_la-linux.lo
src/libcrun/linux.c: In function 'libcrun_create_keyring':
src/libcrun/linux.c:747:12: warning: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Wunused-result]
  747 |     (void) write (labelfd, "", 0);
      |            ^~~~~~~~~~~~~~~~~~~~~~
  CCLD     libcrun.la
  CCLD     crun
  CC       src/libcrun/libcrun_testing_a-linux.o
src/libcrun/linux.c: In function 'libcrun_create_keyring':
src/libcrun/linux.c:747:12: warning: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Wunused-result]
  747 |     (void) write (labelfd, "", 0);
      |            ^~~~~~~~~~~~~~~~~~~~~~

Move the 'write' to 'if' statement to do check for avoid the warning.