### PR TITLE
libcrun: use an hash map to lookup annotations

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ endif
 check_LTLIBRARIES = libcrun_testing.la
 
 libcrun_SOURCES = src/libcrun/utils.c \
+		src/libcrun/string_map.c \
 		src/libcrun/ring_buffer.c \
 		src/libcrun/blake3/blake3.c \
 		src/libcrun/blake3/blake3_portable.c \
@@ -155,7 +156,7 @@ EXTRA_DIST = COPYING COPYING.libcrun README.md NEWS SECURITY.md rpm/crun.spec au
 	src/libcrun/handlers/handler-utils.h \
 	src/libcrun/linux.h src/libcrun/utils.h src/libcrun/error.h src/libcrun/criu.h \
 	src/libcrun/scheduler.h src/libcrun/status.h src/libcrun/terminal.h \
-	src/libcrun/mount_flags.h src/libcrun/intelrdt.h src/libcrun/ring_buffer.h \
+	src/libcrun/mount_flags.h src/libcrun/intelrdt.h src/libcrun/ring_buffer.h src/libcrun/string_map.h \
 	crun.1.md crun.1 libcrun.lds \
 	krun.1.md krun.1 \
 	lua/luacrun.rockspec

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ AC_CHECK_HEADERS([error.h linux/openat2.h stdatomic.h linux/ioprio.h])
 
 AC_CHECK_TYPES([atomic_int], [], [], [[#include <stdatomic.h>]])
 
-AC_CHECK_FUNCS(copy_file_range fgetxattr statx fgetpwent_r issetugid memfd_create)
+AC_CHECK_FUNCS(hsearch_r copy_file_range fgetxattr statx fgetpwent_r issetugid memfd_create)
 
 AC_ARG_ENABLE(crun,
 AS_HELP_STRING([--enable-crun], [Include crun executable in installation (default: yes)]),

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -86,11 +86,11 @@ get_cgroup_manager (int manager, struct libcrun_cgroup_manager **out, libcrun_er
 }
 
 static const char *
-find_delegate_cgroup (json_map_string_string *annotations)
+find_delegate_cgroup (string_map *annotations)
 {
   const char *annotation;
 
-  annotation = find_annotation_map (annotations, "run.oci.delegate-cgroup");
+  annotation = find_string_map_value (annotations, "run.oci.delegate-cgroup");
   if (annotation)
     {
       if (annotation[0] == '\0')

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -19,6 +19,7 @@
 #define CGROUP_H
 
 #include "container.h"
+#include "string_map.h"
 #include <unistd.h>
 
 #ifndef CGROUP_ROOT
@@ -48,7 +49,7 @@ struct libcrun_cgroup_status;
 struct libcrun_cgroup_args
 {
   runtime_spec_schema_config_linux_resources *resources;
-  json_map_string_string *annotations;
+  string_map *annotations;
   const char *cgroup_path;
   int manager;
   pid_t pid;

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -545,6 +545,8 @@ make_container (runtime_spec_schema_config_schema *container_def, const char *pa
   container->host_uid = geteuid ();
   container->host_gid = getegid ();
 
+  container->annotations = make_string_map_from_json (container_def->annotations);
+
   if (path)
     container->config_file = xstrdup (path);
   if (config)
@@ -593,6 +595,8 @@ libcrun_container_free (libcrun_container_t *ctr)
 
   if (ctr->container_def)
     free_runtime_spec_schema_config_schema (ctr->container_def);
+
+  free_string_map (ctr->annotations);
 
   free (ctr->config_file_content);
   free (ctr->config_file);
@@ -2520,7 +2524,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   cg.manager = cgroup_manager;
   cg.id = context->id;
   cg.resources = def->linux ? def->linux->resources : NULL;
-  cg.annotations = def->annotations;
+  cg.annotations = container->annotations;
   cg.root_uid = root_uid;
   cg.root_gid = root_gid;
   cg.state_root = context->state_root;
@@ -4306,7 +4310,7 @@ libcrun_container_restore (libcrun_context_t *context, const char *id, libcrun_c
   {
     struct libcrun_cgroup_args cg = {
       .resources = def->linux ? def->linux->resources : NULL,
-      .annotations = def->annotations,
+      .annotations = container->annotations,
       .cgroup_path = def->linux ? def->linux->cgroups_path : "",
       .manager = cgroup_manager,
       .pid = status.pid,

--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -22,6 +22,7 @@
 #include <config.h>
 #include <ocispec/runtime_spec_schema_config_schema.h>
 #include "error.h"
+#include "string_map.h"
 
 enum handler_configure_phase
 {
@@ -87,6 +88,8 @@ struct libcrun_container_s
 
   char *config_file;
   char *config_file_content;
+
+  string_map *annotations;
 
   void *private_data;
   void (*cleanup_private_data) (void *private_data);

--- a/src/libcrun/string_map.c
+++ b/src/libcrun/string_map.c
@@ -1,0 +1,111 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2025 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE
+
+#include <config.h>
+#include <errno.h>
+#include "string_map.h"
+#include "utils.h"
+
+#include <ocispec/runtime_spec_schema_config_schema.h>
+
+struct kv_s
+{
+  char *key;
+  char *value;
+};
+
+struct string_map_s
+{
+  size_t len;
+  struct kv_s *kvs;
+};
+
+const char *
+find_string_map_value (string_map *map, const char *name)
+
+{
+  size_t i;
+
+  if (map == NULL)
+    return NULL;
+
+  for (i = 0; i < map->len; i++)
+    {
+      if (strcmp (map->kvs[i].key, name) == 0)
+        return map->kvs[i].value;
+    }
+  return NULL;
+}
+
+string_map *
+make_string_map_from_json (json_map_string_string *jmap)
+{
+  struct string_map_s *new_map = xmalloc0 (sizeof (struct string_map_s));
+  size_t i;
+
+  if (jmap == NULL)
+    return new_map;
+
+  new_map->len = jmap->len;
+  new_map->kvs = xmalloc0 (sizeof (struct kv_s) * (jmap->len + 1));
+
+  for (i = 0; i < jmap->len; i++)
+    {
+      new_map->kvs[i].key = xstrdup (jmap->keys[i]);
+      new_map->kvs[i].value = xstrdup (jmap->values[i]);
+    }
+
+  return new_map;
+}
+
+int
+string_map_get_at (string_map *map, size_t index, const char **name, const char **value)
+{
+  if (map == NULL || index >= map->len)
+    {
+      errno = ERANGE;
+      return -1;
+    }
+
+  *name = map->kvs[index].key;
+  *value = map->kvs[index].value;
+
+  return 0;
+}
+
+void
+free_string_map (string_map *map)
+{
+  size_t i;
+
+  for (i = 0; i < map->len; i++)
+    {
+      free (map->kvs[i].key);
+      free (map->kvs[i].value);
+    }
+  free (map->kvs);
+  free (map);
+}
+
+size_t
+string_map_size (string_map *map)
+{
+  return map->len;
+}

--- a/src/libcrun/string_map.h
+++ b/src/libcrun/string_map.h
@@ -1,0 +1,41 @@
+/*
+ * crun - OCI runtime written in C
+ *
+ * Copyright (C) 2025 Giuseppe Scrivano <giuseppe@scrivano.org>
+ * crun is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * crun is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with crun.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef STRING_MAP_H
+#define STRING_MAP_H
+
+#define _GNU_SOURCE
+
+#include <config.h>
+#include <ocispec/runtime_spec_schema_config_schema.h>
+#include "error.h"
+
+struct string_map_s;
+typedef struct string_map_s string_map;
+
+const char *find_string_map_value (string_map *map, const char *name);
+
+string_map *make_string_map_from_json (json_map_string_string *jmap);
+
+void free_string_map (string_map *map);
+
+int string_map_get_at (string_map *map, size_t index, const char **name, const char **value);
+
+size_t string_map_size (string_map *map);
+
+#endif

--- a/src/libcrun/string_map.h
+++ b/src/libcrun/string_map.h
@@ -22,6 +22,11 @@
 #define _GNU_SOURCE
 
 #include <config.h>
+
+#ifdef HAVE_HSEARCH_R
+#  include <search.h>
+#endif
+
 #include <ocispec/runtime_spec_schema_config_schema.h>
 #include "error.h"
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -2204,28 +2204,12 @@ copy_recursive_fd_to_fd (int srcdirfd, int dfd, const char *srcname, const char 
 }
 
 const char *
-find_annotation_map (json_map_string_string *annotations, const char *name)
-{
-  size_t i;
-
-  if (annotations == NULL)
-    return NULL;
-
-  for (i = 0; i < annotations->len; i++)
-    {
-      if (strcmp (annotations->keys[i], name) == 0)
-        return annotations->values[i];
-    }
-  return NULL;
-}
-
-const char *
 find_annotation (libcrun_container_t *container, const char *name)
 {
   if (container->container_def->annotations == NULL)
     return NULL;
 
-  return find_annotation_map (container->container_def->annotations, name);
+  return find_string_map_value (container->annotations, name);
 }
 
 int

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -368,7 +368,6 @@ int libcrun_initialize_selinux (libcrun_error_t *err);
 
 int libcrun_initialize_apparmor (libcrun_error_t *err);
 
-const char *find_annotation_map (json_map_string_string *annotations, const char *name);
 const char *find_annotation (libcrun_container_t *container, const char *name);
 
 int get_file_type_at (int dirfd, mode_t *mode, bool nofollow, const char *path);


### PR DESCRIPTION
Use a hash map to speed up the lookup of annotations.

If the array is small (< 8 elements), use a binary search on the sorted array