### PR TITLE
features: add support for potentiallyUnsafeConfigAnnotations

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -359,6 +359,12 @@ static const char *spec_cgroupns = "\
 				\"type\": \"cgroup\"\n\
 			},\n";
 
+static char *potentially_unsafe_annotations[] = {
+  "module.wasm.image/variant",
+  "io.kubernetes.cri.container-type",
+  "run.oci.",
+};
+
 #define SYNC_SOCKET_MESSAGE_LEN(x, l) (offsetof (struct sync_socket_message_s, message) + l)
 
 static int
@@ -3944,6 +3950,7 @@ libcrun_container_get_features (libcrun_context_t *context, struct features_info
   size_t num_actions = sizeof (actions) / sizeof (actions[0]);
   size_t num_hooks = sizeof (hooks) / sizeof (hooks[0]);
   size_t num_archs = sizeof (archs) / sizeof (archs[0]);
+  size_t num_unsafe_annotations = sizeof (potentially_unsafe_annotations) / sizeof (potentially_unsafe_annotations[0]);
   cleanup_free char **capabilities = NULL;
   size_t num_capabilities = 0;
 
@@ -4016,6 +4023,8 @@ libcrun_container_get_features (libcrun_context_t *context, struct features_info
 #endif
   (*info)->annotations.run_oci_crun_commit = GIT_VERSION;
   (*info)->annotations.run_oci_crun_version = PACKAGE_VERSION;
+
+  populate_array_field (&((*info)->potentially_unsafe_annotations), potentially_unsafe_annotations, num_unsafe_annotations);
 
   return 0;
 }

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -170,6 +170,7 @@ struct features_info_s
   char **mount_options;
   struct linux_info_s linux;
   struct annotations_info_s annotations;
+  char **potentially_unsafe_annotations;
 };
 
 struct libcrun_checkpoint_restore_s

--- a/src/oci_features.c
+++ b/src/oci_features.c
@@ -230,6 +230,12 @@ crun_features_add_annotations_info (yajl_gen json_gen, const struct annotations_
   yajl_gen_map_close (json_gen);
 }
 
+void
+crun_features_add_potentially_unsafe_config_annotations_info (yajl_gen json_gen, char **annotations)
+{
+  add_array_to_json (json_gen, "potentiallyUnsafeConfigAnnotations", annotations);
+}
+
 int
 crun_command_features (struct crun_global_arguments *global_args, int argc, char **argv, libcrun_error_t *err)
 {
@@ -278,6 +284,9 @@ crun_command_features (struct crun_global_arguments *global_args, int argc, char
 
   // Add annotations struct info
   crun_features_add_annotations_info (json_gen, &info->annotations);
+
+  // Add potentially unsafe config annotatinos info
+  crun_features_add_potentially_unsafe_config_annotations_info (json_gen, info->potentially_unsafe_annotations);
 
   // End building the JSON
   yajl_gen_map_close (json_gen);

--- a/tests/test_oci_features.py
+++ b/tests/test_oci_features.py
@@ -167,7 +167,12 @@ def test_crun_features():
                 "org.opencontainers.runc.checkpoint.enabled": "true",
                 "run.oci.checkpoint.enabled": "true",
                 "run.oci.commit": get_crun_commit(),
-            }
+            },
+            "potentiallyUnsafeConfigAnnotations": [
+                "module.wasm.image/variant",
+                "io.kubernetes.cri.container-type",
+                "run.oci.",
+            ]
         }
 
         systemd_enabled = is_systemd_enabled()


### PR DESCRIPTION
list generated by finding all instances of `find_annotation`

(note to reviewer: I don't know if they're all unsafe and I probably will  end up omitting some, per your request)