### PR TITLE
cgroup: remove redundant check

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -470,22 +470,18 @@ int
 libcrun_cgroup_has_oom (struct libcrun_cgroup_status *status, libcrun_error_t *err)
 {
   cleanup_free char *content = NULL;
-  const char *path = NULL;
+  const char *path = status->path;
   const char *prefix = NULL;
   size_t content_size = 0;
   int cgroup_mode;
   char *it;
 
-  path = status->path;
   if (UNLIKELY (path == NULL || path[0] == '\0'))
     return 0;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
   if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
-
-  if (path == NULL || path[0] == '\0')
-    return 0;
 
   switch (cgroup_mode)
     {


### PR DESCRIPTION
The check got duplicated in this git commit ce7dedf98c0a1ba2845747950504beaedfe0bb1b
"_cgroup: move returned data to different struct_"

I guess one of the checks could be removed.