### PR TITLE
src: use mount API to self-clone

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -430,7 +430,7 @@ do_mount_setattr (const char *target, int targetfd, uint64_t clear, uint64_t set
   return 0;
 }
 
-static int
+int
 get_bind_mount (int dirfd, const char *src, bool recursive, bool rdonly, libcrun_error_t *err)
 {
   cleanup_close int open_tree_fd = -1;

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -147,4 +147,6 @@ int libcrun_update_intel_rdt (const char *ctr_name, libcrun_container_t *contain
 
 int libcrun_safe_chdir (const char *path, libcrun_error_t *err);
 
+int get_bind_mount (int dirfd, const char *src, bool recursive, bool rdonly, libcrun_error_t *err);
+
 #endif


### PR DESCRIPTION
if the new mount API is available, use it to grad a read-only reference to the current executable.  The advantage is that there is no need to leak a mount in the current mount namespace.

Closes: https://github.com/containers/crun/issues/1383
Closes: https://issues.redhat.com/browse/RHEL-67558