### PR TITLE
Fix sd-bus error handling for cpu quota and period props update.

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -889,12 +889,12 @@ append_resources (sd_bus_message *m,
             quota = ((quota / 10000) + 1) * 10000;
 
           sd_err = sd_bus_message_append (m, "(sv)", "CPUQuotaPerSecUSec", "t", quota);
-          if (UNLIKELY (ret < 0))
-            return ret;
+          if (UNLIKELY (sd_err < 0))
+            return crun_make_error (err, -sd_err, "sd-bus message append CPUQuotaPerSecUSec");
 
           sd_err = sd_bus_message_append (m, "(sv)", "CPUQuotaPeriodUSec", "t", resources->cpu->period);
-          if (UNLIKELY (ret < 0))
-            return ret;
+          if (UNLIKELY (sd_err < 0))
+            return crun_make_error (err, -sd_err, "sd-bus message append CPUQuotaPeriodUSec");
         }
     }
 


### PR DESCRIPTION
This fix changes the error handling for `sd_bus_message_append` execution for two cases:
- update of cpu-quota,
- update of cpu-period.

The previous code was checking wrong variable to determine error and to return the error code downstream.
The bug has been spotted during occasional code review and was not confirmed in any real case scenario. To reproduce the bug I had to modify the source code to trick `sd_bus_message_append` to fail by providing invalid 2nd argument, e.g.

```
- sd_err = sd_bus_message_append (m, "(sv)", "CPUQuotaPerSecUSec", "t", quota);
+ sd_err = sd_bus_message_append (m, "-invalid-value-", "CPUQuotaPerSecUSec", "t", quota);
```

and then run 

```
crun --cgroup-manager=systemd  update --cpu-quota=50000 --cpu-period=100000 <container-id>
```

In this case `crun` should log error and exit with non-zero code. The previous code was ignoring the error.
