### PR TITLE
Remove libcrun_setup_terminal_ptmx

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2590,7 +2590,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
       close_and_reset (&socket_pair_0);
 
-      ret = libcrun_setup_terminal_ptmx (terminal_fd, &orig_terminal, err);
+      ret = libcrun_set_raw (0, &orig_terminal, err);
       if (UNLIKELY (ret < 0))
         goto fail;
     }
@@ -3685,7 +3685,7 @@ libcrun_container_exec_with_options (libcrun_context_t *context, const char *id,
         }
       else
         {
-          ret = libcrun_setup_terminal_ptmx (terminal_fd, &orig_terminal, err);
+          ret = libcrun_set_raw (0, &orig_terminal, err);
           if (UNLIKELY (ret < 0))
             {
               flush_fd_to_err (context, terminal_fd);

--- a/src/libcrun/terminal.c
+++ b/src/libcrun/terminal.c
@@ -61,8 +61,8 @@ libcrun_new_terminal (char **pty, libcrun_error_t *err)
   return ret;
 }
 
-static int
-set_raw (int fd, void **current_status, libcrun_error_t *err)
+int
+libcrun_set_raw (int fd, void **current_status, libcrun_error_t *err)
 {
   int ret;
   struct termios termios;
@@ -112,23 +112,6 @@ libcrun_set_stdio (char *pty, libcrun_error_t *err)
     return crun_make_error (err, errno, "ioctl TIOCSCTTY");
 
   return 0;
-}
-
-int
-libcrun_setup_terminal_ptmx (int fd, void **current_status, libcrun_error_t *err)
-{
-  int ret;
-  struct termios termios;
-
-  ret = tcgetattr (fd, &termios);
-  if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "tcgetattr");
-
-  ret = tcsetattr (fd, TCSANOW, &termios);
-  if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "tcsetattr");
-
-  return set_raw (0, current_status, err);
 }
 
 void

--- a/src/libcrun/terminal.h
+++ b/src/libcrun/terminal.h
@@ -29,7 +29,7 @@ int libcrun_new_terminal (char **pty, libcrun_error_t *err);
 
 int libcrun_set_stdio (char *pty, libcrun_error_t *err);
 
-int libcrun_setup_terminal_ptmx (int fd, void **current_status, libcrun_error_t *err);
+int libcrun_set_raw (int fd, void **current_status, libcrun_error_t *err);
 
 int libcrun_terminal_setup_size (int fd, unsigned short rows, unsigned short cols, libcrun_error_t *err);
 


### PR DESCRIPTION
Since https://github.com/containers/crun/pull/1214 it is a no-op and does nothing more than call set_raw.

This does change the public interface of libcrun / break backwards compatibility.