### PR TITLE
Disable criu support on riscv64

### DIFF
--- a/rpm/crun.spec
+++ b/rpm/crun.spec
@@ -60,9 +60,11 @@ BuildRequires: libseccomp-devel
 BuildRequires: python3-libmount
 BuildRequires: libtool
 BuildRequires: protobuf-c-devel
+%ifnarch riscv64
 BuildRequires: criu-devel >= 3.17.1-2
 Recommends: criu >= 3.17.1
 Recommends: criu-libs
+%endif
 %if %{defined wasmedge_support}
 BuildRequires: wasmedge-devel
 %endif


### PR DESCRIPTION
Sources for the changes: http://fedora.riscv.rocks:3000/rpms/crun/src/branch/main-riscv64

Latest successful riscv64 build: http://fedora.riscv.rocks/koji/buildinfo?buildID=305890