### PR TITLE
Add `--log-stderr` option

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -136,6 +136,11 @@ Define the log level.  It can either be \fBdebug\fP, \fBwarning\fP or \fBerror\f
 The default is \fBerror\fP\&.
 
 .PP
+\fB--log-stderr\fP
+Additionally log to stderr.  Especially helpful when \fB--log\fR is set to a certain
+destination.
+
+.PP
 \fB--no-pivot\fP
 Use \fBchroot(2)\fR instead of \fBpivot_root(2)\fR when creating the container.
 This option is not safe, and should be avoided.

--- a/crun.1.md
+++ b/crun.1.md
@@ -102,6 +102,10 @@ Define the format of the log messages.  It can either be **text**, or
 Define the log level.  It can either be **debug**, **warning** or **error**.
 The default is **error**.
 
+**--log-stderr**
+Additionally log to stderr.  Especially helpful when `--log` is set to a certain
+destination.
+
 **--no-pivot**
 Use `chroot(2)` instead of `pivot_root(2)` when creating the container.
 This option is not safe, and should be avoided.

--- a/src/crun.c
+++ b/src/crun.c
@@ -105,7 +105,7 @@ init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global
   /* Check if global handler is configured and pass it down to crun context */
   con->handler = glob->handler;
 
-  ret = libcrun_init_logging (&con->output_handler, &con->output_handler_arg, id, glob->log, err);
+  ret = libcrun_init_logging (&con->output_handler, &con->output_handler_arg, id, glob->log, err, glob->log_to_stderr);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -116,7 +116,7 @@ init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global
         return ret;
     }
 
-  libcrun_set_verbosity (arguments.verbosity);
+  libcrun_set_verbosity (glob->verbosity);
   libcrun_debug ("Using debug verbosity");
 
   if (con->bundle == NULL)
@@ -213,6 +213,7 @@ enum
   OPTION_LOG,
   OPTION_LOG_FORMAT,
   OPTION_LOG_LEVEL,
+  OPTION_LOG_STDERR,
   OPTION_ROOT,
   OPTION_ROOTLESS
 };
@@ -225,6 +226,7 @@ static struct argp_option options[] = { { "debug", OPTION_DEBUG, 0, 0, "produce 
                                         { "log", OPTION_LOG, "FILE", 0, "log destination: 'file:PATH' (default), 'journald:ID' or 'syslog:ID'", 0 },
                                         { "log-format", OPTION_LOG_FORMAT, "FORMAT", 0, "log format: 'text' (default) or 'json'", 0 },
                                         { "log-level", OPTION_LOG_LEVEL, "LEVEL", 0, "log level to use: 'error' (default), 'warning' or 'debug'", 0 },
+                                        { "log-stderr", OPTION_LOG_STDERR, 0, 0, "additionally log to stderr", 0 },
                                         { "root", OPTION_ROOT, "DIR", 0, NULL, 0 },
                                         { "rootless", OPTION_ROOT, "VALUE", 0, NULL, 0 },
                                         { "version", OPTION_VERSION, 0, 0, NULL, 0 },
@@ -330,6 +332,10 @@ parse_opt (int key, char *arg, struct argp_state *state)
         {
           libcrun_fail_with_error (0, "unknown verbosity `%s` specified", arg);
         }
+      break;
+
+    case OPTION_LOG_STDERR:
+      arguments.log_to_stderr = true;
       break;
 
     case OPTION_ROOT:

--- a/src/crun.h
+++ b/src/crun.h
@@ -34,6 +34,7 @@ struct crun_global_arguments
   bool command;
   bool option_systemd_cgroup;
   bool option_force_no_cgroup;
+  bool log_to_stderr;
 };
 
 char *argp_mandatory_argument (char *arg, struct argp_state *state);

--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -203,12 +203,13 @@ get_log_type (const char *log, const char **data)
 
 int
 libcrun_init_logging (crun_output_handler *new_output_handler, void **new_output_handler_arg, const char *id,
-                      const char *log, libcrun_error_t *err)
+                      const char *log, libcrun_error_t *err, bool log_to_stderr)
 {
   if (log == NULL)
     {
       *new_output_handler = log_write_to_stderr;
       *new_output_handler_arg = NULL;
+      log_to_stderr = false; // Don't log twice to stderr
     }
   else
     {
@@ -240,7 +241,7 @@ libcrun_init_logging (crun_output_handler *new_output_handler, void **new_output
           break;
         }
     }
-  crun_set_output_handler (*new_output_handler, *new_output_handler_arg, log != NULL);
+  crun_set_output_handler (*new_output_handler, *new_output_handler_arg, log_to_stderr);
   return 0;
 }
 

--- a/src/libcrun/error.h
+++ b/src/libcrun/error.h
@@ -92,7 +92,7 @@ LIBCRUN_PUBLIC void libcrun_fail_with_error (int errno_, const char *msg, ...) _
 LIBCRUN_PUBLIC int libcrun_set_log_format (const char *format, libcrun_error_t *err);
 
 LIBCRUN_PUBLIC int libcrun_init_logging (crun_output_handler *output_handler, void **output_handler_arg, const char *id,
-                                         const char *log, libcrun_error_t *err);
+                                         const char *log, libcrun_error_t *err, bool log_to_stderr);
 
 LIBCRUN_PUBLIC int libcrun_error_release (libcrun_error_t *err);
 


### PR DESCRIPTION
This option was inherited before, but now we can set it explicitly to allow/disallow logging to stderr when selecting a certain log driver.

For example on exec, we would need to log log anything to stdio even when the debug logs are enabled.

Refers to https://github.com/containers/crun/issues/1525