### PR TITLE
apparmor: use stacking as fallback

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3232,7 +3232,7 @@ int
 libcrun_set_apparmor_profile (runtime_spec_schema_config_schema_process *proc, bool now, libcrun_error_t *err)
 {
   if (proc->apparmor_profile)
-    return set_apparmor_profile (proc->apparmor_profile, proc->no_new_privileges, now, err);
+    return set_apparmor_profile (proc->apparmor_profile, now, err);
   return 0;
 }
 

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -293,7 +293,7 @@ int set_selinux_label (const char *label, bool now, libcrun_error_t *err);
 
 int add_selinux_mount_label (char **ret, const char *data, const char *label, const char *context_type, libcrun_error_t *err);
 
-int set_apparmor_profile (const char *profile, bool no_new_privileges, bool now, libcrun_error_t *err);
+int set_apparmor_profile (const char *profile, bool now, libcrun_error_t *err);
 
 int read_all_fd_with_size_hint (int fd, const char *description, char **out, size_t *len, size_t hint, libcrun_error_t *err);
 


### PR DESCRIPTION
commit 5078ce6a3c44a379bb6eb3ea42a2c469f79f08f9 introduced a regression that affected some containers.  Change the mechanism for using the "stack" command, as it is now a fallback to use when the previous method failed.

Alternative to: https://github.com/containers/crun/pull/1406