### PR TITLE
linux: new mount option "copy-symlink"

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -686,6 +686,14 @@ If the \fB\fCtmpcopyup\fR option is specified for a tmpfs, then the path that
 is shadowed by the tmpfs mount is recursively copied up to the tmpfs
 itself.
 
+.SH copy-symlink mount options
+.PP
+If the \fB\fCcopy-symlink\fR option is specified, if the source of a bind
+mount is a symlink, the symlink is recreated at the specified
+destination instead of attempting a mount that would resolve the
+symlink itself.  If the destination already exists and it is not a
+symlink with the expected content, crun will return an error.
+
 .SH r$FLAG mount options
 .PP
 If a \fB\fCr$FLAG\fR mount option is specified then the flag \fB\fC$FLAG\fR is set

--- a/crun.1.md
+++ b/crun.1.md
@@ -542,6 +542,14 @@ If the `tmpcopyup` option is specified for a tmpfs, then the path that
 is shadowed by the tmpfs mount is recursively copied up to the tmpfs
 itself.
 
+## copy-symlink mount options
+
+If the `copy-symlink` option is specified, if the source of a bind
+mount is a symlink, the symlink is recreated at the specified
+destination instead of attempting a mount that would resolve the
+symlink itself.  If the destination already exists and it is not a
+symlink with the expected content, crun will return an error.
+
 ## r$FLAG mount options
 
 If a `r$FLAG` mount option is specified then the flag `$FLAG` is set

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2147,7 +2147,7 @@ do_mounts (libcrun_container_t *container, int rootfsfd, const char *rootfs, con
 
           destfd = safe_openat (rootfsfd, rootfs, rootfs_len, target, O_DIRECTORY, 0, err);
           if (UNLIKELY (destfd < 0))
-            return crun_make_error (err, errno, "open target to write for tmpcopyup");
+            return crun_error_wrap (err, "open target to write for tmpcopyup");
 
           /* take ownership for the fd.  */
           tmpfd = get_and_reset (&copy_from_fd);

--- a/src/libcrun/mount_flags.c
+++ b/src/libcrun/mount_flags.c
@@ -48,14 +48,14 @@
 struct propagation_flags_s;
 enum
   {
-    TOTAL_KEYWORDS = 56,
+    TOTAL_KEYWORDS = 57,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 14,
     MIN_HASH_VALUE = 2,
-    MAX_HASH_VALUE = 69
+    MAX_HASH_VALUE = 74
   };
 
-/* maximum key range = 68, duplicates = 0 */
+/* maximum key range = 73, duplicates = 0 */
 
 #ifdef __GNUC__
 __inline
@@ -69,32 +69,32 @@ hash (register const char *str, register size_t len)
 {
   static const unsigned char asso_values[] =
     {
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70,  8, 29,  3,
-       3, 21, 18, 70, 21,  0, 70, 70, 15, 10,
-       0,  4, 32, 70,  0, 19,  8, 17, 22,  0,
-      16, 27, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75,  8, 29, 12,
+       3, 21,  0, 75, 31,  0, 75, 75, 15, 10,
+       0,  4, 16, 75,  0, 19,  8, 17, 26,  0,
+      16, 26, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
+      75, 75, 75, 75, 75, 75
     };
   register unsigned int hval = len;
 
@@ -148,6 +148,8 @@ static const struct propagation_flags_s wordlist[] =
     {"ratime", 1, MS_NOATIME, OPTION_RECURSIVE},
 #line 80 "src/libcrun/mount_flags.perf"
     {"rmand", 0, MS_MANDLOCK, OPTION_RECURSIVE},
+#line 66 "src/libcrun/mount_flags.perf"
+    {"rprivate", 0, MS_REC|MS_PRIVATE, 0},
 #line 51 "src/libcrun/mount_flags.perf"
     {"mand", 0, MS_MANDLOCK, 0},
 #line 91 "src/libcrun/mount_flags.perf"
@@ -178,8 +180,8 @@ static const struct propagation_flags_s wordlist[] =
     {"strictatime", 0, MS_STRICTATIME, 0},
 #line 88 "src/libcrun/mount_flags.perf"
     {"rstrictatime", 0, MS_STRICTATIME, OPTION_RECURSIVE},
-#line 66 "src/libcrun/mount_flags.perf"
-    {"rprivate", 0, MS_REC|MS_PRIVATE, 0},
+#line 36 "src/libcrun/mount_flags.perf"
+    {"defaults", 0, 0, 0},
 #line 71 "src/libcrun/mount_flags.perf"
     {"rsuid", 1, MS_NOSUID, OPTION_RECURSIVE},
 #line 50 "src/libcrun/mount_flags.perf"
@@ -196,40 +198,40 @@ static const struct propagation_flags_s wordlist[] =
     {"noexec", 0, MS_NOEXEC, 0},
 #line 64 "src/libcrun/mount_flags.perf"
     {"rslave", 0, MS_REC|MS_SLAVE, 0},
-#line 43 "src/libcrun/mount_flags.perf"
-    {"dev", 1, MS_NODEV, 0},
-#line 73 "src/libcrun/mount_flags.perf"
-    {"rdev", 1, MS_NODEV, OPTION_RECURSIVE},
+#line 65 "src/libcrun/mount_flags.perf"
+    {"private", 0, MS_PRIVATE, 0},
 #line 77 "src/libcrun/mount_flags.perf"
     {"rsync", 0, MS_SYNCHRONOUS, OPTION_RECURSIVE},
 #line 57 "src/libcrun/mount_flags.perf"
     {"relatime", 0, MS_RELATIME, 0},
-#line 47 "src/libcrun/mount_flags.perf"
-    {"sync", 0, MS_SYNCHRONOUS, 0},
-#line 61 "src/libcrun/mount_flags.perf"
-    {"shared", 0, MS_SHARED, 0},
-#line 62 "src/libcrun/mount_flags.perf"
-    {"rshared", 0, MS_REC|MS_SHARED, 0},
+#line 43 "src/libcrun/mount_flags.perf"
+    {"dev", 1, MS_NODEV, 0},
+#line 73 "src/libcrun/mount_flags.perf"
+    {"rdev", 1, MS_NODEV, OPTION_RECURSIVE},
+#line 90 "src/libcrun/mount_flags.perf"
+    {"tmpcopyup", 0, 0, OPTION_TMPCOPYUP},
 #line 67 "src/libcrun/mount_flags.perf"
     {"unbindable", 0, MS_UNBINDABLE, 0},
 #line 68 "src/libcrun/mount_flags.perf"
     {"runbindable", 0, MS_REC|MS_UNBINDABLE, 0},
-#line 36 "src/libcrun/mount_flags.perf"
-    {"defaults", 0, 0, 0},
 #line 48 "src/libcrun/mount_flags.perf"
     {"async", 1, MS_SYNCHRONOUS, 0},
 #line 78 "src/libcrun/mount_flags.perf"
     {"rasync", 1, MS_SYNCHRONOUS, OPTION_RECURSIVE},
-#line 65 "src/libcrun/mount_flags.perf"
-    {"private", 0, MS_PRIVATE, 0},
-#line 90 "src/libcrun/mount_flags.perf"
-    {"tmpcopyup", 0, 0, OPTION_TMPCOPYUP},
+#line 47 "src/libcrun/mount_flags.perf"
+    {"sync", 0, MS_SYNCHRONOUS, 0},
 #line 75 "src/libcrun/mount_flags.perf"
     {"rexec", 1, MS_NOEXEC, OPTION_RECURSIVE},
-#line 45 "src/libcrun/mount_flags.perf"
-    {"exec", 1, MS_NOEXEC, 0},
+#line 61 "src/libcrun/mount_flags.perf"
+    {"shared", 0, MS_SHARED, 0},
+#line 62 "src/libcrun/mount_flags.perf"
+    {"rshared", 0, MS_REC|MS_SHARED, 0},
+#line 92 "src/libcrun/mount_flags.perf"
+    {"copy-symlink", 0, 0, OPTION_COPY_SYMLINK},
 #line 63 "src/libcrun/mount_flags.perf"
-    {"slave", 0, MS_SLAVE, 0}
+    {"slave", 0, MS_SLAVE, 0},
+#line 45 "src/libcrun/mount_flags.perf"
+    {"exec", 1, MS_NOEXEC, 0}
   };
 
 const struct propagation_flags_s *
@@ -290,85 +292,85 @@ libcrun_mount_flag_in_word_set (register const char *str, register size_t len)
               case 21:
                 resword = &wordlist[14];
                 goto compare;
-              case 23:
+              case 22:
                 resword = &wordlist[15];
                 goto compare;
-              case 24:
+              case 23:
                 resword = &wordlist[16];
                 goto compare;
-              case 25:
+              case 24:
                 resword = &wordlist[17];
                 goto compare;
-              case 26:
+              case 25:
                 resword = &wordlist[18];
                 goto compare;
-              case 27:
+              case 26:
                 resword = &wordlist[19];
                 goto compare;
-              case 28:
+              case 27:
                 resword = &wordlist[20];
                 goto compare;
-              case 29:
+              case 28:
                 resword = &wordlist[21];
                 goto compare;
-              case 30:
+              case 29:
                 resword = &wordlist[22];
                 goto compare;
-              case 31:
+              case 30:
                 resword = &wordlist[23];
                 goto compare;
-              case 32:
+              case 31:
                 resword = &wordlist[24];
                 goto compare;
-              case 33:
+              case 32:
                 resword = &wordlist[25];
                 goto compare;
-              case 34:
+              case 33:
                 resword = &wordlist[26];
                 goto compare;
-              case 35:
+              case 34:
                 resword = &wordlist[27];
                 goto compare;
-              case 36:
+              case 35:
                 resword = &wordlist[28];
                 goto compare;
-              case 37:
+              case 36:
                 resword = &wordlist[29];
                 goto compare;
-              case 38:
+              case 37:
                 resword = &wordlist[30];
                 goto compare;
-              case 39:
+              case 38:
                 resword = &wordlist[31];
                 goto compare;
-              case 40:
+              case 39:
                 resword = &wordlist[32];
                 goto compare;
-              case 41:
+              case 40:
                 resword = &wordlist[33];
                 goto compare;
-              case 42:
+              case 41:
                 resword = &wordlist[34];
                 goto compare;
-              case 43:
+              case 42:
                 resword = &wordlist[35];
                 goto compare;
-              case 44:
+              case 43:
                 resword = &wordlist[36];
                 goto compare;
-              case 45:
+              case 44:
                 resword = &wordlist[37];
                 goto compare;
-              case 46:
+              case 45:
                 resword = &wordlist[38];
                 goto compare;
-              case 47:
+              case 46:
                 resword = &wordlist[39];
                 goto compare;
-              case 48:
+              case 47:
                 resword = &wordlist[40];
                 goto compare;
-              case 49:
+              case 48:
                 resword = &wordlist[41];
                 goto compare;
               case 50:
@@ -395,23 +397,26 @@ libcrun_mount_flag_in_word_set (register const char *str, register size_t len)
               case 57:
                 resword = &wordlist[49];
                 goto compare;
-              case 58:
+              case 59:
                 resword = &wordlist[50];
                 goto compare;
-              case 59:
+              case 61:
                 resword = &wordlist[51];
                 goto compare;
-              case 60:
+              case 62:
                 resword = &wordlist[52];
                 goto compare;
-              case 61:
+              case 63:
                 resword = &wordlist[53];
                 goto compare;
-              case 63:
+              case 68:
                 resword = &wordlist[54];
                 goto compare;
-              case 67:
+              case 71:
                 resword = &wordlist[55];
+                goto compare;
+              case 72:
+                resword = &wordlist[56];
                 goto compare;
             }
           return 0;
