### PR TITLE
linux: fix a hang if there are no reads from the tty

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ endif
 check_LTLIBRARIES = libcrun_testing.la
 
 libcrun_SOURCES = src/libcrun/utils.c \
+		src/libcrun/ring_buffer.c \
 		src/libcrun/blake3/blake3.c \
 		src/libcrun/blake3/blake3_portable.c \
 		src/libcrun/cgroup-cgroupfs.c \
@@ -154,12 +155,12 @@ EXTRA_DIST = COPYING COPYING.libcrun README.md NEWS SECURITY.md rpm/crun.spec au
 	src/libcrun/handlers/handler-utils.h \
 	src/libcrun/linux.h src/libcrun/utils.h src/libcrun/error.h src/libcrun/criu.h \
 	src/libcrun/scheduler.h src/libcrun/status.h src/libcrun/terminal.h \
-	src/libcrun/mount_flags.h src/libcrun/intelrdt.h \
+	src/libcrun/mount_flags.h src/libcrun/intelrdt.h src/libcrun/ring_buffer.h \
 	crun.1.md crun.1 libcrun.lds \
 	krun.1.md krun.1 \
 	lua/luacrun.rockspec
 
-UNIT_TESTS = tests/tests_libcrun_utils tests/tests_libcrun_errors tests/tests_libcrun_intelrdt
+UNIT_TESTS = tests/tests_libcrun_utils tests/tests_libcrun_ring_buffer tests/tests_libcrun_errors tests/tests_libcrun_intelrdt
 
 if ENABLE_CRUN
 bin_PROGRAMS = crun
@@ -180,6 +181,11 @@ tests_tests_libcrun_utils_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(ab
 tests_tests_libcrun_utils_SOURCES = tests/tests_libcrun_utils.c
 tests_tests_libcrun_utils_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_utils_LDFLAGS = $(crun_LDFLAGS)
+
+tests_tests_libcrun_ring_buffer_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_ring_buffer_SOURCES = tests/tests_libcrun_ring_buffer.c
+tests_tests_libcrun_ring_buffer_LDADD = $(TESTS_LDADD)
+tests_tests_libcrun_ring_buffer_LDFLAGS = $(crun_LDFLAGS)
 
 tests_tests_libcrun_intelrdt_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_intelrdt_SOURCES = tests/tests_libcrun_intelrdt.c

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1972,10 +1972,10 @@ wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
   cleanup_close int signalfd = -1;
   int ret, container_exit_code = 0, last_process;
   sigset_t mask;
-  int fds[10];
-  int levelfds[10];
-  int levelfds_len = 0;
-  int fds_len = 0;
+  int in_fds[10];
+  int in_levelfds[10];
+  int in_levelfds_len = 0;
+  int in_fds_len = 0;
   cleanup_seccomp_notify_context struct seccomp_notify_context_s *seccomp_notify_ctx = NULL;
 
   container_exit_code = 0;
@@ -2051,21 +2051,21 @@ wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
       if (UNLIKELY (ret < 0))
         return ret;
 
-      fds[fds_len++] = args->seccomp_notify_fd;
+      in_fds[in_fds_len++] = args->seccomp_notify_fd;
     }
 
-  fds[fds_len++] = signalfd;
+  in_fds[in_fds_len++] = signalfd;
   if (args->notify_socket >= 0)
-    fds[fds_len++] = args->notify_socket;
+    in_fds[in_fds_len++] = args->notify_socket;
   if (args->terminal_fd >= 0)
     {
-      fds[fds_len++] = 0;
-      levelfds[levelfds_len++] = args->terminal_fd;
+      in_fds[in_fds_len++] = 0;
+      in_levelfds[in_levelfds_len++] = args->terminal_fd;
     }
-  fds[fds_len++] = -1;
-  levelfds[levelfds_len++] = -1;
+  in_fds[in_fds_len++] = -1;
+  in_levelfds[in_levelfds_len++] = -1;
 
-  epollfd = epoll_helper (fds, levelfds, err);
+  epollfd = epoll_helper (in_fds, in_levelfds, NULL, NULL, err);
   if (UNLIKELY (epollfd < 0))
     return epollfd;
 

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2041,7 +2041,7 @@ wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
       conf.bundle_path = args->context->bundle;
       conf.oci_config_path = oci_config_path;
 
