### PR TITLE
utils: return error from set_home_env() if the user was not found

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1467,9 +1467,6 @@ set_home_env (uid_t id)
       ret = fgetpwent_r (stream, &pwd, buf, buf_size, &ret_pw);
       if (UNLIKELY (ret != 0))
         {
-          if (errno == ENOENT)
-            goto error;
-
           if (errno != ERANGE)
             goto error;
 


### PR DESCRIPTION
If a given user cannot be found within the container, for example, because the specific `UID` does not exist, then return an error and let the callers of the `set_home_env()` function handle the case of the missing user appropriately.

This will fix an issue where when the user cannot be found, the `HOME` environment variable is not set, which can cause some software not to work correctly.

The two current callers already correctly handled the case when the user was not found per:

- https://github.com/containers/crun/blob/bd4f77330961819150f35bc42f4a6dc44ff135e7/src/libcrun/container.c#L1199-L1207

- https://github.com/containers/crun/blob/bd4f77330961819150f35bc42f4a6dc44ff135e7/src/libcrun/container.c#L3406-L3414

The above will issue a warning and correctly set the `HOME` environment variable to `/` as a fall-back on error.

Related:

- https://github.com/containers/crun/pull/104
- https://github.com/containers/crun/pull/599