### PR TITLE
linux, utils: remove dead code crun_ensure_file*()

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1815,7 +1815,7 @@ create_missing_devs (libcrun_container_t *container, bool binds, libcrun_error_t
 
   if (container->container_def->process && container->container_def->process->terminal)
     {
-      ret = crun_ensure_file_at (devfd, "console", 0620, true, err);
+      ret = create_file_if_missing_at (devfd, "console", 0620, err);
       if (UNLIKELY (ret < 0))
         return ret;
     }

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -267,11 +267,7 @@ int write_file_at_with_flags (int dirfd, int flags, mode_t mode, const char *nam
 
 int crun_ensure_directory (const char *path, int mode, bool nofollow, libcrun_error_t *err);
 
-int crun_ensure_file (const char *path, int mode, bool nofollow, libcrun_error_t *err);
-
 int crun_ensure_directory_at (int dirfd, const char *path, int mode, bool nofollow, libcrun_error_t *err);
-
-int crun_ensure_file_at (int dirfd, const char *path, int mode, bool nofollow, libcrun_error_t *err);
 
 int crun_safe_create_and_open_ref_at (bool dir, int dirfd, const char *dirpath, size_t dirpath_len, const char *path, int mode, libcrun_error_t *err);
 
@@ -287,7 +283,7 @@ int crun_dir_p_at (int dirfd, const char *path, bool nofollow, libcrun_error_t *
 
 int detach_process ();
 
-int create_file_if_missing_at (int dirfd, const char *file, libcrun_error_t *err);
+int create_file_if_missing_at (int dirfd, const char *file, mode_t mode, libcrun_error_t *err);
 
 int check_running_in_user_namespace (libcrun_error_t *err);
 


### PR DESCRIPTION
Remove dead code. 
