### PR TITLE
Fix warning around unused result on chdir("/")

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5766,7 +5766,10 @@ libcrun_safe_chdir (const char *path, libcrun_error_t *err)
   /* Enforce that the returned path is an absolute path.  */
   if (ret == 0 || buffer[0] != '/')
     {
-      (void) chdir ("/");
+      if (chdir ("/") < 0)
+        {
+          /* Braces around empty body, to fix warning for [-Wunused-result] and error for [-Werror=empty-body]. */
+        }
       errno = ENOENT;
 
       /*


### PR DESCRIPTION
This fixes the warning while ignoring the return result of `chdir`:

```
src/libcrun/linux.c:5769:14: warning: ignoring return value of 'chdir' declared with attribute 'warn_unused_result' [-Wunused-result]
 5769 |       (void) chdir ("/");
```