### PR TITLE
tests: fix test_resources_unified_invalid_controller()

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -119,7 +119,10 @@ def test_resources_unified_invalid_controller():
         # must raise an exception, fail if it doesn't.
         return -1
     except Exception as e:
-        if 'the requested cgroup controller `foo` is not available' in e.stdout.decode("utf-8").strip():
+        output = e.stdout.decode("utf-8").strip()
+        if 'controller `foo` is not available under' in output:
+            return 0
+        if 'the requested cgroup controller `foo` is not available' in output:
             return 0
         return -1
     finally:


### PR DESCRIPTION
Commit a4dcb9c (PR #1639) changed error message to show the absolute path to cgroup.controllers when a controller is not available.

Change the test to also expect the new error message, while the old one, as the new code may still conditionally return it.