### PR TITLE
preconfigure cpuset with required resources

### DIFF
--- a/src/libcrun/cgroup-internal.h
+++ b/src/libcrun/cgroup-internal.h
@@ -81,6 +81,7 @@ convert_shares_to_weight (uint64_t shares)
 }
 
 int initialize_cpuset_subsystem (const char *path, libcrun_error_t *err);
+int initialize_cpuset_subsystem_resources (const char *path, runtime_spec_schema_config_linux_resources *resources, libcrun_error_t *err);
 
 int write_cpuset_resources (int dirfd_cpuset, int cgroup2, runtime_spec_schema_config_linux_resources_cpu *cpu, libcrun_error_t *err);
 

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -252,7 +252,7 @@ setup_cpuset_for_systemd_v1 (runtime_spec_schema_config_linux_resources *resourc
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = initialize_cpuset_subsystem (cgroup_path, err);
+  ret = initialize_cpuset_subsystem_resources (cgroup_path, resources, err);
   if (UNLIKELY (ret < 0))
     return ret;
 


### PR DESCRIPTION
if we already know the cpuset, then we should preconfigure the newly created cgroup with those values, instead of using the parent's set. This prevents needless churn in the kernel as it tracks which CPUs have load balancing disabled.