### PR TITLE
container, error: update error handling

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2687,7 +2687,10 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
   ret = close_and_reset (&sync_socket);
   if (UNLIKELY (ret < 0))
-    goto fail;
+    {
+      crun_make_error (err, errno, "close/reset of sync_socket failed");
+      goto fail;
+    }
 
   libcrun_debug ("Writing container status");
   ret = write_container_status (container, context, pid, cgroup_status, err);
@@ -2715,7 +2718,10 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
 
       ret = close_and_reset (&own_seccomp_receiver_fd);
       if (UNLIKELY (ret < 0))
-        goto fail;
+        {
+          crun_make_error (err, errno, "close/reset of seccomp receiver fd failed");
+          goto fail;
+        }
     }
 
   {

--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -71,7 +71,10 @@ crun_error_wrap (libcrun_error_t *err, const char *fmt, ...)
   int ret;
 
   if (err == NULL || *err == NULL)
-    return 0;
+    {
+      // Internal error
+      return 0;
+    }
 
   ret = -(*err)->status - 1;
 
@@ -123,8 +126,11 @@ crun_error_write_warning_and_release (FILE *out, libcrun_error_t **err)
 
   if (out == NULL)
     out = stderr;
-  if (err == NULL || *err == NULL)
-    return;
+  if (err == NULL || *err == NULL || **err == NULL)
+    {
+      // Internal error
+      return;
+    }
 
   ref = **err;
   if (ref->status)


### PR DESCRIPTION
What is the preferred way to write a check that indicates that a failure is not expected and that such a failure would indicate a programming errror?

One way is to write `assert()` (but such a check is only  active for an executable  that was compiled with the debug option enabled)

For example:
```
  assert(err != NULL);
  assert(*err != NULL);
```

This is another way:
```
if (err == NULL || *err == NULL) {
  // programming error
  _exit(EXIT_FAILURE);
}
```

I prefer `assert()` slightly more.


