### PR TITLE
libcrun: deprecate cgroup v1

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -834,6 +834,11 @@ additional id specified in the files \fB/etc/subuid\fR and \fB/etc/subgid\fR
 is automatically added starting with ID 1.
 
 
+.SH CGROUP v1
+.PP
+Support for cgroup v1 is deprecated and will be removed in a future release.
+
+
 .SH CGROUP v2
 .PP
 \fBNote\fP: cgroup v2 does not yet support control of realtime processes and

--- a/crun.1.md
+++ b/crun.1.md
@@ -664,6 +664,10 @@ The current user is mapped to the ID 0 in the container, and any
 additional id specified in the files `/etc/subuid` and `/etc/subgid`
 is automatically added starting with ID 1.
 
+# CGROUP v1
+
+Support for cgroup v1 is deprecated and will be removed in a future release.
+
 # CGROUP v2
 
 **Note**: cgroup v2 does not yet support control of realtime processes and

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2365,6 +2365,14 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   struct libcrun_dirfd_s cgroup_dirfd_s;
   struct libcrun_seccomp_gen_ctx_s seccomp_gen_ctx;
   const char *seccomp_bpf_data = find_annotation (container, "run.oci.seccomp_bpf_data");
+  int cgroup_mode;
+
+  cgroup_mode = libcrun_get_cgroup_mode (err);
+  if (UNLIKELY (cgroup_mode < 0))
+    return cgroup_mode;
+
+  if (cgroup_mode != CGROUP_MODE_UNIFIED)
+    libcrun_warning ("cgroup v1 is deprecated and will be removed in a future release.  Use cgroup v2");
 
   if (def->hooks
       && (def->hooks->prestart_len || def->hooks->poststart_len || def->hooks->create_runtime_len


### PR DESCRIPTION
we are two months away from 2025, cgroup v1 should not be used anymore.

For now, add a warning when cgroup v1 is used.

Closes: https://github.com/containers/crun/issues/1149