### PR TITLE
linux: fix mount of special files with rro

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2279,7 +2279,7 @@ do_mounts (libcrun_container_t *container, int rootfsfd, const char *rootfs, con
           const bool is_dir = S_ISDIR (src_mode);
           cleanup_close int dfd = -1;
 
-          dfd = safe_openat (rootfsfd, rootfs, rootfs_len, target, O_CLOEXEC | (is_dir ? O_DIRECTORY : 0), 0, err);
+          dfd = safe_openat (rootfsfd, rootfs, rootfs_len, target, O_RDONLY | O_PATH | O_CLOEXEC | (is_dir ? O_DIRECTORY : 0), 0, err);
           if (UNLIKELY (dfd < 0))
             return crun_make_error (err, errno, "open mount target `/%s`", target);
 

--- a/tests/init.c
+++ b/tests/init.c
@@ -455,6 +455,51 @@ main (int argc, char **argv)
       return 0;
     }
 
+  if (strcmp (argv[1], "type") == 0)
+    {
+      struct stat st;
+
+      if (argc < 3)
+        error (EXIT_FAILURE, 0, "'type' requires two arguments");
+      if (stat (argv[2], &st) < 0)
+        error (EXIT_FAILURE, errno, "stat %s", argv[2]);
+
+      switch (st.st_mode & S_IFMT)
+        {
+        case S_IFBLK:
+          printf ("block device\n");
+          break;
+        case S_IFCHR:
+          printf ("character device\n");
+          break;
+
+        case S_IFDIR:
+          printf ("directory\n");
+          break;
+
+        case S_IFIFO:
+          printf ("FIFO/pipe\n");
+          break;
+
+        case S_IFLNK:
+          printf ("symlink\n");
+          break;
+
+        case S_IFREG:
+          printf ("regular file\n");
+          break;
+
+        case S_IFSOCK:
+          printf ("socket\n");
+          break;
+
+        default:
+          printf ("unknown?\n");
+          break;
+        }
+      return 0;
+    }
+
   if (strcmp (argv[1], "owner") == 0)
     {
       struct stat st;


### PR DESCRIPTION
open the mount target with O_PATH to prevent open(2) failures with special files like FIFOs or UNIX sockets.

Closes: https://github.com/containers/crun/issues/1463