### PR TITLE
Add autoPatchelfHook to static build

### DIFF
--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -12,6 +12,7 @@ with pkgs; stdenv.mkDerivation {
   outputs = [ "out" ];
   nativeBuildInputs = with buildPackages; [
     autoreconfHook
+    autoPatchelfHook
     bash
     gitMinimal
     pkg-config


### PR DESCRIPTION
This should fix the wrong dlopen search path mentioned in https://github.com/cri-o/cri-o/issues/8518