### PR TITLE
add --parent-rootfs <dir> to run command

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1153,6 +1153,13 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
 
   if (rootfs)
     {
+      if (entrypoint_args->context->parent_rootfs)
+        {
+          ret = libcrun_do_parent_rootfs (entrypoint_args->context->parent_rootfs, err);
+          if (UNLIKELY (ret < 0))
+            return ret;
+        }
+
       ret = libcrun_do_pivot_root (container, entrypoint_args->context->no_pivot, rootfs, err);
       if (UNLIKELY (ret < 0))
         return ret;

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -56,6 +56,7 @@ struct libcrun_context_s
   bool no_new_keyring;
   bool force_no_cgroup;
   bool no_pivot;
+  const char *parent_rootfs;
 
   char **argv;
   int argc;

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -67,6 +67,7 @@ int libcrun_set_mounts (struct container_entrypoint_s *args, libcrun_container_t
                         set_mounts_cb_t cb, void *cb_data, libcrun_error_t *err);
 int libcrun_init_caps (libcrun_error_t *err);
 int libcrun_do_pivot_root (libcrun_container_t *container, bool no_pivot, const char *rootfs, libcrun_error_t *err);
+int libcrun_do_parent_rootfs (const char *rootfs, libcrun_error_t *err);
 int libcrun_reopen_dev_null (libcrun_error_t *err);
 int libcrun_set_usernamespace (libcrun_container_t *container, pid_t pid, libcrun_error_t *err);
 int libcrun_set_caps (runtime_spec_schema_config_schema_process_capabilities *capabilities, uid_t uid, gid_t gid,

--- a/src/run.c
+++ b/src/run.c
@@ -39,6 +39,7 @@ enum
   OPTION_PRESERVE_FDS,
   OPTION_NO_PIVOT,
   OPTION_KEEP,
+  OPTION_PARENT_ROOTFS,
 };
 
 static const char *bundle = NULL;
@@ -59,6 +60,7 @@ static struct argp_option options[]
         { "no-subreaper", OPTION_NO_SUBREAPER, 0, 0, "do not create a subreaper process (ignored)", 0 },
         { "no-new-keyring", OPTION_NO_NEW_KEYRING, 0, 0, "keep the same session key", 0 },
         { "no-pivot", OPTION_NO_PIVOT, 0, 0, "do not use pivot_root", 0 },
+        { "parent-rootfs", OPTION_PARENT_ROOTFS, "DIR", 0, "give rootfs a parent mount", 0 },
         {
             0,
         } };
@@ -109,6 +111,10 @@ parse_opt (int key, char *arg, struct argp_state *state)
 
     case OPTION_NO_PIVOT:
       crun_context.no_pivot = true;
+      break;
+
+    case OPTION_PARENT_ROOTFS:
+      crun_context.parent_rootfs = argp_mandatory_argument (arg, state);
       break;
 
     case ARGP_KEY_NO_ARGS:


### PR DESCRIPTION
add --parent-rootfs <dir> to run command

crun run --parent-rootfs <dir> ... can be used to run from initramfs when the rootfs has no parent mount. This is accomplished by rbind mounting `/` onto the given directory, then moving this bind mount overtop `/` and chroot'ing. Credit to DaanDeMeyer for the idea