### PR TITLE
README: fix EL8 go-md2man install

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,8 @@ installed with:
 
 ```console
 $ sudo yum --enablerepo='*' install -y golang
-$ export GOPATH=$HOME/go
-$ go get github.com/cpuguy83/go-md2man
-$ export PATH=$PATH:$GOPATH/bin
+$ go install github.com/cpuguy83/go-md2man@latest
+$ export PATH=$PATH:$(go env GOPATH)/bin
 ```
 
 ### Ubuntu


### PR DESCRIPTION
Currently EL8 comes with Go 1.22.x, which means `go install` (rather than `go get`) should be used.

Also,
 - there is no need to set `GOPATH`;
 - `go env GOPATH` can be used to determine the built-in default.

Tested on AlmaLinux 8.10.