### PR TITLE
handlers: Fix -Werror=unused-parameter build error for spin

### DIFF
--- a/src/libcrun/handlers/spin.c
+++ b/src/libcrun/handlers/spin.c
@@ -52,7 +52,7 @@ spin_exec (void *cookie arg_unused, libcrun_container_t *container arg_unused,
 }
 
 static int
-spin_load (void **cookie, libcrun_error_t *err)
+spin_load (void **cookie arg_unused, libcrun_error_t *err)
 {
   struct stat st = { 0 };
   if (stat ("/usr/local/bin/spin", &st) == -1)
@@ -90,7 +90,7 @@ spin_configure_container (void *cookie arg_unused, enum handler_configure_phase 
 }
 
 static int
-spin_unload (void *cookie, libcrun_error_t *err)
+spin_unload (void *cookie arg_unused, libcrun_error_t *err arg_unused)
 {
   return 0;
 }


### PR DESCRIPTION
Fix the build with "./configure CFLAGS='-Wall -Wextra -Werror' --with-spin=yes"

	src/libcrun/handlers/spin.c: In function 'spin_load':
	src/libcrun/handlers/spin.c:55:19: error: unused parameter 'cookie' [-Werror=unused-parameter]
	   55 | spin_load (void **cookie, libcrun_error_t *err)
	      |            ~~~~~~~^~~~~~
	src/libcrun/handlers/spin.c: In function 'spin_unload':
	src/libcrun/handlers/spin.c:93:20: error: unused parameter 'cookie' [-Werror=unused-parameter]
	   93 | spin_unload (void *cookie, libcrun_error_t *err)
	      |              ~~~~~~^~~~~~
	src/libcrun/handlers/spin.c:93:45: error: unused parameter 'err' [-Werror=unused-parameter]
	   93 | spin_unload (void *cookie, libcrun_error_t *err)
	      |                            ~~~~~~~~~~~~~~~~~^~~
	cc1: all warnings being treated as errors