### PR TITLE
build: don't compile tests during normal build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -168,7 +168,7 @@ else
 noinst_PROGRAMS = crun
 endif
 
-noinst_PROGRAMS += tests/init $(UNIT_TESTS) tests/tests_libcrun_fuzzer
+check_PROGRAMS = tests/init $(UNIT_TESTS) tests/tests_libcrun_fuzzer
 
 TESTS_LDADD = libcrun_testing.a $(FOUND_LIBS) $(maybe_libyajl.la)
 

--- a/tests/fuzzing/run-tests.sh
+++ b/tests/fuzzing/run-tests.sh
@@ -17,6 +17,7 @@ git clean -fdx
 ./autogen.sh
 ./configure --enable-embedded-yajl HFUZZ_CC_UBSAN=1 HFUZZ_CC_ASAN=1 CC=hfuzz-clang CPPFLAGS="-D FUZZER" CFLAGS="-ggdb3 -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-div,indirect-calls"
 make -j "$(nproc)"
+make -j "$(nproc)" tests/tests_libcrun_fuzzer
 
 mkdir rootfs
 mkdir random-data


### PR DESCRIPTION
Creating the PR to get a feedback as it might have some side effects.

I think not compiling tests during normal build is the expected behavior however it shifts compilation to first `make check` invocation which I believe in CI is done with escalated privileges. Might have some unexpected impact if some files have different ownership/permissions.