### PR TITLE
Enable systemd in s390x builds

### DIFF
--- a/nix/default-s390x.nix
+++ b/nix/default-s390x.nix
@@ -1,9 +1,6 @@
-{ enableSystemd ? false }:
+{ enableSystemd ? true }:
 (import ./nixpkgs.nix {
   crossSystem = {
-    # TODO: Switch back to glibc when
-    # https://github.com/NixOS/nixpkgs/issues/306473
-    # is resolved.
     config = "s390x-unknown-linux-musl";
   };
   overlays = [ (import ./overlay.nix) ];


### PR DESCRIPTION
Fixes #1494 

I also removed the comment to "switch back", which we probably will never do.