### PR TITLE
Packit: Create missing path components in files_to_sync

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,12 +11,15 @@ files_to_sync:
   - src: plans/
     dest: plans/
     delete: true
+    mkpath: true
   - src: tests/tmt/
     dest: tests/tmt/
     delete: true
+    mkpath: true
   - src: .fmf/
     dest: .fmf/
     delete: true
+    mkpath: true
   - .packit.yaml
 
 packages:


### PR DESCRIPTION
Packit's propose-downstream failed[0] for crun 1.17 because packit wasn't able to create `tests/tmt` path structure in the downstream repo[1]. 
[0]: https://github.com/containers/crun/issues/1558
[1]: https://dashboard.packit.dev/jobs/propose-downstream/10800

Using `mkpath: true` will create missing path components if any.
Ref: https://packit.dev/docs/configuration#files_to_sync

Fixes: #1558 