-      ret = set_blocking_fd (args->seccomp_notify_fd, 0, err);
+      ret = set_blocking_fd (args->seccomp_notify_fd, false, err);
       if (UNLIKELY (ret < 0))
         return ret;
 
@@ -2098,7 +2098,7 @@ wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
             }
           else if (events[i].data.fd == args->terminal_fd)
             {
-              ret = set_blocking_fd (args->terminal_fd, 0, err);
+              ret = set_blocking_fd (args->terminal_fd, false, err);
               if (UNLIKELY (ret < 0))
                 return crun_error_wrap (err, "set terminal fd not blocking");
 
@@ -2106,7 +2106,7 @@ wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
               if (UNLIKELY (ret < 0))
                 return crun_error_wrap (err, "copy from terminal fd");
 
-              ret = set_blocking_fd (args->terminal_fd, 1, err);
+              ret = set_blocking_fd (args->terminal_fd, true, err);
               if (UNLIKELY (ret < 0))
                 return crun_error_wrap (err, "set terminal fd blocking");
             }

--- a/src/libcrun/ring_buffer.c
+++ b/src/libcrun/ring_buffer.c
@@ -1,0 +1,234 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2024 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#define _GNU_SOURCE
+#include <config.h>
+#include <sys/uio.h>
+
+#include "ring_buffer.h"
+#include "utils.h"
+
+struct ring_buffer
+{
+  char *buffer;
+  size_t size;
+  size_t head;
+  size_t tail;
+};
+
+/*
+ * It returns up to two regions in `iov` that can be read from.
+ */
+static int
+ring_buffer_get_read_iov (struct ring_buffer *rb, struct iovec *iov)
+{
+  int iov_count = 0;
+
+  /* Buffer is empty.  */
+  if (rb->head == rb->tail)
+    return 0;
+
+  /* Head before tail.  There is only one region to read from, up to tail.  */
+  if (rb->tail > rb->head)
+    {
+      iov[iov_count].iov_base = rb->buffer + rb->head;
+      iov[iov_count].iov_len = rb->tail - rb->head;
+      iov_count++;
+    }
+  /* Head after tail.  There are two regions to read from, up to the
+   * end of the buffer and from the beginning of the buffer to tail.  */
+  else
+    {
+      iov[iov_count].iov_base = rb->buffer + rb->head;
+      iov[iov_count].iov_len = rb->size - rb->head;
+      iov_count++;
+
+      if (rb->tail > 0)
+        {
+          iov[iov_count].iov_base = rb->buffer;
+          iov[iov_count].iov_len = rb->tail;
+          iov_count++;
+        }
+    }
+  return iov_count;
+}
+
+/*
+ * It returns up to two regions in `iov` that can be written to without overwriting
+ * existing data.
+ */
+static int
+ring_buffer_get_write_iov (struct ring_buffer *rb, struct iovec *iov)
+{
+  int iov_count = 0;
+
+  /* Buffer is full.  */
+  if (rb->tail + 1 == rb->head)
+    return 0;
+
+  /* Tail before head.  There is only one region to write to, up to head.  */
+  if (rb->head > rb->tail + 1)
+    {
+      iov[iov_count].iov_base = rb->buffer + rb->tail;
+      iov[iov_count].iov_len = rb->head - rb->tail - 1;
+      iov_count++;
+    }
+  /* Tail after or equal to head.  There are two regions to write to, up to the
+   * end of the buffer and from the beginning of the buffer to head.  */
+  else
+    {
+      iov[iov_count].iov_base = rb->buffer + rb->tail;
+      iov[iov_count].iov_len = rb->size - rb->tail;
+      iov_count++;
+
+      if (rb->head > 1)
+        {
+          iov[iov_count].iov_base = rb->buffer;
+          iov[iov_count].iov_len = rb->head - 1;
+          iov_count++;
+        }
+    }
+  return iov_count;
+}
+
+/* manually advance the head after a successful read.  */
+static void
+ring_buffer_advance_nocheck_head (struct ring_buffer *rb, size_t amount)
+{
+  rb->head = (rb->head + amount) % rb->size;
+}
+
+/* manually advance the tail after a successful write.  */
+static void
+ring_buffer_advance_nocheck_tail (struct ring_buffer *rb, size_t amount)
+{
+  rb->tail = (rb->tail + amount) % rb->size;
+}
+
+size_t
+ring_buffer_get_data_available (struct ring_buffer *rb)
+{
+  if (rb->head <= rb->tail)
+    return rb->tail - rb->head;
+
+  return rb->size - rb->head + rb->tail;
+}
+
+size_t
+ring_buffer_get_size (struct ring_buffer *rb)
+{
+  return rb->size - 1;
+}
+
+size_t
+ring_buffer_get_space_available (struct ring_buffer *rb)
+{
+  return rb->size - ring_buffer_get_data_available (rb) - 1;
+}
+
+int
+ring_buffer_read (struct ring_buffer *rb, int fd, bool *is_eagain, libcrun_error_t *err)
+{
+  struct iovec iov[2];
+  int iov_count = 0;
+  ssize_t ret;
+
+  *is_eagain = false;
+
+  iov_count = ring_buffer_get_write_iov (rb, iov);
+  if (iov_count == 0)
+    {
+      *is_eagain = true;
+      return 0;
+    }
+
+  ret = readv (fd, iov, iov_count);
+  if (UNLIKELY (ret < 0))
+    {
+      if (errno == EIO)
+        return 0;
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+          *is_eagain = true;
+          return 0;
+        }
+      return crun_make_error (err, errno, "readv");
+    }
+  ring_buffer_advance_nocheck_tail (rb, ret);
+  return ret;
+}
+
+int
+ring_buffer_write (struct ring_buffer *rb, int fd, bool *is_eagain, libcrun_error_t *err)
+{
+  ssize_t ret;
+  struct iovec iov[2];
+  int iov_count = 0;
+
+  *is_eagain = false;
+
+  iov_count = ring_buffer_get_read_iov (rb, iov);
+  if (iov_count == 0)
+    {
+      *is_eagain = true;
+      return 0;
+    }
+
+  ret = writev (fd, iov, iov_count);
+  if (UNLIKELY (ret < 0))
+    {
+      if (errno == EIO)
+        return 0;
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+          *is_eagain = true;
+          return 0;
+        }
+      return crun_make_error (err, errno, "writev");
+    }
+  ring_buffer_advance_nocheck_head (rb, ret);
+  /* If the buffer is empty, reset the head and tail.  */
+  if (rb->head == rb->tail)
+    {
+      rb->head = 0;
+      rb->tail = 0;
+    }
+  return ret;
+}
+
+struct ring_buffer *
+ring_buffer_make (size_t size)
+{
+  struct ring_buffer *rb = xmalloc (sizeof (struct ring_buffer));
+
+  /* The extra byte is used to distinguish between full and empty buffer.  */
+  rb->size = size + 1;
+  rb->buffer = xmalloc (rb->size);
+  rb->head = 0;
+  rb->tail = 0;
+
+  return rb;
+}
+
+void
+ring_buffer_free (struct ring_buffer *rb)
+{
+  if (rb == NULL)
+    return;
+  free (rb->buffer);
+  free (rb);
+}

