### PR TITLE
Revert "apparmor: stack apparmor profiles if nnp and confined"

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3232,7 +3232,7 @@ int
 libcrun_set_apparmor_profile (runtime_spec_schema_config_schema_process *proc, bool now, libcrun_error_t *err)
 {
   if (proc->apparmor_profile)
-    return set_apparmor_profile (proc->apparmor_profile, proc->no_new_privileges, now, err);
+    return set_apparmor_profile (proc->apparmor_profile, now, err);
   return 0;
 }
 

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -293,7 +293,7 @@ int set_selinux_label (const char *label, bool now, libcrun_error_t *err);
 
 int add_selinux_mount_label (char **ret, const char *data, const char *label, const char *context_type, libcrun_error_t *err);
 
-int set_apparmor_profile (const char *profile, bool no_new_privileges, bool now, libcrun_error_t *err);
+int set_apparmor_profile (const char *profile, bool now, libcrun_error_t *err);
 
 int read_all_fd_with_size_hint (int fd, const char *description, char **out, size_t *len, size_t hint, libcrun_error_t *err);
 


### PR DESCRIPTION
When running with Ubuntu 22.04, ingress-nginx-controller report `failed (13: Permission denied)` as below:

    # kubectl -n ingress-nginx logs -f ingress-nginx-controller-5d48c4cb7c-2hkx4
    E0130 14:20:01.167583       2 controller.go:205] Unexpected failure reloading the backend:
    exit status 1
    2024/01/30 14:20:00 [notice] 198#198: signal process started
    2024/01/30 14:20:00 [alert] 198#198: kill(18, 1) failed (13: Permission denied)
    nginx: [alert] kill(18, 1) failed (13: Permission denied)
    E0130 14:20:01.167642       2 queue.go:131] "requeuing" err=<
            exit status 1
            2024/01/30 14:20:00 [notice] 198#198: signal process started
            2024/01/30 14:20:00 [alert] 198#198: kill(18, 1) failed (13: Permission denied)
            nginx: [alert] kill(18, 1) failed (13: Permission denied)

As https://github.com/containers/crun/pull/1405#issuecomment-1917095904 suggested, revert the AppArmors changes from https://github.com/containers/crun/pull/1386 solve the issue.

This reverts commit 5078ce6a3c44a379bb6eb3ea42a2c469f79f08f9.