### PR TITLE
cgroup: Show the absolute path to cgroup.controllers when a controller is not available

### DIFF
--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -177,8 +177,15 @@ check_cgroup_v2_controller_available_wrapper (int ret, int cgroup_dirfd, const c
         }
       if (! found)
         {
+          cleanup_free char *absolute_path = NULL;
+          libcrun_error_t tmp_err = NULL;
+
           crun_error_release (err);
-          return crun_make_error (err, 0, "the requested cgroup controller `%s` is not available", key);
+          ret = get_realpath_to_file(cgroup_dirfd, "cgroup.controllers", &absolute_path, &tmp_err);
+          if (UNLIKELY (ret < 0))
+            ret = crun_make_error (err, 0, "the requested cgroup controller `%s` is not available", key);
+          else
+            ret = crun_make_error (err, 0, "controller `%s` is not available under %s", key, absolute_path);
         }
     }
   return ret;

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1057,6 +1057,27 @@ read_all_file (const char *path, char **out, size_t *len, libcrun_error_t *err)
 }
 
 int
+get_realpath_to_file(int dirfd, const char *path_name, char **absolute_path, libcrun_error_t *err)
+{
+  cleanup_close int targetfd = -1;
+
+  targetfd = TEMP_FAILURE_RETRY (openat (dirfd, path_name, O_RDONLY | O_CLOEXEC));
+  if (UNLIKELY (targetfd < 0))
+    return crun_make_error (err, errno, "error opening file `%s`", path_name);
+  else
+    {
+      proc_fd_path_t target_fd_path;
+
+      get_proc_self_fd_path (target_fd_path, targetfd);
+      *absolute_path = realpath(target_fd_path, NULL);
+      if (UNLIKELY (*absolute_path == NULL))
+        return crun_make_error (err, errno, "error unable to provide absolute path to file `%s`", path_name);
+    }
+
+  return 0;
+}
+
+int
 open_unix_domain_client_socket (const char *path, int dgram, libcrun_error_t *err)
 {
   struct sockaddr_un addr = {};

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -305,6 +305,8 @@ read_all_fd (int fd, const char *description, char **out, size_t *len, libcrun_e
   return read_all_fd_with_size_hint (fd, description, out, len, 0, err);
 }
 
+int get_realpath_to_file(int dirfd, const char *path_name, char **absolute_path, libcrun_error_t *err);
+
 int read_all_file (const char *path, char **out, size_t *len, libcrun_error_t *err);
 
 int read_all_file_at (int dirfd, const char *path, char **out, size_t *len, libcrun_error_t *err);


### PR DESCRIPTION
This patch will provide the absolute path to the cgroup.controllers file in the error message if the specified controller is not available. Hopefully this will help with troubleshooting efforts.