### PR TITLE
ci: Add awk dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
 
           install: |
             apt-get update -y
-            apt-get install -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev libprotobuf-c-dev clang
+            apt-get install -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev libprotobuf-c-dev clang mawk
 
           run: |
             find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;
@@ -94,7 +94,7 @@ jobs:
 
           sudo add-apt-repository -y ppa:criu/ppa
           # add-apt-repository runs apt-get update so we don't have to.
-          sudo apt-get install -q -y criu automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev containerd runc libasan6 libprotobuf-c-dev
+          sudo apt-get install -q -y criu automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev containerd runc libasan6 libprotobuf-c-dev mawk
 
       - name: run autogen.sh
         run: |
@@ -207,7 +207,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get update -q -y
-          sudo apt-get install -q -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev libprotobuf-c-dev
+          sudo apt-get install -q -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev libprotobuf-c-dev mawk
       - uses: lumaxis/shellcheck-problem-matchers@v2
       - name: shellcheck
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -187,7 +187,7 @@ jobs:
           esac
 
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: vars

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -2357,11 +2357,17 @@ append_paths (char **out, libcrun_error_t *err, ...)
   return 0;
 }
 
+#if __has_attribute(__nonstring__)
+#  define __nonstring __attribute__ ((__nonstring__))
+#else
+#  define __nonstring
+#endif
+
 /* Adapted from mailutils 0.6.91 (distributed under LGPL 2.0+)  */
 static int
 b64_input (char c)
 {
-  const char table[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  const char table[64] __nonstring = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
   int i;
 
   for (i = 0; i < 64; i++)

--- a/tests/clang-check/Dockerfile
+++ b/tests/clang-check/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 
-RUN yum install -y git protobuf-c protobuf-c-devel make clang-tools-extra clang python3-pip 'dnf-command(builddep)' && \
+RUN dnf install -y awk git protobuf-c protobuf-c-devel make clang-tools-extra clang python3-pip 'dnf-command(builddep)' && \
         dnf builddep -y crun && pip install scan-build
 
 COPY run-tests.sh /usr/local/bin

--- a/tests/clang-format/Dockerfile
+++ b/tests/clang-format/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 
-RUN dnf install -y git make clang-tools-extra 'dnf-command(builddep)' && dnf builddep -y crun
+RUN dnf install -y awk git make clang-tools-extra 'dnf-command(builddep)' && dnf builddep -y crun
 
 COPY run-tests.sh /usr/local/bin
 ENTRYPOINT /usr/local/bin/run-tests.sh

--- a/tests/codespell/Dockerfile
+++ b/tests/codespell/Dockerfile
@@ -1,3 +1,3 @@
 FROM fedora:latest
 
-RUN yum install -y codespell && yum clean all -y
+RUN dnf install -y awk codespell && yum clean all -y

--- a/tests/cri-o/Dockerfile
+++ b/tests/cri-o/Dockerfile
@@ -3,11 +3,11 @@ FROM fedora:latest
 ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
-RUN yum install -y python git gcc automake autoconf libcap-devel \
+RUN dnf install -y awk python git gcc automake autoconf libcap-devel \
     systemd-devel yajl-devel libseccomp-devel go-md2man conntrack-tools which \
     glibc-static python3-libmount libtool make podman xz nmap-ncat jq bats \
     iproute openssl iputils socat criu-libs irqbalance && \
-    dnf install -y 'dnf-command(builddep)' && dnf builddep -y podman && \
+    dnf install -y awk 'dnf-command(builddep)' && dnf builddep -y podman && \
     dnf remove -y golang && \
     sudo dnf update -y && \
     curl -LO https://dl.google.com/go/go1.19.4.linux-amd64.tar.gz && \

--- a/tests/fuzzing/Dockerfile
+++ b/tests/fuzzing/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 
-RUN yum install -y golang python git automake autoconf libcap-devel \
+RUN dnf install -y awk golang python git automake autoconf libcap-devel \
      systemd-devel yajl-devel libseccomp-devel go-md2man \
     glibc-static python3-libmount libtool make honggfuzz git
 

--- a/tests/oci-validation/Dockerfile
+++ b/tests/oci-validation/Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:latest
 ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
-RUN yum install -y golang python git gcc automake autoconf libcap-devel \
+RUN dnf install -y awk golang python git gcc automake autoconf libcap-devel \
     systemd-devel yajl-devel libseccomp-devel libselinux-devel \
     glibc-static python3-libmount libtool make go-md2man perl-Test2-Harness
 

--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:latest
 ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
-RUN dnf install -y golang python git gcc automake autoconf libcap-devel \
+RUN dnf install -y awk golang python git gcc automake autoconf libcap-devel \
     systemd-devel yajl-devel libseccomp-devel go-md2man  \
     glibc-static python3-libmount libtool make podman xz nmap-ncat procps-ng slirp4netns \
     device-mapper-devel containernetworking-plugins 'dnf-command(builddep)' && \

--- a/tests/wasmedge-build/Dockerfile
+++ b/tests/wasmedge-build/Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:latest
 ARG WASM_EDGE_VERSION="0.14.0"
 
 # Install the deps for building crun
-RUN dnf update -y && dnf install -y make python git gcc automake autoconf libcap-devel \
+RUN dnf update -y && dnf install -y awk make python git gcc automake autoconf libcap-devel \
 		systemd-devel yajl-devel libseccomp-devel pkg-config diffutils \
 		systemd-devel yajl-devel libseccomp-devel pkg-config \
 		go-md2man glibc-static python3-libmount libtool buildah podman which


### PR DESCRIPTION
Add awk to the list of installed packages in the
build, test, and shellcheck jobs.

## Summary by Sourcery

CI:
- Add awk package to the list of installed dependencies in GitHub Actions workflows for build, test, and shellcheck jobs