### PR TITLE
utils: improve error message if path not executable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ AC_CHECK_HEADERS([error.h linux/openat2.h stdatomic.h linux/ioprio.h])
 
 AC_CHECK_TYPES([atomic_int], [], [], [[#include <stdatomic.h>]])
 
-AC_CHECK_FUNCS(hsearch_r copy_file_range fgetxattr statx fgetpwent_r issetugid memfd_create)
+AC_CHECK_FUNCS(eaccess hsearch_r copy_file_range fgetxattr statx fgetpwent_r issetugid memfd_create)
 
 AC_ARG_ENABLE(crun,
 AS_HELP_STRING([--enable-crun], [Include crun executable in installation (default: yes)]),

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3499,7 +3499,14 @@ exec_process_entrypoint (libcrun_context_t *context,
     {
       ret = find_executable (&exec_path, process->args[0], process->cwd, err);
       if (UNLIKELY (ret < 0))
-        return ret;
+        {
+          if (custom_handler == NULL || is_empty_string (process->args[0]))
+            return ret;
+
+          /* If a custom handler is used, pass argv0 as specified.  e.g. with wasm the file could miss the +x bit.  */
+          crun_error_release (err);
+          exec_path = xstrdup (process->args[0]);
+        }
     }
 
   if (UNLIKELY ((! chdir_done) && libcrun_safe_chdir (cwd, err) < 0))

--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -297,7 +297,7 @@ log_write_to_stderr (int errno_, const char *msg, int verbosity, void *arg arg_u
 void
 log_write_to_syslog (int errno_, const char *msg, int verbosity, void *arg arg_unused)
 {
-  int priority;
+  int priority = LOG_ERR;
   switch (verbosity)
     {
     case LIBCRUN_VERBOSITY_DEBUG:
@@ -323,7 +323,7 @@ log_write_to_journald (int errno_, const char *msg, int verbosity, void *arg arg
   (void) msg;
   (void) verbosity;
 #ifdef HAVE_SYSTEMD
-  int priority;
+  int priority = LOG_ERR;
   switch (verbosity)
     {
     case LIBCRUN_VERBOSITY_DEBUG:

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1855,10 +1855,10 @@ check_access (const char *path)
   int ret;
   mode_t mode;
 
-#ifdef ANDROID
-  ret = access (path, X_OK);
-#else
+#ifdef HAVE_EACCESS
   ret = eaccess (path, X_OK);
+#else
+  ret = access (path, X_OK);
 #endif
   if (ret < 0)
     return ret;

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -358,7 +358,7 @@ has_prefix (const char *str, const char *prefix)
   return strlen (str) >= prefix_len && memcmp (str, prefix, prefix_len) == 0;
 }
 
-char *find_executable (const char *executable_path, const char *cwd);
+int find_executable (char **exec_path, const char *executable_path, const char *cwd, libcrun_error_t *err);
 
 int copy_recursive_fd_to_fd (int srcfd, int destfd, const char *srcname, const char *destname, libcrun_error_t *err);
 

--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf install -y golang python git gcc automake autoconf libcap-devel \
     device-mapper-devel containernetworking-plugins 'dnf-command(builddep)' && \
     dnf builddep -y podman && \
     chmod 755 /root && \
-    git clone https://github.com/containers/podman /root/go/src/github.com/containers/podman && \
+    git clone --depth=1 https://github.com/containers/podman /root/go/src/github.com/containers/podman && \
     cd /root/go/src/github.com/containers/podman && \
     make .install.ginkgo install.catatonit && cp ./test/tools/build/ginkgo /usr/local/bin && \
     make


### PR DESCRIPTION
 improve the error returned when the specified path is not executable.

Return the reason why the lookup failed when the path is not a regular file, or has no executable bit set.

Closes: https://github.com/containers/crun/issues/1671
