### PR TITLE
restore: update console-socket option description

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -64,7 +64,7 @@ static struct argp_option options[]
         { "detach", 'd', 0, 0, "detach from the container's process", 0 },
         { "pid-file", OPTION_PID_FILE, "FILE", 0, "where to write the PID of the container", 0 },
         { "console-socket", OPTION_CONSOLE_SOCKET, "SOCKET", 0,
-          "path to a socket that will receive the master end of the tty", 0 },
+          "path to a socket that will receive the ptmx end of the tty", 0 },
         { "file-locks", OPTION_FILE_LOCKS, 0, 0, "allow file locks", 0 },
         { "manage-cgroups-mode", OPTION_MANAGE_CGROUPS_MODE, "MODE", 0, "cgroups mode: 'soft' (default), 'ignore', 'full' and 'strict'", 0 },
         {


### PR DESCRIPTION
This pull request updates the description for the `--console-socket` option of the `restore` command for consistency with other crun commands (see https://github.com/containers/crun/commit/65aa6bbeb356e5f757ac046a43c0e21ef8a33c9d).