### PR TITLE
cgroup-systemd: fix comment

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -878,7 +878,7 @@ append_resources (sd_bus_message *m,
 
   if (resources->cpu)
     {
-      /* do not bother with systemd internal representation if both values are not specified */
+      /* do not bother with systemd internal representation unless both values are specified */
       if (resources->cpu->quota && resources->cpu->period)
         {
           uint64_t quota = resources->cpu->quota;


### PR DESCRIPTION
The comment does not correctly describe the code.

One way to fix it could be 
```diff
diff --git a/src/libcrun/cgroup-systemd.c b/src/libcrun/cgroup-systemd.c
index e997285..b3ea1e9 100644
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -878,7 +878,7 @@ append_resources (sd_bus_message *m,
 
   if (resources->cpu)
     {
-      /* do not bother with systemd internal representation if both values are not specified */
+      /* do not bother with systemd internal representation if not both values are specified */
       if (resources->cpu->quota && resources->cpu->period)
         {
           uint64_t quota = resources->cpu->quota;
```

To make it sound more English, I replaced `if not` with `unless`


