### PR TITLE
TMT: Replace adjust with prepare conditionals

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -65,7 +65,7 @@ jobs:
     trigger: pull_request
     packages: [crun-centos]
     notifications: *copr_build_failure_notification
-    targets: &centos_targets
+    targets: &centos_copr_targets
       # Need epel9 repos to fetch wasmedge build dependency
       centos-stream-9-x86_64:
         additional_repos:
@@ -107,7 +107,7 @@ jobs:
     trigger: pull_request
     packages: [crun-centos]
     notifications: *podman_system_test_fail_notification
-    targets: *centos_targets
+    targets: *centos_copr_targets
     tf_extra_params:
       environments:
         - artifacts:

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -2,26 +2,15 @@ discover:
     how: fmf
 execute:
     how: tmt
-adjust:
+prepare:
+    - how: feature
+      epel: enabled
     - when: initiator == packit
       because: "We need to test with updated packages from rhcontainerbot/podman-next copr"
-      prepare+:
-        how: shell
-        script: |
-            sed -i -n '/^priority=/!p;$apriority=1' /etc/yum.repos.d/*podman-next*.repo
-            dnf -y upgrade --allowerasing
-    # FIXME: Use epel10 once bats is available there
-    - when: distro == centos-stream-10 or distro == rhel-10
-      because: "bats isn't yet available on epel10"
-      prepare+:
-        how: install
-        copr: rhcontainerbot/bats-el10
-        package: bats
-    - when: distro == centos-stream-9 or distro == rhel-9
-      because: "bats is present on EPEL on rhel9 / c9s"
-      prepare+:
-        how: feature
-        epel: enabled
+      how: shell
+      script: |
+        sed -i -n '/^priority=/!p;$apriority=1' /etc/yum.repos.d/*podman-next*.repo
+        dnf -y upgrade --allowerasing
 
 /upstream:
     summary: Run crun specific Podman system tests on upstream PRs


### PR DESCRIPTION
The previous `adjust` conditionals ended up skipping copr repo and package upgrade steps for CentOS Stream environments.

This should be resolved by directly using `prepare` and `when` keywords for setting conditions.