### PR TITLE
WIP: Use `.gitignore` in nix build excludes

### DIFF
--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -5,7 +5,8 @@
 }:
 with pkgs; stdenv.mkDerivation {
   name = "crun";
-  src = ./..;
+  # Use Pure to avoid exuding the .git directory
+  src = nix-gitignore.gitignoreSourcePure [ ../.gitignore ] ./..;
   vendorSha256 = null;
   doCheck = false;
   enableParallelBuilding = true;


### PR DESCRIPTION
This avoids building with wrong pre-built data locally as well as in CI.