--- a/src/libcrun/ring_buffer.h
+++ b/src/libcrun/ring_buffer.h
@@ -1,0 +1,52 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2024 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef RING_BUFFER_H
+#define RING_BUFFER_H
+
+#include <config.h>
+
+#include "error.h"
+#include "utils.h"
+
+struct ring_buffer;
+
+size_t ring_buffer_get_data_available (struct ring_buffer *rb);
+
+size_t ring_buffer_get_space_available (struct ring_buffer *rb);
+
+size_t ring_buffer_get_size (struct ring_buffer *rb);
+
+int ring_buffer_read (struct ring_buffer *rb, int fd, bool *is_eagain, libcrun_error_t *err);
+
+int ring_buffer_write (struct ring_buffer *rb, int fd, bool *is_eagain, libcrun_error_t *err);
+
+struct ring_buffer *ring_buffer_make (size_t size);
+
+void ring_buffer_free (struct ring_buffer *rb);
+
+#define cleanup_ring_buffer __attribute__ ((cleanup (cleanup_ring_bufferp)))
+
+static inline void
+cleanup_ring_bufferp (struct ring_buffer **p)
+{
+  struct ring_buffer *rb = *p;
+  if (rb)
+    ring_buffer_free (rb);
+}
+
+#endif

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1831,7 +1831,7 @@ get_current_timestamp (char *out, size_t len)
 }
 
 int
