### PR TITLE
src/libcrun: ensure DefaultDependencies respects CRI-O annotation

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1065,6 +1065,13 @@ enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *resource
         }
     }
 
+  sd_err = sd_bus_message_append (m, "(sv)", "DefaultDependencies", "b", 0);
+  if (UNLIKELY (sd_err < 0))
+    {
+      ret = crun_make_error (err, -sd_err, "sd-bus message append DefaultDependencies");
+      goto exit;
+    }
+
   if (annotations)
     {
       size_t prefix_len = sizeof (SYSTEMD_PROPERTY_PREFIX) - 1;
@@ -1102,13 +1109,6 @@ enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *resource
   if (UNLIKELY (sd_err < 0))
     {
       ret = crun_make_error (err, -sd_err, "sd-bus message append PIDs");
-      goto exit;
-    }
-
-  sd_err = sd_bus_message_append (m, "(sv)", "DefaultDependencies", "b", 0);
-  if (UNLIKELY (sd_err < 0))
-    {
-      ret = crun_make_error (err, -sd_err, "sd-bus message append DefaultDependencies");
       goto exit;
     }
 


### PR DESCRIPTION
The issue with DefaultDependencies being set to 'no' instead of 'yes' was caused by the order of the code. The annotations were being processed before setting the DefaultDependencies property, which allowed crun's default behavior to override the CRI-O annotation.

Here's the test with this fix.

```sh
$ sudo crictl run test/testdata/container_sleep.json test/testdata/sandbox_config.json 
DEBU[0000] get image connection                         
DEBU[0000] get runtime connection                       
90439cccfb277148f31a7e5b1c79a2188931e88e3831733b6a0b83330832fc18


$ systemctl show crio-90439cccfb277148f31a7e5b1c79a2188931e88e3831733b6a0b83330832fc18.scope | grep "Default*"
DefaultMemoryLow=0
DefaultStartupMemoryLow=0
DefaultMemoryMin=0
DefaultDependencies=yes

```