### PR TITLE
container: move dereference after check

### DIFF
--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -300,9 +300,11 @@ static inline void
 cleanup_struct_features_free (struct features_info_s **info)
 {
   size_t i;
-  struct features_info_s *ptr = *info;
+  struct features_info_s *ptr;
   if (info == NULL || *info == NULL)
     return;
+
+  ptr = *info;
 
   // Free oci_version_min if it is not NULL
   if (ptr->oci_version_min != NULL)


### PR DESCRIPTION
dereference the pointer only after it has been checked.