-set_blocking_fd (int fd, int blocking, libcrun_error_t *err)
+set_blocking_fd (int fd, bool blocking, libcrun_error_t *err)
 {
   int ret, flags = fcntl (fd, F_GETFL, 0);
   if (UNLIKELY (flags < 0))

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -325,7 +325,7 @@ int receive_fd_from_socket_with_payload (int from, char *payload, size_t payload
 
 int create_signalfd (sigset_t *mask, libcrun_error_t *err);
 
-int epoll_helper (int *fds, int *levelfds, libcrun_error_t *err);
+int epoll_helper (int *in_fds, int *in_levelfds, int *out_fds, int *out_levelfds, libcrun_error_t *err);
 
 int copy_from_fd_to_fd (int src, int dst, int consume, libcrun_error_t *err);
 

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -475,4 +475,37 @@ validate_options (unsigned int specified_options, unsigned int supported_options
 
 extern int cpuset_string_to_bitmask (const char *str, char **out, size_t *out_size, libcrun_error_t *err);
 
+/*
+ * A channel_fd_pair takes care of copying data between two file descriptors.
+ * The two file descriptors are expected to be set to non-blocking mode.
+ * The channel_fd_pair will buffer data read from the input file descriptor and
+ * write it to the output file descriptor.  If the output file descriptor is not
+ * ready to accept the data, the channel_fd_pair will buffer the data until it
+ * can be written.
+ */
+struct channel_fd_pair;
+
+struct channel_fd_pair *channel_fd_pair_new (int in_fd, int out_fd, size_t size);
+
+void channel_fd_pair_free (struct channel_fd_pair *channel);
+
+/* Process the data in the channel_fd_pair.  This function will read data from
+ * the input file descriptor and write it to the output file descriptor.  If
+ * the output file descriptor is not ready to accept the data, the data will be
+ * buffered.  If epollfd is provided, the in_fd and out_fd will be registered
+ * and unregistered as necessary.
+ */
+int channel_fd_pair_process (struct channel_fd_pair *channel, int epollfd, libcrun_error_t *err);
+
+static inline void
+cleanup_channel_fd_pairp (void *p)
+{
+  struct channel_fd_pair **pp = (struct channel_fd_pair **) p;
+  if (*pp == NULL)
+    return;
+
+  channel_fd_pair_free (*pp);
+}
+#define cleanup_channel_fd_pair __attribute__ ((cleanup (cleanup_channel_fd_pairp)))
+
 #endif

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -340,7 +340,7 @@ int mark_or_close_fds_ge_than (int n, bool close_now, libcrun_error_t *err);
 
 void get_current_timestamp (char *out, size_t len);
 
-int set_blocking_fd (int fd, int blocking, libcrun_error_t *err);
+int set_blocking_fd (int fd, bool blocking, libcrun_error_t *err);
 
 int parse_json_file (yajl_val *out, const char *jsondata, struct parser_context *ctx, libcrun_error_t *err);
 

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -591,11 +591,14 @@ def test_cgroup_mount_without_netns():
 
         out, _ = run_and_get_output(conf)
         print(out)
+        # validate there are two mounts
+        count = 0
         for i in out.split("\n"):
             if i.find("/sys/fs/cgroup") >= 0:
-                if i.find("tmpfs") >= 0:
-                    print("tmpfs temporary mount still present with cgroupns=%s %s" % (cgroupns, i))
-                    return -1
+                count = count + 1
+        if count < 2:
+            print("fail with cgroupns=%s, got %s" % (cgroupns, out))
+            return -1
     return 0
 
 all_tests = {

--- a/tests/tests_libcrun_ring_buffer.c
+++ b/tests/tests_libcrun_ring_buffer.c
@@ -1,0 +1,282 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2017, 2018, 2019, 2024 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE
+
+#include <libcrun/ring_buffer.h>
+#include <libcrun/utils.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+typedef int (*test) ();
+
+static void
+fill_data (char *buffer, size_t size)
+{
+  size_t i;
+  buffer[0] = rand () % 256;
+  for (i = 1; i < size; i++)
+    buffer[i] = buffer[i - 1] + 13;
+}
+
+static int
+do_test_ring_buffer_read_write (int max_data_size, int rb_size)
+{
+  const int repeat = 2048;
+  cleanup_free char *buffer_w = xmalloc (max_data_size);
+  cleanup_free char *buffer_r = xmalloc (max_data_size);
+  libcrun_error_t err = NULL;
+  int fds_to_close[5] = {
+    -1,
+  };
+  int fds_to_close_n = 0;
+  cleanup_close_vec int *autocleanup_fds = fds_to_close;
+  cleanup_ring_buffer struct ring_buffer *rb = NULL;
+  int ret = 0;
+  int fd_w[2];
+  int fd_r[2];
+  size_t i;
+
+  if (max_data_size > rb_size)
+    {
+      fprintf (stderr, "max_data_size must be smaller than rb_size\n");
+      return 1;
+    }
+  if (pipe2 (fd_w, O_NONBLOCK) < 0)
+    {
+      fprintf (stderr, "failed to create pipe\n");
+      return 1;
+    }
+  if (pipe2 (fd_r, O_NONBLOCK) < 0)
+    {
+      fprintf (stderr, "failed to create pipe\n");
+      return 1;
+    }
+
+  /* use a bigger buffer size for the pipe to be sure synchronization
+   * between reads and writes is not just a side effect of the
+   * underlying buffer size.  */
+  ret = fcntl (fd_w[0], F_SETPIPE_SZ, max_data_size * 2);
+  if (ret < 0)
+    {
+      fprintf (stderr, "failed to set pipe size\n");
+      return 1;
+    }
+  ret = fcntl (fd_r[0], F_SETPIPE_SZ, max_data_size * 2);
+  if (ret < 0)
+    {
+      fprintf (stderr, "failed to set pipe size\n");
+      return 1;
+    }
+
+  fds_to_close[fds_to_close_n++] = fd_w[0];
+  fds_to_close[fds_to_close_n++] = fd_w[1];
+  fds_to_close[fds_to_close_n++] = fd_r[0];
+  fds_to_close[fds_to_close_n++] = fd_r[1];
+  fds_to_close[fds_to_close_n++] = -1;
+
+  rb = ring_buffer_make (rb_size);
+
+  fill_data (buffer_w, max_data_size);
+
+  for (i = 0; i < repeat; i++)
+    {
+      bool is_eagain = false;
+      size_t avail;
+      size_t data_size = 1 + (i % max_data_size);
+
+      memset (buffer_r, 0, max_data_size);
+
+      fill_data (buffer_w, data_size);
+      avail = ring_buffer_get_size (rb);
+      if (avail != rb_size)
+        {
+          fprintf (stderr, "wrong get_size\n");
+          return 1;
+        }
+
+      avail = ring_buffer_get_data_available (rb);
+      if (avail != 0)
+        {
+          fprintf (stderr, "wrong get_data_available for empty ring buffer\n");
+          return 1;
+        }
+
+      ret = write (fd_r[1], buffer_w, data_size);
+      if (ret != data_size)
+        {
+          fprintf (stderr, "write failed\n");
+          return 1;
+        }
+
+      ret = ring_buffer_read (rb, fd_r[0], &is_eagain, &err);
+      if (ret < 0)
+        {
+          libcrun_error_release (&err);
+          fprintf (stderr, "read from ring_buffer failed\n");
+          return 1;
+        }
+      if (is_eagain)
+        {
+          fprintf (stderr, "read from ring_buffer failed with EAGAIN\n");
+          return 1;
+        }
+      avail = ring_buffer_get_data_available (rb);
+      if (avail != ret)
+        {
+          fprintf (stderr, "wrong get_data_available got %zu instead of %zu\n", avail, ret);
+          return 1;
+        }
+      avail = ring_buffer_get_space_available (rb);
+      if (avail != rb_size - ret)
+        {
+          fprintf (stderr, "wrong get_space_available got %zu instead of %zu\n", avail, rb_size - ret);
+          return 1;
+        }
+
+      ret = ring_buffer_write (rb, fd_w[1], &is_eagain, &err);
+      if (ret < 0)
+        {
+          libcrun_error_release (&err);
+          fprintf (stderr, "write to ring_buffer failed\n");
+          return 1;
+        }
+      if (is_eagain)
+        {
+          fprintf (stderr, "write failed with EAGAIN\n");
+          return 1;
+        }
+      if (ret != data_size)
+        {
+          fprintf (stderr, "write to ring_buffer wrong size\n");
+          return 1;
+        }
+      avail = ring_buffer_get_data_available (rb);
+      if (avail != 0)
+        {
+          fprintf (stderr, "wrong get_data_available got %zu instead of 0\n", avail);
+          return 1;
+        }
+      avail = ring_buffer_get_space_available (rb);
+      if (avail != rb_size)
+        {
+          fprintf (stderr, "wrong get_space_available got %zu instead of %zu\n", avail, rb_size);
+          return 1;
+        }
+
+      ret = read (fd_w[0], buffer_r, data_size);
+      if (ret != data_size)
+        {
+          fprintf (stderr, "read wrong size\n");
+          return 1;
+        }
+      if (memcmp (buffer_w, buffer_r, data_size) != 0)
+        {
+          fprintf (stderr, "data mismatch\n");
+          return 1;
+        }
+
+      /* Try again with an empty fd and an empty ring buffer.  */
+      is_eagain = false;
+      ret = ring_buffer_read (rb, fd_r[0], &is_eagain, &err);
+      if (ret < 0)
+        {
+          libcrun_error_release (&err);
+          fprintf (stderr, "read to ring_buffer failed\n");
+          return 1;
+        }
+      if (! is_eagain)
+        {
+          fprintf (stderr, "read should have returned EAGAIN\n");
+          return 1;
+        }
+
+      is_eagain = false;
+      ret = ring_buffer_write (rb, fd_w[1], &is_eagain, &err);
+      if (ret < 0)
+        {
+          libcrun_error_release (&err);
+          fprintf (stderr, "write to ring_buffer failed\n");
+          return 1;
+        }
+      if (! is_eagain)
+        {
+          fprintf (stderr, "write should have returned EAGAIN\n");
+          return 1;
+        }
+    }
+
+  return 0;
+}
+
+static int
+test_ring_buffer_read_write ()
+{
+  int max_data_sizes[] = { 1, 7, 10, 101, 1024, 4096, 4096, 7919, 8191, 8192 };
+  int rb_sizes[] = { 11, 16, 128, 512, 2048, 4096, 4096, 8192, 8192, 8192 };
+  int ret;
+  int i;
+
+  if (sizeof (max_data_sizes) != sizeof (rb_sizes))
+    {
+      fprintf (stderr, "internal error: max_data_sizes and rb_sizes must have the same length\n");
+      return 1;
+    }
+
+  for (i = 0; i < sizeof (max_data_sizes) / sizeof (max_data_sizes[0]); i++)
+    {
+      ret = do_test_ring_buffer_read_write (max_data_sizes[i], rb_sizes[i]);
+      if (ret < 0)
+        {
+          fprintf (stderr, "test failed with data_size=%d, rb_size=%d\n", max_data_sizes[i], rb_sizes[i]);
+          return ret;
+        }
+    }
+  return 0;
+}
+
+static void
+run_and_print_test_result (const char *name, int id, test t)
+{
+  int ret = t ();
+  if (ret == 0)
+    printf ("ok %d - %s\n", id, name);
+  else if (ret == 77)
+    printf ("ok %d - %s #SKIP\n", id, name);
+  else
+    printf ("not ok %d - %s\n", id, name);
+}
+
+#define RUN_TEST(T)                            \
+  do                                           \
+    {                                          \
+      run_and_print_test_result (#T, id++, T); \
+  } while (0)
+
+int
+main ()
+{
+  int id = 1;
+  printf ("1..1\n");
+
+  RUN_TEST (test_ring_buffer_read_write);
+  return 0;
+}


### PR DESCRIPTION
avoid a "crun exec" hang when the the other end of the terminal stopped reading.

That happened because `copy_fd_to_fd` tried to write everything that it has received from the source fd, so it would hang the current process.  Prevent that using non blocking file descriptors and using epoll to detect when the file descriptor is available for write.

Fixes: https://issues.redhat.com/browse/OCPBUGS-45632
