### PR TITLE
[crun run] Avoid setting crun_context.handler redundantly

### DIFF
--- a/src/run.c
+++ b/src/run.c
@@ -133,8 +133,6 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
 
   crun_context.preserve_fds = 0;
   crun_context.listen_fds = 0;
-  /* Check if global handler is configured and pass it down to crun context */
-  crun_context.handler = global_args->handler;
 
   argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &crun_context);
   crun_assert_n_args (argc - first_arg, 1, 1);


### PR DESCRIPTION
Starting from b3e167dbcda8fe25c26285c4c9f96f2735f1054f the handler is already set in `init_libcrun_context`.