### PR TITLE
fix checking of relative idmapped mount

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -512,7 +512,7 @@ parse_idmapped_mount_option (runtime_spec_schema_config_schema *def, bool is_uid
           mappings = is_uids ? def->linux->uid_mappings : def->linux->gid_mappings;
 
           for (i = 0; i < mappings_len; i++)
-            if (value[0] >= mappings[i]->container_id && value[0] < mappings[i]->container_id + mappings[i]->size)
+            if (value[1] >= mappings[i]->container_id && value[1] < mappings[i]->container_id + mappings[i]->size)
               break;
 
           if (i == mappings_len)


### PR DESCRIPTION
id mapped mount is specified in terms of `host_filesystem_id:maped_id:range` or `@host_filesystem_id:container_id:range`. When looking up the relative container_id, one should check value[1] (the id we map to) instead of value[0] (the id we map from).

---
I realized the bug when trying to do thing described in containers/podman#20960. I was doing something like `idmap=uids=@1000-0-1` hoping to let uid 0 in container capable to access files owned by uid 1000 on disk, while I got the error:
```
Error: could not find a user namespace mapping for the relative mapping "@1000-0-1"
```
that doesn't make sense.