### PR TITLE
Remove the redundant header file #include <stdarg.h>

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -40,7 +40,6 @@
 #include <sys/vfs.h>
 #include <linux/magic.h>
 #include <limits.h>
-#include <stdarg.h>
 #include <sys/mman.h>
 #ifdef HAVE_LINUX_OPENAT2_H
 #  include <linux/openat2.h>


### PR DESCRIPTION
While going through the source code, #include <stdarg.h> is mentioned in multiple places within the same file.