### PR TITLE
cgroup, systemd: fix segfault if resources not specified

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -210,7 +210,7 @@ setup_missing_cpu_options_for_systemd (runtime_spec_schema_config_linux_resource
   int parent;
   int ret;
 
-  if (resources->cpu == NULL)
+  if (resources == NULL || resources->cpu == NULL)
     return 0;
 
   if (! resources->cpu->burst_present)


### PR DESCRIPTION
fix a segfault when the "resources" block is not specified and '--systemd-cgroup' is used.

Closes: https://github.com/containers/crun/issues/1402