### PR TITLE
build: Don't build cloned_binary as part of crun

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,7 +130,7 @@ endif
 crun_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -D CRUN_LIBDIR="\"$(CRUN_LIBDIR)\""
 crun_SOURCES = src/crun.c src/run.c src/delete.c src/kill.c src/pause.c src/unpause.c src/oci_features.c src/spec.c \
 		src/exec.c src/list.c src/create.c src/start.c src/state.c src/update.c src/ps.c \
-		src/checkpoint.c src/restore.c src/libcrun/cloned_binary.c
+		src/checkpoint.c src/restore.c
 
 if DYNLOAD_LIBCRUN
 crun_LDFLAGS = -Wl,--unresolved-symbols=ignore-all $(CRUN_LDFLAGS)


### PR DESCRIPTION
Building crun after commit 8a0ee4b56a801c26efdcd26732090bbe86236e8c yields the following link error:

```
2024-11-28T01:45:15.2415817Z   CCLD     libcrun.la
2024-11-28T01:45:15.3802217Z   CCLD     crun
2024-11-28T01:45:15.4957602Z /home/runner/work/zebrafish/zebrafish/buildroot/output/host/lib/gcc/x86_64-buildroot-linux-gnu/13.3.0/../../../../x86_64-buildroot-linux-gnu/bin/ld: src/libcrun/crun-cloned_binary.o: in function `ensure_cloned_binary':
2024-11-28T01:45:15.4959563Z cloned_binary.c:(.text+0x87c): undefined reference to `get_bind_mount'
2024-11-28T01:45:15.4961482Z /home/runner/work/zebrafish/zebrafish/buildroot/output/host/lib/gcc/x86_64-buildroot-linux-gnu/13.3.0/../../../../x86_64-buildroot-linux-gnu/bin/ld: cloned_binary.c:(.text+0x8b7): undefined reference to `crun_error_release'
2024-11-28T01:45:15.4973731Z collect2: error: ld returned 1 exit status
2024-11-28T01:45:15.4989126Z make[3]: *** [Makefile:1547: crun] Error 1
```

This is because 8a0ee4b56a801c26efdcd26732090bbe86236e8c adds an include to "linux.h" (which has `get_bind_mount` and a transitive include to "error.h" which has `crun_error_release`). The Makefile for `crun` the binary builds `src/libcrun/cloned_binary.c`... which is already built as part of `libcrun` the library which is linked directly to `crun`.

Therefore it's enough to remove the `src/libcrun/cloned_binary.c` file from `crun` sources, it is already included through the link step.

An alternative would be to add src/libcrun/error.c, src/libcrun/utils.c, src/libcrun/linux.c to the crun sources, but that would be too much unnecessary bloat.