### PR TITLE
status: validate container id

### DIFF
--- a/lua/lua_crun.c
+++ b/lua/lua_crun.c
@@ -512,9 +512,10 @@ luacrun_ctx_status_container (lua_State *S)
     cleanup_container libcrun_container_t *container = NULL;
     cleanup_free char *dir = NULL;
 
-    dir = libcrun_get_state_directory (state_root, id);
-    if (dir == NULL)
+    ret = libcrun_get_state_directory (&dir, state_root, id, &crun_err);
+    if (UNLIKELY (ret < 0))
       {
+        libcrun_error_release (&crun_err);
         lua_pushnil (S);
         lua_pushstring (S, "cannot get state directory");
         return 2;
@@ -526,6 +527,7 @@ luacrun_ctx_status_container (lua_State *S)
     lua_pop (S, 1);
     if (container == NULL)
       {
+        libcrun_error_release (&crun_err);
         lua_pushnil (S);
         lua_pushstring (S, "error loading config.json");
         return 2;

--- a/src/crun.c
+++ b/src/crun.c
@@ -239,7 +239,18 @@ static struct argp_option options[] = { { "debug", OPTION_DEBUG, 0, 0, "produce 
 static void
 print_version (FILE *stream, struct argp_state *state arg_unused)
 {
-  cleanup_free char *rundir = libcrun_get_state_directory (arguments.root, NULL);
+  libcrun_error_t err = NULL;
+  cleanup_free char *rundir = NULL;
+  int ret;
+
+  ret = libcrun_get_state_directory (&rundir, arguments.root, NULL, &err);
+  if (UNLIKELY (ret < 0))
+    {
+      libcrun_error_release (&err);
+      fprintf (stderr, "Failed to get state directory\n");
+      exit (EXIT_FAILURE);
+    }
+
   fprintf (stream, "%s version %s\n", PACKAGE_NAME, PACKAGE_VERSION);
   fprintf (stream, "commit: %s\n", GIT_VERSION);
   fprintf (stream, "rundir: %s\n", rundir);

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1551,7 +1551,9 @@ enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *resource
 
   *can_retry = false;
 
-  state_dir = libcrun_get_state_directory (state_root, NULL);
+  ret = libcrun_get_state_directory (&state_dir, state_root, NULL, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   i = 0;
   boolean_opts[i++] = "Delegate";
@@ -1937,7 +1939,9 @@ libcrun_update_resources_systemd (struct libcrun_cgroup_status *cgroup_status,
   int sd_err, ret;
   int cgroup_mode;
 
-  state_dir = libcrun_get_state_directory (state_root, NULL);
+  ret = libcrun_get_state_directory (&state_dir, state_root, NULL, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
   if (UNLIKELY (cgroup_mode < 0))

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1604,9 +1604,9 @@ read_container_config_from_state (libcrun_container_t **container, const char *s
 
   *container = NULL;
 
-  dir = libcrun_get_state_directory (state_root, id);
-  if (UNLIKELY (dir == NULL))
-    return crun_make_error (err, 0, "cannot get state directory from `%s`", state_root);
+  ret = libcrun_get_state_directory (&dir, state_root, id, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   ret = append_paths (&config_file, err, dir, "config.json", NULL);
   if (UNLIKELY (ret < 0))
@@ -2041,9 +2041,9 @@ wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
       struct libcrun_load_seccomp_notify_conf_s conf;
       memset (&conf, 0, sizeof conf);
 
-      state_root = libcrun_get_state_directory (args->context->state_root, args->context->id);
-      if (UNLIKELY (state_root == NULL))
-        return crun_make_error (err, 0, "cannot get state directory");
+      ret = libcrun_get_state_directory (&state_root, args->context->state_root, args->context->id, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
 
       ret = append_paths (&oci_config_path, err, state_root, "config.json", NULL);
       if (UNLIKELY (ret < 0))
@@ -2777,9 +2777,9 @@ libcrun_copy_config_file (const char *id, const char *state_root, libcrun_contai
   cleanup_free char *buffer = NULL;
   size_t len;
 
-  dir = libcrun_get_state_directory (state_root, id);
-  if (UNLIKELY (dir == NULL))
-    return crun_make_error (err, 0, "cannot get state directory");
+  ret = libcrun_get_state_directory (&dir, state_root, id, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   ret = append_paths (&dest_path, err, dir, "config.json", NULL);
   if (UNLIKELY (ret < 0))
@@ -3259,12 +3259,9 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
     cleanup_container libcrun_container_t *container = NULL;
     cleanup_free char *dir = NULL;
 
-    dir = libcrun_get_state_directory (state_root, id);
-    if (UNLIKELY (dir == NULL))
-      {
-        ret = crun_make_error (err, 0, "cannot get state directory");
-        goto exit;
-      }
+    ret = libcrun_get_state_directory (&dir, state_root, id, err);
+    if (UNLIKELY (ret < 0))
+      goto exit;
 
     ret = append_paths (&config_file, err, dir, "config.json", NULL);
     if (UNLIKELY (ret < 0))
@@ -3598,9 +3595,9 @@ libcrun_container_exec_with_options (libcrun_context_t *context, const char *id,
     return ret;
   container_status = ret;
 
-  dir = libcrun_get_state_directory (state_root, id);
-  if (UNLIKELY (dir == NULL))
-    return crun_make_error (err, 0, "cannot get state directory");
+  ret = libcrun_get_state_directory (&dir, state_root, id, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   ret = append_paths (&config_file, err, dir, "config.json", NULL);
   if (UNLIKELY (ret < 0))
@@ -4474,9 +4471,9 @@ libcrun_container_update_intel_rdt (libcrun_context_t *context, const char *id, 
   cleanup_free char *dir = NULL;
   int ret;
 
-  dir = libcrun_get_state_directory (context->state_root, id);
-  if (UNLIKELY (dir == NULL))
-    return crun_make_error (err, 0, "cannot get state directory");
+  ret = libcrun_get_state_directory (&dir, context->state_root, id, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   ret = append_paths (&config_file, err, dir, "config.json", NULL);
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -195,9 +195,9 @@ libkrun_configure_container (void *cookie, enum handler_configure_phase phase,
       cleanup_free char *config = NULL;
       size_t config_size;
 
-      state_dir = libcrun_get_state_directory (context->state_root, context->id);
-      if (UNLIKELY (state_dir == NULL))
-        return crun_make_error (err, 0, "could not retrieve the state directory");
+      ret = libcrun_get_state_directory (&state_dir, context->state_root, context->id, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
 
       ret = append_paths (&origin_config_path, err, state_dir, "config.json", NULL);
       if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2362,7 +2362,9 @@ get_notify_fd (libcrun_context_t *context, libcrun_container_t *container, int *
 
   if (host_path == NULL)
     {
-      state_dir = libcrun_get_state_directory (context->state_root, context->id);
+      ret = libcrun_get_state_directory (&state_dir, context->state_root, context->id, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
 
       ret = append_paths (&host_notify_socket_path, err, state_dir, "notify/notify", NULL);
       if (UNLIKELY (ret < 0))
@@ -2406,13 +2408,17 @@ do_notify_socket (libcrun_container_t *container, const char *rootfs, libcrun_er
   const char *notify_socket = container->context->notify_socket;
   cleanup_free char *host_notify_socket_path = NULL;
   cleanup_free char *container_notify_socket_path = NULL;
-  cleanup_free char *state_dir = libcrun_get_state_directory (container->context->state_root, container->context->id);
+  cleanup_free char *state_dir = NULL;
   uid_t container_root_uid = -1;
   gid_t container_root_gid = -1;
   int notify_socket_tree_fd;
 
   if (notify_socket == NULL)
     return 0;
+
+  ret = libcrun_get_state_directory (&state_dir, container->context->state_root, container->context->id, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   ret = append_paths (&container_notify_socket_path, err, rootfs, notify_socket, "notify", NULL);
   if (UNLIKELY (ret < 0))
@@ -4268,9 +4274,9 @@ prepare_and_send_dev_mounts (libcrun_container_t *container, int sync_socket_hos
   if (! has_userns || is_empty_string (container->context->id) || geteuid () > 0)
     return send_mounts (sync_socket_host, dev_fds, how_many, def->linux->devices_len, err);
 
-  state_dir = libcrun_get_state_directory (container->context->state_root, container->context->id);
-  if (state_dir == NULL)
-    return send_mounts (sync_socket_host, dev_fds, how_many, def->linux->devices_len, err);
+  ret = libcrun_get_state_directory (&state_dir, container->context->state_root, container->context->id, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   ret = append_paths (&devs_path, err, state_dir, "devs", NULL);
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -456,10 +456,11 @@ open_rundir_dirfd (const char *state_root, libcrun_error_t *err)
 {
   cleanup_free char *dir = NULL;
   int dirfd;
+  int ret;
 
-  dir = libcrun_get_state_directory (state_root, NULL);
-  if (UNLIKELY (dir == NULL))
-    return crun_make_error (err, 0, "cannot get state directory");
+  ret = libcrun_get_state_directory (&dir, state_root, NULL, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   dirfd = TEMP_FAILURE_RETRY (open (dir, O_PATH | O_DIRECTORY | O_CLOEXEC));
   if (UNLIKELY (dirfd < 0))

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -45,6 +45,16 @@ struct pid_stat
   unsigned long long starttime;
 };
 
+/* If ID is not NULL, then ennsure that it does not contain any slash.  */
+static int
+validate_id (const char *id, libcrun_error_t *err)
+{
+  if (id && strchr (id, '/') != NULL)
+    return crun_make_error (err, 0, "invalid character `/` in the ID `%s`", id);
+
+  return 0;
+}
+
 static int
 get_run_directory (char **out, const char *state_root, libcrun_error_t *err)
 {
@@ -82,6 +92,10 @@ libcrun_get_state_directory (char **out, const char *state_root, const char *id,
   cleanup_free char *path = NULL;
   cleanup_free char *root = NULL;
 
+  ret = validate_id (id, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   ret = get_run_directory (&root, state_root, err);
   if (UNLIKELY (ret < 0))
     return ret;
@@ -101,6 +115,10 @@ get_state_directory_status_file (char **out, const char *state_root, const char 
   cleanup_free char *root = NULL;
   char *path = NULL;
   int ret;
+
+  ret = validate_id (id, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   ret = get_run_directory (&root, state_root, err);
   if (UNLIKELY (ret < 0))
@@ -550,6 +568,10 @@ libcrun_container_delete_status (const char *state_root, const char *id, libcrun
   cleanup_close int rundir_dfd = -1;
   cleanup_close int dfd = -1;
   cleanup_free char *dir = NULL;
+
+  ret = validate_id (id, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   ret = get_run_directory (&dir, state_root, err);
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/status.h
+++ b/src/libcrun/status.h
@@ -55,7 +55,7 @@ LIBCRUN_PUBLIC int libcrun_read_container_status (libcrun_container_status_t *st
                                                   const char *id, libcrun_error_t *err);
 LIBCRUN_PUBLIC void libcrun_free_containers_list (libcrun_container_list_t *list);
 LIBCRUN_PUBLIC int libcrun_is_container_running (libcrun_container_status_t *status, libcrun_error_t *err);
-LIBCRUN_PUBLIC char *libcrun_get_state_directory (const char *state_root, const char *id);
+LIBCRUN_PUBLIC int libcrun_get_state_directory (char **out, const char *state_root, const char *id, libcrun_error_t *err);
 LIBCRUN_PUBLIC int libcrun_container_delete_status (const char *state_root, const char *id, libcrun_error_t *err);
 LIBCRUN_PUBLIC int libcrun_get_containers_list (libcrun_container_list_t **ret, const char *state_root,
                                                 libcrun_error_t *err);

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -540,6 +540,22 @@ def test_run_keep():
 
     return 0
 
+def test_invalid_id():
+    conf = base_config()
+    conf['process']['args'] = ['./init', 'echo', 'hello']
+    conf['process']['cwd'] = "/sbin"
+    add_all_namespaces(conf)
+    try:
+        out, _ = run_and_get_output(conf, id_container="this/is/invalid")
+        return -1
+    except Exception as e:
+        err = e.output.decode()
+        if "invalid character `/` in the ID" in err:
+            return 0
+        sys.stderr.write("Got error: %s\n" % err)
+        return -1
+    return 0
+
 all_tests = {
     "start" : test_start,
     "start-override-config" : test_start_override_config,
@@ -562,6 +578,7 @@ all_tests = {
     "unknown-sysctl": test_unknown_sysctl,
     "ioprio": test_ioprio,
     "run-keep": test_run_keep,
+    "invalid-id": test_invalid_id,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
check that the container name does not contain any slash so that operations in status.c won't risk to access directories/files outside of the run directory.

Beside, it is not a security issue because if a directory exists, crun refuses to use it; and if it does not exist then it is created and immediately deleted because the container creation fails.

Play safe and do not allow any slash in the container name.

Closes: https://github.com/containers/crun/issues/1646