### PR TITLE
linux: attempt to make rootfs private too

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+* crun-1.16.1
+
+- fix a regression introduced by 1.16 where using 'rshared' rootfs
+  mount propagation and the rootfs itself is a mountpoint.
+- inherit user from original process on exec, if not overridden.
+
 * crun-1.16
 
 - build: fix build for s390x.

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1093,7 +1093,7 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
                 }
             }
 
-          /* If nothing else worked, just use the path as is.  */
+          /* If nothing else worked, just use the path as it is.  */
           if (rootfs == NULL)
             rootfs = xstrdup (def->root->path);
         }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2571,7 +2571,7 @@ make_parent_mount_private (const char *rootfs, libcrun_error_t *err)
         {
           ret = faccessat (rootfsfd, "..", X_OK, AT_EACCESS);
           if (ret != 0)
-            return crun_make_error (err, EACCES, "make `%s`private: a component is not accessible", rootfs);
+            return crun_make_error (err, EACCES, "make `%s` private: a component is not accessible", rootfs);
         }
 
       get_proc_self_fd_path (proc_path, parentfd);


### PR DESCRIPTION
commit 66824320e3fe9b36e94b3f54d77779da498c6b2b introduced the regression.  After that change, crun does not attempt anymore to make the rootfs directory private but starts from its parent directory, causing pivot_root to fail when the rootfs itself is a mountpoint.

Closes: https://github.com/containers/crun/issues/1514
    
