### PR TITLE
Packit: constrain koji and bodhi jobs to the fedora package

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -158,9 +158,11 @@ jobs:
 
   - job: koji_build
     trigger: commit
+    packages: [crun-fedora]
     dist_git_branches: *fedora_targets
 
   - job: bodhi_update
     trigger: commit
+    packages: [crun-fedora]
     dist_git_branches:
       - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
Without this constraint, packit creates duplicate jobs when running downstream jobs. This does not affect upstream.