### PR TITLE
Fix cleanup of /run/crun state dir when cgroup failed to mount

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1353,9 +1353,12 @@ do_mount_cgroup_v2 (libcrun_container_t *container, int targetfd, const char *ta
                           if (LIKELY (ret == 0))
                             return 0;
 
+                          /* Best-effort cleanup of now-unused temporary mount */
+                          umount2 (tmp_mount_dir, MNT_DETACH);
                           crun_error_release (err);
                         }
                     }
+                  rmdir (tmp_mount_dir);
                 }
 
               ret = do_mount (container, "tmpfs", targetfd, target, "tmpfs", MS_PRIVATE, "nr_blocks=1,nr_inodes=1", LABEL_NONE, err);


### PR DESCRIPTION
This fixes a regression introduced in crun 1.9.1 with https://github.com/containers/crun/commit/523eed3f0f4b3ba59f002fae3fb95f7d570115e3

When running a container with /sys/fs/cgroup already mounted (e.g. --volume=/sys:/sys) and another shared volume somewhere (e.g. --volume=/mnt:/mnt:shared), the move mount fails with EINVAL:
```
mount("/run/crun/6d75ef05e540486f21ef54743f8af97f4dff0d0d7c54d9b7852cd5302e884db8/tmpmount", "/proc/self/fd/8", NULL, MS_MOVE, NULL) = -1 EINVAL (Invalid argument)
```

This leaves tmpmount as a mountpoint behind, which then fails to cleanup:
```
openat(AT_FDCWD, "/run/crun", O_RDONLY|O_CLOEXEC|O_DIRECTORY) = 3
openat(3, "0d1342f7a7375593813287c743170bb71f30f9a64fa8bc141d3cf9b8e9aa5a89", O_RDONLY|O_DIRECTORY) = 4
unlinkat(4, "tmpmount", 0) = -1 EISDIR (Is a directory)
unlinkat(4, "tmpmount", AT_REMOVEDIR) = -1 EBUSY (Device or resource busy)
close(4)                   = 0
unlinkat(3, "0d1342f7a7375593813287c743170bb71f30f9a64fa8bc141d3cf9b8e9aa5a89", AT_REMOVEDIR) = -1 ENOTEMPTY (Directory not empty)
```

This in turn ultimately fails libcrun_container_delete_status() and friends, leading to the non-execution of post hooks in this reproducer:

```
$ mkdir hooks.d
$ cat > hooks.d/hook.json <<'EOF'
{
  "version": "1.0.0",
  "when": {"always": true},
  "hook": {
    "path": "/bin/sh",
    "args": ["/bin/sh", "-c", "date >> /tmp/hookme"]
  },
  "stages": ["poststop"]
}
EOF
$ podman --runtime=path/crun run  \
    --net=none --name test -d --replace --hooks-dir=$PWD/hooks.d \
    --volume=/sys:/sys --volume=/mnt:/mnt:shared \
    docker.io/alpine true
```

(the hook is eventually run on podman rm, but not by crun immediately on container stop)


This PR has two commits, either of which fix this issue:
- the first one umounts when the move mount failed, not leaving a mountpoint behind
- the second allows cleaning up such stray mounts

happy to drop either commit, but I think it's worth keeping the safety as such mount points are easy to forget.