### PR TITLE
Only log to stderr if `--log` is not provided

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -116,7 +116,7 @@ init_libcrun_context (libcrun_context_t *con, const char *id, struct crun_global
         return ret;
     }
 
-  libcrun_set_verbosity (arguments.verbosity);
+  libcrun_set_verbosity (glob->verbosity);
   libcrun_debug ("Using debug verbosity");
 
   if (con->bundle == NULL)
@@ -222,7 +222,7 @@ const char *argp_program_bug_address = "https://github.com/containers/crun/issue
 static struct argp_option options[] = { { "debug", OPTION_DEBUG, 0, 0, "produce verbose output, similar to --log-level=debug", 0 },
                                         { "cgroup-manager", OPTION_CGROUP_MANAGER, "MANAGER", 0, "cgroup manager", 0 },
                                         { "systemd-cgroup", OPTION_SYSTEMD_CGROUP, 0, 0, "use systemd cgroups", 0 },
-                                        { "log", OPTION_LOG, "FILE", 0, "log destination: 'file:PATH' (default), 'journald:ID' or 'syslog:ID'", 0 },
+                                        { "log", OPTION_LOG, "FILE", 0, "log destination: '[file:]PATH', 'journald:ID' or 'syslog:ID' (defaults to stderr)", 0 },
                                         { "log-format", OPTION_LOG_FORMAT, "FORMAT", 0, "log format: 'text' (default) or 'json'", 0 },
                                         { "log-level", OPTION_LOG_LEVEL, "LEVEL", 0, "log level to use: 'error' (default), 'warning' or 'debug'", 0 },
                                         { "root", OPTION_ROOT, "DIR", 0, NULL, 0 },

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1446,7 +1446,7 @@ container_init (void *args, char *notify_socket, int sync_socket, libcrun_error_
 
   entrypoint_args->sync_socket = sync_socket;
 
-  crun_set_output_handler (log_write_to_sync_socket, args, false);
+  crun_set_output_handler (log_write_to_sync_socket, args);
 
   /* sync receive own pid.  */
   ret = TEMP_FAILURE_RETRY (read (sync_socket, &own_pid, sizeof (own_pid)));
@@ -1505,7 +1505,7 @@ container_init (void *args, char *notify_socket, int sync_socket, libcrun_error_
       close_and_reset (&entrypoint_args->context->fifo_exec_wait_fd);
     }
 
-  crun_set_output_handler (log_write_to_stderr, NULL, false);
+  crun_set_output_handler (log_write_to_stderr, NULL);
 
   if (def->process && def->process->no_new_privileges)
     {
@@ -2972,7 +2972,7 @@ libcrun_container_create (libcrun_context_t *context, libcrun_container_t *conta
     {
       force_delete_container_status (context, def);
       libcrun_error ((*err)->status, "%s", (*err)->msg);
-      crun_set_output_handler (log_write_to_stderr, NULL, false);
+      crun_set_output_handler (log_write_to_stderr, NULL);
     }
 
   if (pipefd1 >= 0)

--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -42,7 +42,6 @@ enum
 };
 
 static int log_format;
-static bool log_also_to_stderr;
 static int output_verbosity = LIBCRUN_VERBOSITY_ERROR;
 
 int
@@ -240,7 +239,7 @@ libcrun_init_logging (crun_output_handler *new_output_handler, void **new_output
           break;
         }
     }
-  crun_set_output_handler (*new_output_handler, *new_output_handler_arg, log != NULL);
+  crun_set_output_handler (*new_output_handler, *new_output_handler_arg);
   return 0;
 }
 
@@ -353,11 +352,10 @@ libcrun_get_verbosity ()
 }
 
 void
-crun_set_output_handler (crun_output_handler handler, void *arg, bool log_to_stderr)
+crun_set_output_handler (crun_output_handler handler, void *arg)
 {
   output_handler = handler;
   output_handler_arg = arg;
-  log_also_to_stderr = log_to_stderr;
 }
 
 static char *
@@ -434,8 +432,8 @@ write_log (int errno_, int verbosity, const char *msg, va_list args_list)
   if (UNLIKELY (ret < 0))
     OOM ();
 
-  if (log_also_to_stderr)
-    log_write_to_stderr (errno_, output, verbosity, NULL);
+  if (verbosity == LIBCRUN_VERBOSITY_ERROR)
+    log_write_to_stderr (errno_, output, LIBCRUN_VERBOSITY_ERROR, NULL);
 
   switch (log_format)
     {

--- a/src/libcrun/error.h
+++ b/src/libcrun/error.h
@@ -57,7 +57,7 @@ typedef struct libcrun_error_s *libcrun_error_t;
 
 typedef void (*crun_output_handler) (int errno_, const char *msg, int verbosity, void *arg);
 
-void crun_set_output_handler (crun_output_handler handler, void *arg, bool log_to_stderr);
+void crun_set_output_handler (crun_output_handler handler, void *arg);
 
 void log_write_to_journald (int errno_, const char *msg, int verbosity, void *arg);
 

--- a/tests/clang-format/run-tests.sh
+++ b/tests/clang-format/run-tests.sh
@@ -5,7 +5,7 @@ set -e -x
 cd /crun
 
 # Recent git complains that the directory is owned by someone else,
-# which happens if we run it via a Dockefile with a volume mounted.
+# which happens if we run it via a Dockerfile with a volume mounted.
 git config --global --add safe.directory "$(pwd)"
 
 ./configure


### PR DESCRIPTION
In any other case we log to the dedicated log driver for consistency reason. This avoids having another option like `--log-stderr`.

Needs https://github.com/containers/crun/pull/1545

Alternative to https://github.com/containers/crun/pull/1542