### PR TITLE
README: add CentOS Stream 9 & 10, rm 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,30 +56,33 @@ These dependencies are required for the build:
 ### Fedora
 
 ```console
-$ sudo dnf install -y make python git gcc automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel pkg-config \
-    go-md2man glibc-static python3-libmount libtool
+$ sudo dnf install -y \
+    autoconf automake gcc git-core glibc-static go-md2man \
+    libcap-devel libseccomp-devel libtool make pkg-config \
+    python python-libmount systemd-devel yajl-devel
 ```
 
-### RHEL/CentOS 8
+### RHEL/CentOS Stream 9
 
 ```console
-$ sudo yum --enablerepo='*' --disablerepo='media-*' install -y make automake \
-    autoconf gettext \
-    libtool gcc libcap-devel systemd-devel yajl-devel \
-    glibc-static libseccomp-devel python36 git
+$ sudo dnf config-manager --set-enabled crb
+$ sudo dnf install -y \
+    autoconf automake gcc git-core glibc-static go-md2man \
+    libcap-devel libseccomp-devel libtool make pkg-config \
+    python python-libmount systemd-devel yajl-devel
 ```
 
-go-md2man is not available on RHEL/CentOS 8, so if you'd like to build
-the man page, you also need to manually install go-md2man. It can be
-installed with:
+### RHEL/CentOS Stream 10
 
 ```console
-$ sudo yum --enablerepo='*' install -y golang
-$ export GOPATH=$HOME/go
-$ go get github.com/cpuguy83/go-md2man
-$ export PATH=$PATH:$GOPATH/bin
+$ sudo dnf config-manager --set-enabled crb
+$ sudo dnf install -y \
+    autoconf automake gcc git-core glibc-static go-md2man \
+    libcap-devel libseccomp-devel libtool make pkg-config \
+    python python-libmount systemd-devel
 ```
+
+NOTE that you need to add `--enable-embedded-yajl` to `./configure` flags below.
 
 ### Ubuntu
 


### PR DESCRIPTION
Remove outdated RHEL/CentOS 8 build instructions.

Add RHEL/CentOS Stream 9 and 10.

_Replaces #1641._