### PR TITLE
restore: add lsm-profile and lsm-mount-context options

### DIFF
--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -187,6 +187,7 @@ struct libcrun_checkpoint_restore_s
   char *parent_path;
   bool pre_dump;
   int manage_cgroups_mode;
+  char *lsm_profile;
 };
 typedef struct libcrun_checkpoint_restore_s libcrun_checkpoint_restore_t;
 

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -188,6 +188,7 @@ struct libcrun_checkpoint_restore_s
   bool pre_dump;
   int manage_cgroups_mode;
   char *lsm_profile;
+  char *lsm_mount_context;
 };
 typedef struct libcrun_checkpoint_restore_s libcrun_checkpoint_restore_t;
 

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -89,6 +89,7 @@ struct libcriu_wrapper_s
   void (*criu_set_tcp_established) (bool tcp_established);
   void (*criu_set_track_mem) (bool track_mem);
   void (*criu_set_work_dir_fd) (int fd);
+  int (*criu_set_lsm_profile) (const char *name);
 };
 
 static struct libcriu_wrapper_s *libcriu_wrapper;
@@ -824,6 +825,13 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
     {
       /* This is only for the error message later. */
       cr_options->work_path = cr_options->image_path;
+    }
+
+  if (cr_options->lsm_profile != NULL)
+    {
+      ret = libcriu_wrapper->criu_set_lsm_profile (cr_options->lsm_profile);
+      if (UNLIKELY (ret != 0))
+        return crun_make_error (err, 0, "error setting LSM profile to `%s`", cr_options->lsm_profile);
     }
 
   /* Tell CRIU about external bind mounts. */

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -90,6 +90,7 @@ struct libcriu_wrapper_s
   void (*criu_set_track_mem) (bool track_mem);
   void (*criu_set_work_dir_fd) (int fd);
   int (*criu_set_lsm_profile) (const char *name);
+  int (*criu_set_lsm_mount_context) (const char *name);
 };
 
 static struct libcriu_wrapper_s *libcriu_wrapper;
@@ -832,6 +833,13 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
       ret = libcriu_wrapper->criu_set_lsm_profile (cr_options->lsm_profile);
       if (UNLIKELY (ret != 0))
         return crun_make_error (err, 0, "error setting LSM profile to `%s`", cr_options->lsm_profile);
+    }
+
+  if (cr_options->lsm_mount_context != NULL)
+    {
+      ret = libcriu_wrapper->criu_set_lsm_mount_context (cr_options->lsm_mount_context);
+      if (UNLIKELY (ret != 0))
+        return crun_make_error (err, 0, "error setting LSM mount context to `%s`", cr_options->lsm_mount_context);
     }
 
   /* Tell CRIU about external bind mounts. */

--- a/src/restore.c
+++ b/src/restore.c
@@ -45,6 +45,7 @@ enum
   OPTION_FILE_LOCKS,
   OPTION_MANAGE_CGROUPS_MODE,
   OPTION_LSM_PROFILE,
+  OPTION_LSM_MOUNT_CONTEXT,
 };
 
 static char doc[] = "OCI runtime";
@@ -69,6 +70,7 @@ static struct argp_option options[]
         { "file-locks", OPTION_FILE_LOCKS, 0, 0, "allow file locks", 0 },
         { "manage-cgroups-mode", OPTION_MANAGE_CGROUPS_MODE, "MODE", 0, "cgroups mode: 'soft' (default), 'ignore', 'full' and 'strict'", 0 },
         { "lsm-profile", OPTION_LSM_PROFILE, "VALUE", 0, "Specify an LSM profile to be used during restore in the form of TYPE:NAME", 0 },
+        { "lsm-mount-context", OPTION_LSM_MOUNT_CONTEXT, "VALUE", 0, "Specify an LSM mount context to be used during restore", 0 },
         {
             0,
         } };
@@ -129,6 +131,10 @@ parse_opt (int key, char *arg, struct argp_state *state)
 
     case OPTION_LSM_PROFILE:
       cr_options.lsm_profile = argp_mandatory_argument (arg, state);
+      break;
+
+    case OPTION_LSM_MOUNT_CONTEXT:
+      cr_options.lsm_mount_context = argp_mandatory_argument (arg, state);
       break;
 
     default:

--- a/src/restore.c
+++ b/src/restore.c
@@ -44,6 +44,7 @@ enum
   OPTION_CONSOLE_SOCKET,
   OPTION_FILE_LOCKS,
   OPTION_MANAGE_CGROUPS_MODE,
+  OPTION_LSM_PROFILE,
 };
 
 static char doc[] = "OCI runtime";
@@ -67,6 +68,7 @@ static struct argp_option options[]
           "path to a socket that will receive the ptmx end of the tty", 0 },
         { "file-locks", OPTION_FILE_LOCKS, 0, 0, "allow file locks", 0 },
         { "manage-cgroups-mode", OPTION_MANAGE_CGROUPS_MODE, "MODE", 0, "cgroups mode: 'soft' (default), 'ignore', 'full' and 'strict'", 0 },
+        { "lsm-profile", OPTION_LSM_PROFILE, "VALUE", 0, "Specify an LSM profile to be used during restore in the form of TYPE:NAME", 0 },
         {
             0,
         } };
@@ -123,6 +125,10 @@ parse_opt (int key, char *arg, struct argp_state *state)
 
     case OPTION_MANAGE_CGROUPS_MODE:
       cr_options.manage_cgroups_mode = crun_parse_manage_cgroups_mode (argp_mandatory_argument (arg, state));
+      break;
+
+    case OPTION_LSM_PROFILE:
+      cr_options.lsm_profile = argp_mandatory_argument (arg, state);
       break;
 
     default:


### PR DESCRIPTION
By default, CRIU restores containers with the same SELinux process labels used during checkpointing. However, when restoring multiple copies of a container, this results in all containers using identical SELinux labels, which is undesirable. In addition, all containers in a Pod share the SELinux label of the infrastructure container. To restore a new container into an existing Pod, we need to specify the SELinux label to be used during restore.
    
This pull request adds `--lsm-profile` and `--lsm-mount-context` options for the `crun restore` command to enable this functionality, similar to runc (https://github.com/opencontainers/runc/pull/3005)