### PR TITLE
krun: implement support for external kernels

### DIFF
--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -43,7 +43,15 @@
 /* libkrun has a hard-limit of 8 vCPUs per microVM. */
 #define LIBKRUN_MAX_VCPUS 8
 
+/* crun dumps the container configuration into this file, which will be read by
+ * libkrun to set up the environment for the workload inside the microVM.
+ */
 #define KRUN_CONFIG_FILE ".krun_config.json"
+
+/* The presence of this file indicates this is a container intended to be run
+ * as a confidential workload inside a SEV-powered TEE.
+ */
+#define KRUN_SEV_FILE "/krun-sev.json"
 
 struct krun_config
 {
@@ -90,7 +98,7 @@ libkrun_exec (void *cookie, libcrun_container_t *container, const char *pathname
   int32_t ctx_id, ret;
   cpu_set_t set;
 
-  if (access ("/krun-sev.json", F_OK) == 0)
+  if (access (KRUN_SEV_FILE, F_OK) == 0)
     {
       if (kconf->handle_sev == NULL)
         error (EXIT_FAILURE, 0, "the container requires libkrun-sev but it's not available");
@@ -126,7 +134,7 @@ libkrun_exec (void *cookie, libcrun_container_t *container, const char *pathname
       if (UNLIKELY (ret < 0))
         error (EXIT_FAILURE, -ret, "could not set root disk");
 
-      ret = krun_set_tee_config_file (ctx_id, "/krun-sev.json");
+      ret = krun_set_tee_config_file (ctx_id, KRUN_SEV_FILE);
       if (UNLIKELY (ret < 0))
         error (EXIT_FAILURE, -ret, "could not set krun tee config file");
     }

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -40,8 +40,8 @@
 #  include <libkrun.h>
 #endif
 
-/* libkrun has a hard-limit of 8 vCPUs per microVM. */
-#define LIBKRUN_MAX_VCPUS 8
+/* libkrun has a hard-limit of 16 vCPUs per microVM. */
+#define LIBKRUN_MAX_VCPUS 16
 
 /* crun dumps the container configuration into this file, which will be read by
  * libkrun to set up the environment for the workload inside the microVM.


### PR DESCRIPTION
    krun: implement support for external kernels

    libkrun has recently acquired the ability to load external kernels. Use
    it to enable users to bundle kernel images in their container files.

    Note: in our execution model, the kernel in the microVM is not (and has
    never been) considered a trusted component. This is the reason why we
    put the whole VMM inside the container and avoid using vhost or any
    other features that require special privileges, beyond KVM.