### PR TITLE
rpm: Use relative, not absolute, symbolic links

### DIFF
--- a/rpm/crun.spec
+++ b/rpm/crun.spec
@@ -116,11 +116,11 @@ Recommends: wasmedge
 rm -rf %{buildroot}%{_prefix}/lib*
 
 %if %{defined krun_support}
-ln -s %{_bindir}/%{name} %{buildroot}%{_bindir}/krun
+ln -s %{name} %{buildroot}%{_bindir}/krun
 %endif
 
 %if %{defined wasm_support}
-ln -s %{_bindir}/%{name} %{buildroot}%{_bindir}/%{name}-wasm
+ln -s %{name} %{buildroot}%{_bindir}/%{name}-wasm
 %endif
 
 %files


### PR DESCRIPTION
Currently, the Fedora Packaging Guidelines don't choose sides between absolute and relative symbolic links [1], but RPM does [2,3].  Building the crun RPM with absolute symlinks leads to:
```
  ...
  warning: absolute symlink: /usr/bin/krun -> /usr/bin/crun
  ...
  warning: absolute symlink: /usr/bin/crun-wasm -> /usr/bin/crun
  ...
  RPM build warnings:
    absolute symlink: /usr/bin/krun -> /usr/bin/crun
    absolute symlink: /usr/bin/crun-wasm -> /usr/bin/crun
  ...
```

Given the prevalence of chroot-like environments these days due to bind mounts in containers, relative symbolic links do look like the better alternative, and various prominent parts of the operating system already use them.  Some examples:
  * /etc/localtime -> ../usr/share/zoneinfo/Europe/Prague
  * /etc/mtab -> ../proc/self/mounts
  * /etc/os-release -> ../usr/lib/os-release
  * /usr/bin/dnf -> dnf-3
  * /usr/bin/ghostscript -> /usr/bin/gs
  * /usr/bin/gpg2 -> gpg
  * /usr/bin/python -> ./python3
  * /usr/bin/python3 -> python3.11
  * /usr/bin/qemu-kvm -> qemu-system-x86_64
  * /usr/bin/systemd-resolve -> resolvectl
  * /usr/bin/systemd-umount -> systemd-mount
  * /usr/bin/traceroute6 -> traceroute
  * /usr/bin/unxz -> xz

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/#_symlinks

[2] https://github.com/rpm-software-management/rpm/issues/668

[3] https://github.com/rpm-software-management/rpm/issues/2419