### PR TITLE
TMT: account for environments on internal testing farm ranch

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -3,14 +3,26 @@ discover:
 execute:
     how: tmt
 prepare:
-    - how: feature
-      epel: enabled
-    - when: initiator == packit
-      because: "We need to test with updated packages from rhcontainerbot/podman-next copr"
+    - when: distro == centos-stream or distro == rhel
       how: shell
       script: |
-        sed -i -n '/^priority=/!p;$apriority=1' /etc/yum.repos.d/*podman-next*.repo
+        dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm --eval '%{?rhel}').noarch.rpm
+        dnf -y config-manager --set-enabled epel
+      order: 10
+    - when: initiator == packit
+      how: shell
+      script: |
+        COPR_REPO_FILE="/etc/yum.repos.d/*podman-next*.repo"
+        if compgen -G $COPR_REPO_FILE > /dev/null; then
+            sed -i -n '/^priority=/!p;$apriority=1' $COPR_REPO_FILE
+        fi
         dnf -y upgrade --allowerasing
+      order: 20
+    - how: install
+      package:
+        - bats
+        - crun
+        - podman-tests
 
 /upstream:
     summary: Run crun specific Podman system tests on upstream PRs

--- a/tests/tmt/podman/system-test.fmf
+++ b/tests/tmt/podman/system-test.fmf
@@ -1,10 +1,3 @@
-require:
-    - bats
-    - conmon
-    - crun
-    - make
-    - podman-tests
-
 adjust:
     duration: 10m
     when: arch == aarch64

--- a/tests/tmt/sanity/main.fmf
+++ b/tests/tmt/sanity/main.fmf
@@ -1,4 +1,3 @@
-require: [crun, podman]
 summary: Sanity test for crun
 tag: ['upstream', 'downstream']
 test: bash ./runtest.sh


### PR DESCRIPTION
RHEL envs on the internal redhat testing farm ranch don't have any easy way to install and enable the `epel-release` package.

Also, CentOS-Stream envs on the internal ranch have EPEL installed but disabled.

This PR should account for both these envs. The tests on public ranch should continue unaffected.

The packages required for testing have also been moved to the plan preparation stage itself.