### PR TITLE
src/libcrun: fix handling of device paths with trailing slashes

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -2507,3 +2507,17 @@ get_overflow_gid (void)
     }
   return gid;
 }
+
+void
+consume_trailing_slashes (char *path)
+{
+  if (! path || path[0] == '\0')
+    return;
+
+  char *last = path + strlen (path);
+
+  while (last > path && *(last - 1) == '/')
+    last--;
+
+  *last = '\0';
+}

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -225,6 +225,8 @@ xstrdup (const char *str)
   return ret;
 }
 
+void consume_trailing_slashes (char *path);
+
 static inline const char *
 consume_slashes (const char *t)
 {

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -214,6 +214,19 @@ def test_mknod_device():
         return -1
     return 0
 
+def test_trailing_slash_mknod_device():
+    if is_rootless():
+        return 77
+
+    conf = base_config()
+    add_all_namespaces(conf)
+    conf['process']['args'] = ['/init', 'true']
+    conf['linux']['devices'] = [{"path": "/mnt/", "type": "b", "major": 10, "minor": 229}]
+    try:
+        run_and_get_output(conf)
+    except Exception as e:
+        return -1
+    return 0
 
 all_tests = {
     "owner-device" : test_owner_device,
@@ -223,6 +236,7 @@ all_tests = {
     "mknod-device" : test_mknod_device,
     "mode-device"  : test_mode_device,
     "create-or-bind-mount-device" : test_create_or_bind_mount_device,
+    "handle-device-trailing-slash" : test_trailing_slash_mknod_device,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change handles device paths with trailing slashes correctly. It address the following issue when we use `crun` as the default container runtime:
```sh
Error: container create failed: mknod `/mnt/`: No such file or directory .
```