### PR TITLE
NEWS: tag 1.11.2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,12 +23,6 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: true
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: false
-AllowShortBlocksOnASingleLine: false
-BreakBeforeBraces: Allman
 BraceWrapping:
   AfterCaseLabel:  true
   AfterClass:      true

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+* crun-1.11.2
+
+- fix a regression caused by 1.11.1 where the process crashes if there
+  are no CPU limits configured on cgroup v1.
+- fix error code check for the ptsname_r function.
+
 * crun-1.11.1
 
 - force a remount operation with bind mounts from the host to correctly

--- a/src/libcrun/cloned_binary.c
+++ b/src/libcrun/cloned_binary.c
@@ -119,7 +119,7 @@ static int is_self_cloned(void)
 	 * Is the binary a fully-sealed memfd? We don't need CLONED_BINARY_ENV for
 	 * this, because you cannot write to a sealed memfd no matter what (so
 	 * sharing it isn't a bad thing -- and an admin could bind-mount a sealed
-	 * memfd to /usr/bin/crun to allow re-use).
+	 * memfd to /usr/bin/crun to allow reuse).
 	 */
 	ret = fcntl(fd, F_GET_SEALS);
 	if (ret >= 0) {

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3086,7 +3086,7 @@ libcrun_set_usernamespace (libcrun_container_t *container, pid_t pid, libcrun_er
   return 0;
 }
 
-#define CAP_TO_MASK_0(x) (1L << ((x) &31))
+#define CAP_TO_MASK_0(x) (1L << ((x) & 31))
 #define CAP_TO_MASK_1(x) CAP_TO_MASK_0 (x - 32)
 
 struct all_caps_s


### PR DESCRIPTION
- fix a regression caused by 1.11.1 where the process crashes if there are no CPU limits configured on cgroup v1.
- fix error code check for the ptsname_r function.
