### PR TITLE
exec: always call setsid

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,8 +36,8 @@ jobs:
           githubToken: ${{ github.token }}
 
           install: |
-            apt-get update -q -y
-            apt-get install -q -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev libprotobuf-c-dev
+            apt-get update -y
+            apt-get install -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev libprotobuf-c-dev
 
           run: |
             find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
           run: |
             find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;
             ./autogen.sh
-            ./configure CFLAGS='-Wall -Werror'
+            ./configure CFLAGS='-Wall -Werror' || cat config.log
             make -j $(nproc) -C libocispec libocispec.la
             make git-version.h
             make -j $(nproc) libcrun.la

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ jobs:
   build_job:
     runs-on: ubuntu-latest
     name: Build on ${{ matrix.arch }}
+    permissions:
+      contents: read
+      packages: write
 
     strategy:
       matrix:

--- a/tests/init.c
+++ b/tests/init.c
@@ -690,6 +690,13 @@ main (int argc, char **argv)
   if (strcmp (argv[1], "systemd-notify") == 0)
     return sd_notify ();
 
+  if (strcmp (argv[1], "getpgrp") == 0)
+    {
+      pid_t pid = getpgrp ();
+      printf ("%d\n", pid);
+      return 0;
+    }
+
   if (strcmp (argv[1], "check-feature") == 0)
     {
       if (argc < 3)


### PR DESCRIPTION
previously setsid was called only for interactive sessions.  Change it to be always used for the "crun exec" process.

Closes: https://github.com/containers/crun/issues/1642