### PR TITLE
linux: improve error writing to net.ipv4.ping_group_range

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3442,6 +3442,17 @@ fail:
   return crun_make_error (err, 0, "the sysctl `%s` requires a new %s namespace", original_key, namespace);
 }
 
+/* Best-effort attempt to give a better explanation why setting a sysctl could have failed. */
+static char *
+sysctl_error_reason (const char *name, int namespaces_created, int errno_)
+{
+
+  if (strcmp (name, "net.ipv4.ping_group_range") == 0 && (errno_ == EINVAL) && (namespaces_created & CLONE_NEWUSER))
+    return xstrdup ("are all the IDs mapped in the user namespace?");
+
+  return NULL;
+}
+
 int
 libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err)
 {
@@ -3491,7 +3502,12 @@ libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err)
 
       ret = TEMP_FAILURE_RETRY (write (fd, def->linux->sysctl->values[i], strlen (def->linux->sysctl->values[i])));
       if (UNLIKELY (ret < 0))
-        return crun_make_error (err, errno, "write to `/proc/sys/%s`", name);
+        {
+          cleanup_free char *reason = NULL;
+
+          reason = sysctl_error_reason (def->linux->sysctl->keys[i], namespaces_created, errno);
+          return crun_make_error (err, errno, "write to `/proc/sys/%s`%s%s%s", name, reason ? " (" : "", reason ?: "", reason ? ")" : "");
+        }
     }
   return 0;
 }


### PR DESCRIPTION
improve the error message when writing to the
/proc/sys/net/ipv4/ping_group_range file and the write fails with EINVAL.  When running in a user namespace, it might mean the requested groups are not mapped.

Closes: https://github.com/containers/crun/issues/1648