@@ -426,7 +431,7 @@ libcrun_mount_flag_in_word_set (register const char *str, register size_t len)
     }
   return 0;
 }
-#line 92 "src/libcrun/mount_flags.perf"
+#line 93 "src/libcrun/mount_flags.perf"
 
 
 const struct propagation_flags_s *

--- a/src/libcrun/mount_flags.h
+++ b/src/libcrun/mount_flags.h
@@ -24,6 +24,7 @@ enum
   OPTION_TMPCOPYUP = (1 << 0),
   OPTION_RECURSIVE = (1 << 1),
   OPTION_IDMAP = (1 << 2),
+  OPTION_COPY_SYMLINK = (1 << 3),
 };
 
 struct propagation_flags_s

--- a/src/libcrun/mount_flags.perf
+++ b/src/libcrun/mount_flags.perf
@@ -89,6 +89,7 @@ rstrictatime, 0, MS_STRICTATIME, OPTION_RECURSIVE
 rnostrictatime, 1, MS_STRICTATIME, OPTION_RECURSIVE
 tmpcopyup, 0, 0, OPTION_TMPCOPYUP
 idmap, 0, 0, OPTION_IDMAP
+copy-symlink, 0, 0, OPTION_COPY_SYMLINK
 %%
 
 const struct propagation_flags_s *

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -422,7 +422,7 @@ safe_openat (int dirfd, const char *rootfs, size_t rootfs_len, const char *path,
   return safe_openat_fallback (dirfd, rootfs, rootfs_len, path, flags, mode, err);
 }
 
