### PR TITLE
error: reset pointer after vasprintf failure

### DIFF
--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -81,6 +81,7 @@ crun_error_wrap (libcrun_error_t *err, const char *fmt, ...)
   if (vasprintf (&msg, fmt, args_list) < 0)
     {
       va_end (args_list);
+      msg = NULL;
       return ret;
     }
   va_end (args_list);


### PR DESCRIPTION
Quote from
https://www.kernel.org/doc/man-pages/online/pages/man3/vasprintf.3.html
"_If memory allocation wasn't possible, or some other error occurs, these functions will return -1, and the contents of strp are undefined._"

Is there a need to reset the pointer?
