### PR TITLE
Console socket client is initialized only when the user declares terminal

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2508,7 +2508,7 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
         return ret;
     }
 
-  if (context->console_socket)
+  if (context->console_socket && def->process && def->process->terminal)
     {
       console_socket_fd = open_unix_domain_client_socket (context->console_socket, 0, err);
       if (UNLIKELY (console_socket_fd < 0))


### PR DESCRIPTION
That console socket client is initialized only when the user declares terminal.

Otherwise, the console socket client is not used after initialization.