### PR TITLE
rpm: remove eln macro

### DIFF
--- a/rpm/crun.spec
+++ b/rpm/crun.spec
@@ -6,8 +6,7 @@
 %ifarch aarch64 || x86_64
 %global wasm_support 1
 
-# wasmedge not present on Fedora ELN environments
-%if !0%{?eln}
+%if %{defined fedora} || %{defined copr_project}
 %global wasmedge_support 1
 %global wasmedge_opts --with-wasmedge
 %endif


### PR DESCRIPTION
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2271814

wasmedge is enabled for all official Fedora and for all copr build jobs.
