### PR TITLE
Prevent dlopen() for CRIU in static link'ed binary

### DIFF
--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -33,7 +33,7 @@ with pkgs; stdenv.mkDerivation {
     ] ++ lib.optionals enableCriu [ criu ];
   configureFlags = [ "--enable-static" ] ++ lib.optional (!enableSystemd) [ "--disable-systemd" ];
   prePatch = ''
-    export CFLAGS='-static -pthread'
+    export CFLAGS='-static -pthread -DSTATIC'
     export LDFLAGS='-s -w -static-libgcc -static'
     export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
     export CRUN_LDFLAGS='-all-static'

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -3,7 +3,27 @@ let
 in
 self: super:
 {
-  criu = (static super.criu);
+  protobufc = super.protobufc.overrideAttrs (x: {
+    configureFlags = (x.configureFlags or [ ]) ++ [ "--enable-static" ];
+  });
+  libnl = super.libnl.overrideAttrs (x: {
+    configureFlags = (x.configureFlags or [ ]) ++ [ "--enable-static" ];
+  });
+  libnet = super.libnet.overrideAttrs (x: {
+    configureFlags = (x.configureFlags or [ ]) ++ [ "--enable-static" ];
+  });
+  criu = (static super.criu).overrideAttrs (x: {
+    buildInputs = (x.buildInputs or []) ++ [
+      super.protobuf
+      super.protobufc
+      super.libnl
+      super.libnet
+    ];
+    NIX_LDFLAGS = "${x.NIX_LDFLAGS or ""} -lprotobuf-c";
+    buildPhase = ''
+      make lib
+    '';
+  });
   gpgme = (static super.gpgme);
   libassuan = (static super.libassuan);
   libgpgerror = (static super.libgpgerror);


### PR DESCRIPTION
I tried to get container checkpoint with static link'ed crun via CRI-O, but it failed due not to load `libcriu.so.2`.  
I strace'ed checkpointing, I saw following lines in the log:

```
openat(AT_FDCWD, "/nix/store/wn7v2vhyyyi6clcyn0s9ixvl7d4d87ic-glibc-2.40-36/lib/libcriu.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/nix/store/2d5spnl8j5r4n1s4bj1zmra7mwx0f1n8-xgcc-13.3.0-libgcc/lib/libcriu.so.2", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
write(2, "could not load `libcriu.so.2`\n", 30could not load `libcriu.so.2`
```

I think it is because `dlopen()` for `libcriu.so.2` was called despite of static link'ed binary - library path seems to be on build environment (Nix).

In static link'ed library, all of libraries should be static linked, so `libcriu.so.2` should be included. `dlopen()` route should live for dynamic link binary only.

This patch works fine on combination of Kubernetes v1.32 and CRI-O v1.32.