### PR TITLE
linux: harden chdir

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1293,11 +1293,8 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
     if (UNLIKELY (chdir (def->process->cwd) < 0))
       return crun_make_error (err, errno, "chdir `%s`", def->process->cwd);
 
-  if (notify_socket)
-    {
-      if (putenv (notify_socket) < 0)
-        return crun_make_error (err, errno, "putenv `%s`", notify_socket);
-    }
+  if (notify_socket && putenv (notify_socket) < 0)
+    return crun_make_error (err, errno, "putenv `%s`", notify_socket);
 
   return 0;
 }

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -143,4 +143,6 @@ int libcrun_destroy_intelrdt (const char *name, libcrun_error_t *err);
 
 int libcrun_update_intel_rdt (const char *ctr_name, libcrun_container_t *container, const char *l3_cache_schema, const char *mem_bw_schema, libcrun_error_t *err);
 
+int libcrun_safe_chdir (const char *path, libcrun_error_t *err);
+
 #endif


### PR DESCRIPTION
there was recently a security vulnerability (CVE-2024-21626) that allowed a malicious user to chdir(2) to a /proc/*/fd entry that is outside the container rootfs.  While crun is not affected directly, harden chdir by validating that we are still inside the container rootfs.