### PR TITLE
Improve Python API

### DIFF
--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -121,7 +121,7 @@ make_context (PyObject *self arg_unused, PyObject *args, PyObject *kwargs)
   char *state_root = NULL;
   char *notify_socket = NULL;
   static char *kwlist[] =
-    { "id", "bundle", "state-root", "systemd-cgroup", "notify-socket", "detach", NULL };
+    { "id", "bundle", "state-root", "systemd-cgroup", "notify-socket", "detach", "no_new_keyring", NULL };
   libcrun_context_t *ctx = malloc (sizeof (*ctx));
   if (ctx == NULL)
     return NULL;
@@ -130,8 +130,8 @@ make_context (PyObject *self arg_unused, PyObject *args, PyObject *kwargs)
   ctx->fifo_exec_wait_fd = -1;
 
   if (!PyArg_ParseTupleAndKeywords
-      (args, kwargs, "s|ssbsb", kwlist, &id, &bundle, &state_root,
-       &ctx->systemd_cgroup, &notify_socket, &ctx->detach))
+      (args, kwargs, "s|ssbsbb", kwlist, &id, &bundle, &state_root,
+       &ctx->systemd_cgroup, &notify_socket, &ctx->detach, &ctx->no_new_keyring))
     return NULL;
 
   ctx->id = xstrdup (id);

--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -121,7 +121,7 @@ make_context (PyObject *self arg_unused, PyObject *args, PyObject *kwargs)
   char *state_root = NULL;
   char *notify_socket = NULL;
   static char *kwlist[] =
-    { "id", "bundle", "state-root", "systemd-cgroup", "notify-socket", "detach", "no_new_keyring", NULL };
+    { "id", "bundle", "state_root", "systemd_cgroup", "notify_socket", "detach", "no_new_keyring", NULL };
   libcrun_context_t *ctx = malloc (sizeof (*ctx));
   if (ctx == NULL)
     return NULL;

--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -121,7 +121,7 @@ make_context (PyObject *self arg_unused, PyObject *args, PyObject *kwargs)
   char *state_root = NULL;
   char *notify_socket = NULL;
   static char *kwlist[] =
-    { "id", "bundle", "state_root", "systemd_cgroup", "notify_socket", "detach", "no_new_keyring", NULL };
+    { "id", "bundle", "state_root", "systemd_cgroup", "notify_socket", "detach", "no_new_keyring", "force_no_cgroup", "no_pivot", NULL };
   libcrun_context_t *ctx = malloc (sizeof (*ctx));
   if (ctx == NULL)
     return NULL;
@@ -130,8 +130,8 @@ make_context (PyObject *self arg_unused, PyObject *args, PyObject *kwargs)
   ctx->fifo_exec_wait_fd = -1;
 
   if (!PyArg_ParseTupleAndKeywords
-      (args, kwargs, "s|ssbsbb", kwlist, &id, &bundle, &state_root,
-       &ctx->systemd_cgroup, &notify_socket, &ctx->detach, &ctx->no_new_keyring))
+      (args, kwargs, "s|ssbsbbbb", kwlist, &id, &bundle, &state_root,
+       &ctx->systemd_cgroup, &notify_socket, &ctx->detach, &ctx->no_new_keyring, &ctx->force_no_cgroup, &ctx->no_pivot))
     return NULL;
 
   ctx->id = xstrdup (id);


### PR DESCRIPTION
Hi there,

I was playing around with the Python API a bit and noticed that in `make_context()`

- parameter names used dashes, making them invalid Python identifiers, and that
- a few boolean flags offered by `libcrun_context_t` were missing. (*)

My changes fix the above issues. 

*) As are a couple other non-boolean parameters but since I lack experience with both crun and the Python C API I wanted to focus on the simple cases first.

Since this is my first PR, please let me know if there's anything that's missing or there are any contribution guidelines I should follow. (I couldn't find anything in the README.)

PS: Seeing that tests for the crun CLI are written in Python, would it make sense to also add Python tests for the Python API?
