### PR TITLE
Downstream Fedora: fix gating config

### DIFF
--- a/rpm/gating.yaml
+++ b/rpm/gating.yaml
@@ -1,7 +1,7 @@
 --- !Policy
 product_versions:
   - fedora-*
-decision_context:
+decision_contexts:
   - bodhi_update_push_stable
   - bodhi_update_push_testing
 rules:


### PR DESCRIPTION
Doesn't affect upstream. The wrongly configured file blocked koji builds.