### PR TITLE
cgroup-systemd: check for sd_bus_message_append error

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1106,6 +1106,11 @@ enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *resource
     }
 
   sd_err = sd_bus_message_append (m, "(sv)", "DefaultDependencies", "b", 0);
+  if (UNLIKELY (sd_err < 0))
+    {
+      ret = crun_make_error (err, -sd_err, "sd-bus message append DefaultDependencies");
+      goto exit;
+    }
 
   for (i = 0; boolean_opts[i]; i++)
     {


### PR DESCRIPTION
Check if sd_bus_message_append() returns an error.