### PR TITLE
Revert "cgroup: remove tun/tap from the default allow list"

### DIFF
--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -50,6 +50,7 @@ struct default_dev_s default_devices[] = {
   { 'c', 5, 1, "rwm" },
   { 'c', 136, -1, "rwm" },
   { 'c', 5, 2, "rwm" },
+  { 'c', 10, 200, "rwm" },
   { 0, 0, 0, NULL }
 };
 


### PR DESCRIPTION
This reverts commit 1e3042427df0eb04add740f1618fae7d0827fa63.

Copy what runc is already doing here: https://github.com/opencontainers/runc/pull/4555