### PR TITLE
cgroup: fix crash on cgroup v1 without cpu resources

### DIFF
--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -1037,6 +1037,9 @@ write_cpuset_resources (int dirfd_cpuset, int cgroup2, runtime_spec_schema_confi
 {
   int ret;
 
+  if (cpu == NULL)
+    return 0;
+
   if (cpu->cpus)
     {
       ret = write_file_and_check_controllers_at (cgroup2, dirfd_cpuset, "cpuset.cpus", "cpus",


### PR DESCRIPTION
fix a crash when running on cgroup v1 and cpu resources are not set in the configuration file.

commit 5a0ede20fdd73c6de09d8c07b4ba2ea410fbb7cb introduced the regression.

Closes: https://github.com/containers/crun/issues/1338