### PR TITLE
criu: fix error return value

### DIFF
--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -624,8 +624,8 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
     }
 
   ret = libcriu_wrapper->criu_set_freeze_cgroup (freezer_path);
-  if (UNLIKELY (ret != 0))
-    return crun_make_error (err, ret, "CRIU: failed setting freezer %d", ret);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, -ret, "CRIU: failed setting freezer %d", ret);
 
   /* Set boolean options . */
   libcriu_wrapper->criu_set_leave_running (cr_options->leave_running);


### PR DESCRIPTION

criu_set_freeze_cgroup() returns `0` or `-ENOMEM`

https://github.com/checkpoint-restore/criu/blob/criu-dev/lib/c/criu.c#L653

The ENOMEM error is disregarded in this if statement
https://github.com/containers/crun/blob/ab6fd3fe3b03a3459d7ad21cd390df5a51a94ada/src/libcrun/container.c#L4064

I also replaced `!=` with `<` to protect against the the possibility tha criu_set_freeze_cgroup() in the future is modified to return `1`. I'm not sure about this part in the PR. What do you think?
