### PR TITLE
linux: fixup libcrun_safe_chdir

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5753,7 +5753,7 @@ libcrun_safe_chdir (const char *path, libcrun_error_t *err)
         when it is not reachable from the current mount namespace.
         Use it to give a better error message.
       */
-#define UNREACHABLE "unreachable"
+#define UNREACHABLE "(unreachable)"
 #define UNREACHABLE_LEN ((int) sizeof (UNREACHABLE) - 1)
 
       if ((ret >= UNREACHABLE_LEN) && (memcmp (buffer, UNREACHABLE, UNREACHABLE_LEN) == 0))


### PR DESCRIPTION
The check for "unreachable" for better error message won't work because of the missing parentheses, i.e. it needs to be "(unreachable)" (as the comment says).

Fixes: adb912d ("linux: harden chdir()")