### PR TITLE
Packit: Fixes for RHEL, CentOS Stream and COPR, TMT: more generic testing prep steps to minimize distro conditionals

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -40,12 +40,22 @@ jobs:
     packages: [crun-centos]
     notifications: *copr_build_failure_notification
     targets:
-      - epel-9-x86_64
-      - epel-9-aarch64
-      - centos-stream-9-x86_64
-      - centos-stream-9-aarch64
-      - centos-stream-10-x86_64
-      - centos-stream-10-aarch64
+      epel-9-x86_64: {}
+      epel-9-aarch64: {}
+      # Need epel9 repos to fetch wasmedge build dependency
+      centos-stream-9-x86_64:
+        additional_repos:
+          - https://kojipkgs.fedoraproject.org/repos/epel9-build/latest/x86_64
+      centos-stream-9-aarch64:
+        additional_repos:
+          - https://kojipkgs.fedoraproject.org/repos/epel9-build/latest/aarch64
+      # Use epel9 repos until epel10 is available
+      centos-stream-10-x86_64:
+        additional_repos:
+          - https://kojipkgs.fedoraproject.org/repos/epel9-build/latest/x86_64
+      centos-stream-10-aarch64:
+        additional_repos:
+          - https://kojipkgs.fedoraproject.org/repos/epel9-build/latest/aarch64
 
   # Run on commit to main branch
   - job: copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -60,6 +60,7 @@ jobs:
   # Run on commit to main branch
   - job: copr_build
     trigger: commit
+    packages: [crun-fedora]
     notifications:
       failure_comment:
         message: "podman-next COPR build failed. @containers/packit-build please check."

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -49,13 +49,9 @@ jobs:
       centos-stream-9-aarch64:
         additional_repos:
           - https://kojipkgs.fedoraproject.org/repos/epel9-build/latest/aarch64
-      # Use epel9 repos until epel10 is available
-      centos-stream-10-x86_64:
-        additional_repos:
-          - https://kojipkgs.fedoraproject.org/repos/epel9-build/latest/x86_64
-      centos-stream-10-aarch64:
-        additional_repos:
-          - https://kojipkgs.fedoraproject.org/repos/epel9-build/latest/aarch64
+      # TODO: build on CS10 with wasmedge once epel-10 is available
+      centos-stream-10-x86_64: {}
+      centos-stream-10-aarch64: {}
 
   - job: copr_build
     trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,6 +11,8 @@ packages:
   crun-centos:
     pkg_tool: centpkg
     specfile_path: rpm/crun.spec
+  crun-rhel:
+    specfile_path: rpm/crun.spec
 
 srpm_build_deps:
   - git-archive-all
@@ -40,8 +42,6 @@ jobs:
     packages: [crun-centos]
     notifications: *copr_build_failure_notification
     targets:
-      epel-9-x86_64: {}
-      epel-9-aarch64: {}
       # Need epel9 repos to fetch wasmedge build dependency
       centos-stream-9-x86_64:
         additional_repos:
@@ -56,6 +56,14 @@ jobs:
       centos-stream-10-aarch64:
         additional_repos:
           - https://kojipkgs.fedoraproject.org/repos/epel9-build/latest/aarch64
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [crun-rhel]
+    notifications: *copr_build_failure_notification
+    targets:
+      - epel-9-x86_64
+      - epel-9-aarch64
 
   # Run on commit to main branch
   - job: copr_build
@@ -99,7 +107,7 @@ jobs:
   # Podman system tests for RHEL
   - job: tests
     trigger: pull_request
-    packages: [crun-centos]
+    packages: [crun-rhel]
     use_internal_tf: true
     notifications: *podman_system_test_fail_notification
     targets:

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,39 +1,33 @@
-## Note: "order" is set to 50 by default. Orders with lower values are
-## prioritized.
-## Ref: https://tmt.readthedocs.io/en/stable/spec/core.html#order
+prepare+:
+    - name: Install bats
+      how: shell
+      script: |
+        BATS_VERSION=1.11.0
+        curl -s -L -O https://github.com/bats-core/bats-core/archive/refs/tags/v$BATS_VERSION.tar.gz
+        tar zxf v$BATS_VERSION.tar.gz
+        cd bats-core-$BATS_VERSION
+        ./install.sh /usr
 
