### PR TITLE
utils: fix PATH lookup

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1892,7 +1892,7 @@ find_executable (const char *executable_path, const char *cwd)
       return NULL;
     }
 
-  if (executable_path[0] == '.' || (executable_path[0] != '/' && strchr (executable_path, '/')))
+  if (executable_path[0] != '/' && strchr (executable_path, '/'))
     {
       cleanup_free char *cwd_allocated = NULL;
 


### PR DESCRIPTION
Support filenames starting with a dot when
doing PATH lookup.

Fixes: https://github.com/containers/crun/issues/1664
