### PR TITLE
chroot_realpath: do not return non-existing paths

### DIFF
--- a/src/libcrun/chroot_realpath.c
+++ b/src/libcrun/chroot_realpath.c
@@ -133,11 +133,6 @@ char *chroot_realpath(const char *chroot, const char *path, char resolved_path[]
 		*new_path = '\0';
 		n = readlink(got_path, link_path, PATH_MAX - 1);
 		if (n < 0) {
-			/* If a component doesn't exist, then return what we could translate. */
-			if (errno == ENOENT) {
-				sprintf (resolved_path, "%s%s%s", got_path, path[0] == '/' || path[0] == '\0' ? "" : "/", path);
-				return resolved_path;
-			}
 			/* EINVAL means the file exists but isn't a symlink. */
 			if (errno != EINVAL) {
 				/* Make sure it's null terminated. */

--- a/src/libcrun/chroot_realpath.c
+++ b/src/libcrun/chroot_realpath.c
@@ -134,12 +134,8 @@ char *chroot_realpath(const char *chroot, const char *path, char resolved_path[]
 		n = readlink(got_path, link_path, PATH_MAX - 1);
 		if (n < 0) {
 			/* EINVAL means the file exists but isn't a symlink. */
-			if (errno != EINVAL) {
-				/* Make sure it's null terminated. */
-				*new_path = '\0';
-				strcpy(resolved_path, got_path);
+			if (errno != EINVAL)
 				return NULL;
-			}
 		} else {
 			/* Note: readlink doesn't add the null byte. */
 			link_path[n] = '\0';


### PR DESCRIPTION
The PR is marked as a draft as of now.
I'm pretty sure it's correct but I will go through it later.

----

* Do not return non-existing paths in chroot_realpath().
  Rationale: failing early is good.

* Remove dead code

