### PR TITLE
ebpf: add fallback when bpf(2) fails

### DIFF
--- a/src/libcrun/ebpf.c
+++ b/src/libcrun/ebpf.c
@@ -451,9 +451,22 @@ static void
 bump_memlock ()
 {
   struct rlimit limit;
+  int ret;
 
   limit.rlim_cur = RLIM_INFINITY;
   limit.rlim_max = RLIM_INFINITY;
+
+  ret = setrlimit (RLIMIT_MEMLOCK, &limit);
+  if (ret == 0)
+    return;
+
+  /* If the above failed, try to set the current limit
+     to the max configured.  */
+  ret = getrlimit (RLIMIT_MEMLOCK, &limit);
+  if (ret < 0)
+    return;
+
+  limit.rlim_cur = limit.rlim_max;
   /* Best effort, ignore errors.  */
   (void) setrlimit (RLIMIT_MEMLOCK, &limit);
 }

--- a/src/libcrun/ebpf.c
+++ b/src/libcrun/ebpf.c
@@ -496,12 +496,15 @@ libcrun_ebpf_load (struct bpf_program *program, int dirfd, const char *pin, libc
   fd = bpf (BPF_PROG_LOAD, &attr, sizeof (attr));
   if (fd < 0)
     {
-      const size_t log_size = 8192;
-      cleanup_free char *log = xmalloc (log_size);
-
       /* Prior to Linux 5.11, eBPF programs were accounted to the memlock
          prlimit.  Attempt to bump the limit, if possible.  */
       bump_memlock ();
+      fd = bpf (BPF_PROG_LOAD, &attr, sizeof (attr));
+    }
+  if (fd < 0)
+    {
+      const size_t log_size = 8192;
+      cleanup_free char *log = xmalloc (log_size);
 
       log[0] = '\0';
       attr.log_level = 1;


### PR DESCRIPTION
commit 93064574a09df639f5f66f73733f41a9b611109b was too eager to use the same fallback with a log, and that could fail for other reasons (e.g. not enough buffer space).  Add a fallback without using the log, so that on kernels older than 5.11 we have a better chance of success.
    
Closes: https://github.com/containers/crun/issues/1400
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>