### PR TITLE
terminal: adopt ptsname_r POSIX specified return value

### DIFF
--- a/src/libcrun/terminal.c
+++ b/src/libcrun/terminal.c
@@ -46,7 +46,7 @@ libcrun_new_terminal (char **pty, libcrun_error_t *err)
     return crun_make_error (err, errno, "open `/dev/ptmx`");
 
   ret = ptsname_r (fd, buf, sizeof (buf));
-  if (UNLIKELY (ret < 0))
+  if (UNLIKELY (ret != 0))
     return crun_make_error (err, errno, "ptsname");
 
   ret = unlockpt (fd);


### PR DESCRIPTION
ptsname_r has been adopted by POSIX and is specified to return an error number on failure[1].  Thus check that the return value is != 0 rather than < 0.

[1] https://www.austingroupbugs.net/view.php?id=508