-static ssize_t
+ssize_t
 safe_readlinkat (int dfd, const char *name, char **buffer, ssize_t hint, libcrun_error_t *err)
 {
   ssize_t buf_size = hint > 0 ? hint + 1 : 512;

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -383,6 +383,8 @@ int base64_decode (const char *iptr, size_t isize, char *optr, size_t osize, siz
 int has_suffix (const char *source, const char *suffix);
 char *str_join_array (int offset, size_t size, char *const array[], const char *joint);
 
+ssize_t safe_readlinkat (int dfd, const char *name, char **buffer, ssize_t hint, libcrun_error_t *err);
+
 static inline bool
 is_empty_string (const char *s)
 {

--- a/tests/init.c
+++ b/tests/init.c
@@ -421,6 +421,23 @@ main (int argc, char **argv)
       return cat (argv[2]);
     }
 
+  if (strcmp (argv[1], "readlink") == 0)
+    {
+      ssize_t ret;
+      char *buf = malloc (PATH_MAX);
+      if (buf == NULL)
+        error (EXIT_FAILURE, errno, "malloc");
+      if (argc < 3)
+        error (EXIT_FAILURE, 0, "'readlink' requires an argument");
+
+      ret = readlink (argv[2], buf, PATH_MAX);
+      if (ret < 0)
+        error (EXIT_FAILURE, errno, "readlink");
+      printf ("%.*s", (int) ret, buf);
+      free (buf);
+      return 0;
+    }
+
   if (strcmp (argv[1], "open") == 0)
     {
       if (argc < 3)

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -489,7 +489,7 @@ all_tests = {
     "mount-linux-readonly-should-inherit-flags": test_mount_readonly_should_inherit_options_from_parent,
     "proc-linux-readonly-should-inherit-flags": test_proc_readonly_should_inherit_options_from_parent,
     "mount-ro-cgroup": test_ro_cgroup,
-    "cgroup-mount-without-netns": test_cgroup_mount_without_netns,
+    "mount-cgroup-without-netns": test_cgroup_mount_without_netns,
 }
 
 if __name__ == "__main__":

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -152,6 +152,23 @@ def test_proc_readonly_should_inherit_options_from_parent():
         return 0
     return -1
 
+def test_copy_symlink():
+    root = get_tests_root()
+    symlink = os.path.join(root, "a-broken-link")
+    target = "point-to-nowhere"
+
+    os.symlink(target, symlink)
+
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'readlink', '/a/sym/link']
+    add_all_namespaces(conf)
+    mount_opt = {"destination": "/a/sym/link", "type": "bind", "source": symlink, "options": ["rbind", "copy-symlink"]}
+    conf['mounts'].append(mount_opt)
+    out, _ = run_and_get_output(conf, hide_stderr=True)
+    if target in out:
+        return 0
+    return -1
+
 def test_mount_path_with_multiple_slashes():
     conf = base_config()
     conf['process']['args'] = ['/init', 'cat', '/proc/self/mountinfo']
@@ -490,6 +507,7 @@ all_tests = {
     "proc-linux-readonly-should-inherit-flags": test_proc_readonly_should_inherit_options_from_parent,
     "mount-ro-cgroup": test_ro_cgroup,
     "mount-cgroup-without-netns": test_cgroup_mount_without_netns,
+    "mount-copy-symlink": test_copy_symlink,
 }
 
 if __name__ == "__main__":

--- a/tests/test_oci_features.py
+++ b/tests/test_oci_features.py
@@ -109,6 +109,7 @@ def test_crun_features():
                 "private",
                 "tmpcopyup",
                 "rexec",
+                "copy-symlink",
                 "exec",
                 "slave"
             ],
@@ -211,7 +212,7 @@ def test_crun_features():
                         sys.stderr.write("wrong value for run.oci.crun.checkpoint.enabled\n")
                         return -1
             else:
-                if key not in features or features[key] != value:
+                if key not in features or sorted(features[key]) != sorted(value):
                     sys.stderr.write(f"Mismatch in feature: {key}\n")
                     sys.stderr.write(f"Expected: {value}\n")
                     sys.stderr.write(f"Actual: {features.get(key)}\n")

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -463,6 +463,8 @@ def test_listen_pid_env():
     return 0
 
 def test_ioprio():
+    if is_rootless():
+        return 77
     IOPRIO_CLASS_NONE = 0
     IOPRIO_CLASS_RT = 1
     IOPRIO_CLASS_BE = 2


### PR DESCRIPTION
provide an option to copy the original symlink instead of dereferencing it.  This requires a new mount flag, which is handled directly by crun and not passed down to the kernel.  When "copy-symlink" is found, if the source of a mount is a symlink, then crun creates the symlink at the destination instead of attempting a mount(2).

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
