### PR TITLE
linux: fix definition of CLONE_NEWTIME on Centos 9

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -192,7 +192,7 @@ get_private_data (struct libcrun_container_s *container)
 #  define CLONE_NEWTIME 0x00000080
 #endif
 #ifndef CLONE_NEWCGROUP
-#  define CLONE_NEWCGROUP 0
+#  define CLONE_NEWCGROUP 0x02000000
 #endif
 #ifndef AT_RECURSIVE
 #  define AT_RECURSIVE 0x8000

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -65,6 +65,7 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <sched.h>
+#include <linux/sched.h>
 
 #include <yajl/yajl_tree.h>
 #include <yajl/yajl_gen.h>

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -189,7 +189,7 @@ get_private_data (struct libcrun_container_s *container)
 }
 
 #ifndef CLONE_NEWTIME
-#  define CLONE_NEWTIME 0
+#  define CLONE_NEWTIME 0x00000080
 #endif
 #ifndef CLONE_NEWCGROUP
 #  define CLONE_NEWCGROUP 0


### PR DESCRIPTION
Include <linux/sched.h> header to provide the proper definition of CLONE_NEWTIME.

Closes: https://github.com/containers/crun/issues/1718

## Summary by Sourcery

Fix the definition of CLONE_NEWTIME and CLONE_NEWCGROUP constants for compatibility on Centos 9

Bug Fixes:
- Provide correct constant values for CLONE_NEWTIME and CLONE_NEWCGROUP when they are not defined by the system headers

Enhancements:
- Include <linux/sched.h> header to ensure proper constant definitions