### PR TITLE
Fix `additional_gids_size` on `process_user_dup`

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -568,6 +568,7 @@ process_user_dup (const runtime_spec_schema_config_schema_process_user *const sr
 
   if (src->additional_gids)
     {
+      dst->additional_gids_len = src->additional_gids_len;
       const size_t additional_gids_size = src->additional_gids_len * sizeof (gid_t);
       dst->additional_gids = xmalloc (additional_gids_size);
       memcpy (dst->additional_gids, src->additional_gids, additional_gids_size);


### PR DESCRIPTION
The size needs to be set as well otherwise we may break `additional_gids`.

Found in critest, like: https://github.com/cri-o/cri-o/actions/runs/10680190170/job/29601173374

```
Summarizing 3 Failures:
  [FAIL] [k8s.io] Security Context SupplementalGroupsPolicy when SupplementalGroupsPolicy=Strict [It] even if the container's primary UID belongs to some groups in the image, runtime should not add SupplementalGroups to them
  sigs.k8s.io/cri-tools/pkg/validate/security_context_linux.go:737
  [FAIL] [k8s.io] Security Context bucket [It] runtime should support SupplementalGroups
  sigs.k8s.io/cri-tools/pkg/validate/security_context_linux.go:309
  [FAIL] [k8s.io] Security Context SupplementalGroupsPolicy when SupplementalGroupsPolicy=Merge (Default) [It] if the container's primary UID belongs to some groups in the image, runtime should add SupplementalGroups to them
  sigs.k8s.io/cri-tools/pkg/validate/security_context_linux.go:669
```

Follow-up on https://github.com/containers/crun/pull/1538