### PR TITLE
linux, mono: remove unneeded crun_error_release()

### DIFF
--- a/src/libcrun/handlers/mono.c
+++ b/src/libcrun/handlers/mono.c
@@ -131,9 +131,6 @@ mono_configure_container (void *cookie arg_unused, enum handler_configure_phase 
   if (ret != 0)
     return ret;
 
-  /* release any error if set since we are going to be returning from here */
-  crun_error_release (err);
-
   return 0;
 }
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2181,8 +2181,6 @@ do_mounts (libcrun_container_t *container, int rootfsfd, const char *rootfs, con
             {
               if (errno != ENOTDIR)
                 return crun_make_error (err, errno, "cannot reopen `%s`", target);
-
-              crun_error_release (err);
             }
         }
 


### PR DESCRIPTION
It looks like those `crun_error_release()` are not needed.