### PR TITLE
libcrun, krun: use existing error

### DIFF
--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -748,7 +748,7 @@ read_available_controllers (const char *path, libcrun_error_t *err)
 
   ret = read_all_file (controllers, &buf, NULL, err);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "error reading from file `%s`", controllers);
+    return ret;
 
   for (token = strtok_r (buf, " \n", &saveptr); token; token = strtok_r (NULL, " \n", &saveptr))
     {

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -557,8 +557,8 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   if (cgroup_mode != CGROUP_MODE_UNIFIED)
     {
       ret = checkpoint_cgroup_v1_mount (def, err);
-      if (UNLIKELY (ret != 0))
-        return crun_make_error (err, 0, "error handling cgroup v1 mounts");
+      if (UNLIKELY (ret < 0))
+        return ret;
     }
 
   /* Tell CRIU about external bind mounts. */

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -155,11 +155,11 @@ libkrun_configure_vm (uint32_t ctx_id, void *handle, bool *configured, libcrun_e
 
   ret = read_all_file (KRUN_VM_FILE, &config, NULL, err);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "could not read krun vm configuration file");
+    return ret;
 
   ret = parse_json_file (&config_tree, config, &ctx, err);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, ret, "could not parse krun vm configuration file");
+    return ret;
 
   /* Try to configure an external kernel. If the configuration file doesn't
    * specify a kernel, libkrun automatically fall back to using libkrunfw,

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1036,7 +1036,7 @@ do_masked_or_readonly_path (libcrun_container_t *container, const char *rel_path
   if (UNLIKELY (pathfd < 0))
     {
       if (errno != ENOENT && errno != EACCES)
-        return crun_make_error (err, errno, "open `%s`", rel_path);
+        return pathfd;
 
       crun_error_release (err);
       return 0;


### PR DESCRIPTION
Use existing errors. This fixes some small memory leaks.

This also fixes a negative second argument given to crun_make_error()

https://github.com/containers/crun/blob/db8977e94974dfcacc09b983aec85600d90a4944/src/libcrun/handlers/krun.c#L161-L162