### PR TITLE
cgroup: use "max" when pids limit < 0

### DIFF
--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -683,13 +683,14 @@ write_devices_resources (int dirfd, bool cgroup2, runtime_spec_schema_defs_linux
 
 /* use for cgroupv2 files with .min, .max, .low, or .high suffix */
 static int
-cg_itoa (char *buf, int64_t value, bool cgroup2)
+cg_itoa (char *buf, int64_t value, bool use_max)
 {
-  if (! (cgroup2 && value == -1))
-    return sprintf (buf, "%" PRIi64, value);
-
-  memcpy (buf, "max", 4);
-  return 3;
+  if (use_max && value < 0)
+    {
+      memcpy (buf, "max", 4);
+      return 3;
+    }
+  return sprintf (buf, "%" PRIi64, value);
 }
 
 static int
@@ -912,7 +913,7 @@ write_pids_resources (int dirfd, bool cgroup2, runtime_spec_schema_config_linux_
       size_t len;
       int ret;
 
-      len = cg_itoa (fmt_buf, pids->limit, cgroup2);
+      len = cg_itoa (fmt_buf, pids->limit, true);
       ret = write_file_and_check_controllers_at (cgroup2, dirfd, "pids.max", NULL, fmt_buf, len, err);
       if (UNLIKELY (ret < 0))
         return ret;

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -17,6 +17,18 @@
 
 from tests_utils import *
 
+def test_limit_pid_minus_1():
+    conf = base_config()
+    add_all_namespaces(conf)
+    if is_rootless():
+        return 77
+    conf['process']['args'] = ['/init', 'cat', '/dev/null']
+    conf['linux']['resources'] = {"pids" : {"limit" : -1}}
+    out, _ = run_and_get_output(conf)
+    if len(out) == 0:
+        return 0
+    return -1
+
 def test_limit_pid_0():
     conf = base_config()
     add_all_namespaces(conf)
@@ -44,6 +56,7 @@ def test_limit_pid_n():
     return -1
 
 all_tests = {
+    "limit-pid-minus-1" : test_limit_pid_minus_1,
     "limit-pid-0" : test_limit_pid_0,
     "limit-pid-n" : test_limit_pid_n,
 }


### PR DESCRIPTION
use the value "max" also on cgroup v1 when the pids limit specified is < 0.