### PR TITLE
Allow passing an ID to journald log driver

### DIFF
--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -236,7 +236,7 @@ libcrun_init_logging (crun_output_handler *new_output_handler, void **new_output
 
         case LOG_TYPE_JOURNALD:
           *new_output_handler = log_write_to_journald;
-          *new_output_handler_arg = NULL;
+          *new_output_handler_arg = (void *) id;
           break;
         }
     }


### PR DESCRIPTION
The ID has been dropped before this patch, but we can use it to refer a container ID or anything else identifiable.

Will be used by conmon-rs in https://github.com/containers/conmon-rs/pull/2401/files#diff-5d1350be7d73e8dfd3f43f70d9d71838500a7c04b2ee5ee19f1c4521f9df7d12R395

Refers to https://github.com/containers/crun/issues/1525