### PR TITLE
fix getpwuid_r error handling

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1488,7 +1488,7 @@ getsubidrange (uid_t id, int is_uid, uint32_t *from, uint32_t *len)
           return -1;
         }
 
-      if (ret < 0 && errno != ERANGE)
+      if (ret != ERANGE)
         return ret;
 
       buf_size *= 2;


### PR DESCRIPTION
getpwuid_r returns the error directly, not -1. In a situation with no /etc/passwd for example, ret is ENOFILE (2) and so the branch is never taken, resulting in a runaway realloc loop

Closes: https://github.com/containers/crun/issues/1536