### PR TITLE
linux: append tmpfs mode if missing for mounts

### DIFF
--- a/tests/init.c
+++ b/tests/init.c
@@ -468,6 +468,19 @@ main (int argc, char **argv)
       return 0;
     }
 
+  if (strcmp (argv[1], "mode") == 0)
+    {
+      struct stat st;
+
+      if (argc < 3)
+        error (EXIT_FAILURE, 0, "'mode' requires two arguments");
+      if (stat (argv[2], &st) < 0)
+        error (EXIT_FAILURE, errno, "stat %s", argv[2]);
+
+      printf ("%o", st.st_mode & 07777);
+      return 0;
+    }
+
   if (strcmp (argv[1], "id") == 0)
     {
       int ret;

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -55,6 +55,21 @@ def test_mount_symlink():
         return 0
     return -1
 
+def test_mount_tmpfs_permissions():
+    def prepare_rootfs(rootfs):
+        path = os.path.join(rootfs, "tmp")
+        os.mkdir(path)
+        os.chmod(path, 0o712)
+
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'mode', '/tmp']
+    add_all_namespaces(conf)
+    mount_opt = {"destination": "/tmp", "type": "tmpfs", "source": "tmpfs", "options": ["bind", "ro"]}
+    out, _ = run_and_get_output(conf, hide_stderr=True, callback_prepare_rootfs=prepare_rootfs)
+    if "712" in out:
+        return 0
+    return -1
+
 def test_ro_cgroup():
     for cgroupns in [True, False]:
         for netns in [True, False]:
@@ -508,6 +523,7 @@ all_tests = {
     "mount-ro-cgroup": test_ro_cgroup,
     "mount-cgroup-without-netns": test_cgroup_mount_without_netns,
     "mount-copy-symlink": test_copy_symlink,
+    "mount-tmpfs-permissions": test_mount_tmpfs_permissions,
 }
 
 if __name__ == "__main__":

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -463,8 +463,6 @@ def test_listen_pid_env():
     return 0
 
 def test_ioprio():
-    if is_rootless():
-        return 77
     IOPRIO_CLASS_NONE = 0
     IOPRIO_CLASS_RT = 1
     IOPRIO_CLASS_BE = 2
@@ -484,7 +482,7 @@ def test_ioprio():
     conf['process']['args'] = ['/init', 'ioprio']
     conf['process']['ioPriority'] = {
         "class": "IOPRIO_CLASS_IDLE",
-        "priority": 11
+        "priority": 0
     }
 
     cid = None
@@ -494,7 +492,7 @@ def test_ioprio():
         if ((value >> IOPRIO_CLASS_SHIFT) & IOPRIO_CLASS_MASK) != IOPRIO_CLASS_IDLE:
             print("invalid ioprio class returned")
             return 1
-        if value & IOPRIO_PRIO_MASK != 11:
+        if value & IOPRIO_PRIO_MASK != 0:
             print("invalid ioprio priority returned")
             return 1
         return 0

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -208,7 +208,7 @@ def get_crun_path():
 def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
                        command='run', env=None, use_popen=False, hide_stderr=False, cgroup_manager='cgroupfs',
                        all_dev_null=False, id_container=None, relative_config_path="config.json",
-                       chown_rootfs_to=None):
+                       chown_rootfs_to=None, callback_prepare_rootfs=None):
 
     # Some tests require that the container user, which might not be the
     # same user as the person running the tests, is able to resolve the full path
@@ -259,6 +259,9 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
         for root, dirs, files in os.walk(temp_dir):
             for f in dirs + files:
                 os.chown(os.path.join(root, f), chown_rootfs_to, chown_rootfs_to, follow_symlinks=False)
+
+    if callback_prepare_rootfs is not None:
+        callback_prepare_rootfs(rootfs)
 
     detach_arg = ['--detach'] if detach else []
     preserve_fds_arg = ['--preserve-fds', str(preserve_fds)] if preserve_fds else []


### PR DESCRIPTION
For tmpfs type mounts, ensure that a mode is appended to the mount data if it is not already present.  The function checks the existing directory and appends the mode based on the file permissions of the source path at the rootfs.  This helps in preserving the intended file permissions when overriding a directory with a new tmpfs file system.

Closes: https://issues.redhat.com/browse/RHEL-14469
Closes: https://github.com/containers/crun/issues/1330

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
