### PR TITLE
ctx: drop no_subreaper bool

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -50,7 +50,7 @@ static struct argp_option options[]
         { "preserve-fds", OPTION_PRESERVE_FDS, "N", 0, "pass additional FDs to the container", 0 },
         { "no-pivot", OPTION_NO_PIVOT, 0, 0, "do not use pivot_root", 0 },
         { "pid-file", OPTION_PID_FILE, "FILE", 0, "where to write the PID of the container", 0 },
-        { "no-subreaper", OPTION_NO_SUBREAPER, 0, 0, "do not create a subreaper process", 0 },
+        { "no-subreaper", OPTION_NO_SUBREAPER, 0, 0, "do not create a subreaper process (ignored)", 0 },
         { "no-new-keyring", OPTION_NO_NEW_KEYRING, 0, 0, "keep the same session key", 0 },
         {
             0,
@@ -84,7 +84,6 @@ parse_opt (int key, char *arg, struct argp_state *state)
       break;
 
     case OPTION_NO_SUBREAPER:
-      crun_context.no_subreaper = true;
       break;
 
     case OPTION_NO_PIVOT:

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -53,7 +53,6 @@ struct libcrun_context_s
 
   bool systemd_cgroup;
   bool detach;
-  bool no_subreaper;
   bool no_new_keyring;
   bool force_no_cgroup;
   bool no_pivot;

--- a/src/run.c
+++ b/src/run.c
@@ -89,7 +89,6 @@ parse_opt (int key, char *arg, struct argp_state *state)
       break;
 
     case OPTION_NO_SUBREAPER:
-      crun_context.no_subreaper = true;
       break;
 
     case OPTION_NO_NEW_KEYRING:


### PR DESCRIPTION
it was initially added for compatibility with runc but it was never implemented, so let's clean it up.

Closes: https://github.com/containers/crun/issues/1369