-adjust:
-    - when: distro != fedora
-      prepare+:
-        - how: shell
-          order: 20
-          script: rpm -q epel-release || dnf -y install https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/e/epel-release-9-7.el9.noarch.rpm
-      because: Need `bats` to run podman system tests, present by default on Fedora but RHEL and CentOS Stream need to use EPEL repos.
-    - when: distro == fedora
-      prepare+:
-        - how: shell
-          order: 20
-          script:  dnf config-manager --set-disabled testing-farm-tag-repository
-      because: We don't want to use this repository for Fedora tests.
-    - when: distro != centos-stream-10 and distro != rhel-10
-      prepare+:
-        - how: shell
-          order: 30
-          script: dnf -y copr enable rhcontainerbot/podman-next
-      because: We can't use the idiomatic `copr` key globally because of non-default instructions for centos-stream-10.
-    - when: distro == centos-stream-10 or distro == rhel-10
-      prepare+:
-        - how: shell
-          order: 30
-          script: |
-            sed -i "s/\$releasever/9/g" /etc/yum.repos.d/epel.repo
-            dnf -y copr enable rhcontainerbot/podman-next centos-stream-10
-      because: The default epel-10 target doesn't exist yet.
+    - name: Remove testing-farm dnf repo
+      how: shell
+      script: rm -f /etc/yum.repos.d/testing-farm-tag-repository.repo
 
-prepare:
-    # Ensure podman-next has higher priority than default repos
-    - how: shell
-      script: dnf config-manager --save --setopt="*:rhcontainerbot:podman-next.priority=5"
+    - name: Enable podman-next repo and set it at higher priority than default
+      how: shell
+      script: |
+        CENTOS_VERSION=$(rpm --eval '%{?centos}')
+        RHEL_VERSION=$(rpm --eval '%{?rhel}')
+        if [[ -n $CENTOS_VERSION ]]; then
+            dnf -y copr enable rhcontainerbot/podman-next centos-stream-$CENTOS_VERSION
+        # Need to handle RHEL-10 specially until EPEL-10 is available
+        elif [[ $RHEL_VERSION -ge 10 ]]; then
+            dnf -y copr enable rhcontainerbot/podman-next centos-stream-$RHEL_VERSION
+        else
+            dnf -y copr enable rhcontainerbot/podman-next
+        fi
+        # Bump podman-next copr priority
+        echo "priority=5" >> /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next.repo
+
     # Install packages to run podman revdep tests
     - how: install
       package:

--- a/rpm/crun.spec
+++ b/rpm/crun.spec
@@ -6,7 +6,7 @@
 %ifarch aarch64 || x86_64
 %global wasm_support 1
 
-%if %{defined copr_project}
+%if %{defined copr_username}
 %define copr_build 1
 %endif
 
@@ -22,7 +22,7 @@
 %endif
 
 # wasmtime exists only on podman-next copr for now
-%if %{defined copr_project} && "%{?copr_project}" == "podman-next"
+%if %{defined copr_build} && "%{?copr_projectname}" == "podman-next"
 %global wasmtime_support 1
 %global wasmtime_opts --with-wasmtime
 %endif

--- a/rpm/crun.spec
+++ b/rpm/crun.spec
@@ -10,7 +10,9 @@
 %define copr_build 1
 %endif
 
-%if %{defined fedora} || %{defined copr_build}
+# Disable wasmedge on rhel 10 until EPEL10 is in place, otherwise it causes
+# build issues on copr
+%if %{defined fedora} || (%{defined %copr_build} && %{defined rhel} && 0%{?rhel} < 10)
 %global wasmedge_support 1
 %global wasmedge_opts --with-wasmedge
 %endif


### PR DESCRIPTION
Commit 1: Because of the wrong `copr_project` macro, recent crun builds on copr
didn't actually include the Epoch. We should use either
copr_username, copr_projectname or both. Those 2 macros are only defined
on copr environments.

Commit 2: CentOS Stream builds don't have epel repos configured by default because
of which they can't directly fetch the wasmedge build dependency.

Commit 3: Use `packages: [crun-fedora]` for copr jobs on podman-next after commit to main to avoid duplicate build jobs.

Commit 4: Separate rhel and centos-stream jobs to allow centos stream jobs to run for all PR authors, regardless of access levels.

Commit 5: Differences across distros and versions in components like dnf as well as variable package availability for bats makes idiomatic TMT hard to maintain if we're to install all dependencies using rpm packages. Fetching `bats` from upstream and simply deleting problematic yum repos instead of resorting to tricky dnf commands makes the TMT logic a lot easier to maintain.

Commit 6: COPR/RPM: Disable wasmedge on RHEL10 until EPEL10 is available as wasmedge is only available in epel.

