### PR TITLE
ci: improve shellcheck job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -192,9 +192,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: install shellcheck
         env:
-          VERSION: v0.8.0
+          VERSION: v0.10.0
           BASEURL: https://github.com/koalaman/shellcheck/releases/download
-          SHA256: f4bce23c11c3919c1b20bcb0f206f6b44c44e26f2bc95f8aa708716095fa0651
+          SHA256: f35ae15a4677945428bdfe61ccc297490d89dd1e544cc06317102637638c6deb
         run: |
           mkdir ~/bin
           curl -sSfL --retry 5 $BASEURL/$VERSION/shellcheck-$VERSION.linux.x86_64.tar.xz |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -190,20 +190,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: vars
-        run: |
-          echo 'VERSION=v0.8.0' >> $GITHUB_ENV
-          echo 'BASEURL=https://github.com/koalaman/shellcheck/releases/download' >> $GITHUB_ENV
-          echo 'SHA256SUM=f4bce23c11c3919c1b20bcb0f206f6b44c44e26f2bc95f8aa708716095fa0651' >> $GITHUB_ENV
-          echo ~/bin >> $GITHUB_PATH
       - name: install shellcheck
+        env:
+          VERSION: v0.8.0
+          BASEURL: https://github.com/koalaman/shellcheck/releases/download
+          SHA256: f4bce23c11c3919c1b20bcb0f206f6b44c44e26f2bc95f8aa708716095fa0651
         run: |
           mkdir ~/bin
           curl -sSfL --retry 5 $BASEURL/$VERSION/shellcheck-$VERSION.linux.x86_64.tar.xz |
             tar xfJ - -C ~/bin --strip 1 shellcheck-$VERSION/shellcheck
-          sha256sum ~/bin/shellcheck | grep -q $SHA256SUM
+          sha256sum --strict --check - <<<"$SHA256 *$HOME/bin/shellcheck"
           # make sure to remove the old version
           sudo rm -f /usr/bin/shellcheck
+          # Add ~/bin to $PATH.
+          echo ~/bin >> $GITHUB_PATH
       - name: install dependencies
         run: |
           sudo apt-get update -q -y

--- a/Makefile.am
+++ b/Makefile.am
@@ -320,6 +320,6 @@ clang-format:
 	git ls-files src tests | grep -E "\\.[hc]" | grep -v "blake3\|chroot_realpath.c\|cloned_binary.c\|signals.c\|mount_flags.c" | xargs clang-format -style=file -i
 
 shellcheck:
-	shellcheck autogen.sh tests/run_all_tests.sh tests/*/*.sh contrib/*.sh
+	shellcheck autogen.sh build-aux/release.sh tests/run_all_tests.sh tests/*/*.sh contrib/*.sh
 
 .PHONY: coverity sync generate-rust-bindings generate-signals.c generate-mount_flags.c clang-format shellcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -320,6 +320,6 @@ clang-format:
 	git ls-files src tests | grep -E "\\.[hc]" | grep -v "blake3\|chroot_realpath.c\|cloned_binary.c\|signals.c\|mount_flags.c" | xargs clang-format -style=file -i
 
 shellcheck:
-	shellcheck tests/*/*.sh contrib/*.sh
+	shellcheck autogen.sh tests/run_all_tests.sh tests/*/*.sh contrib/*.sh
 
 .PHONY: coverity sync generate-rust-bindings generate-signals.c generate-mount_flags.c clang-format shellcheck

--- a/build-aux/release.sh
+++ b/build-aux/release.sh
@@ -13,54 +13,63 @@ test -e Makefile && make distclean
 
 ./configure
 
-make -j $(nproc)
+make -j "$(nproc)"
 
-VERSION=$($(dirname $0)/git-version-gen --prefix "" .)
-if test x$SKIP_CHECKS = x; then
-    grep $VERSION NEWS
+VERSION="$("$(dirname "$0")/git-version-gen" --prefix "" .)"
+if test "$SKIP_CHECKS" = ""; then
+    grep "$VERSION" NEWS
 fi
 
 OUTDIR=${OUTDIR:-release-$VERSION}
-if test -e $OUTDIR; then
+if test -e "$OUTDIR"; then
     echo "the directory $OUTDIR already exists" >&2
     exit 1
 fi
 
-mkdir -p $OUTDIR
+mkdir -p "$OUTDIR"
 
 rm -f crun-*.tar*
 
 make dist-gzip
 make ZSTD_OPT="--ultra -c22" dist-zstd
 
-mv crun-*.tar.gz $OUTDIR
-mv crun-*.tar.zst $OUTDIR
+mv crun-*.tar.gz "$OUTDIR"
+mv crun-*.tar.zst "$OUTDIR"
 
 make distclean
 
-RUNTIME=${RUNTIME:-podman}
-RUNTIME_EXTRA_ARGS=${RUNTIME_EXTRA_ARGS:-}
+read -r -a RUNTIME_EXTRA_ARGS <<< "${RUNTIME_EXTRA_ARGS:-}"
+
+BUILD_CMD=(
+	"${RUNTIME:-podman}" run --init --rm
+	"${RUNTIME_EXTRA_ARGS[@]}"
+	--privileged
+	-v /nix:/nix -v "${PWD}:${PWD}"
+	-w "${PWD}"
+	"${NIX_IMAGE}"
+	nix
+	--extra-experimental-features nix-command
+	--print-build-logs
+	--option cores "$(nproc)"
+	--option max-jobs "$(nproc)"
+	build
+	--max-jobs auto
+)
 
 mkdir -p /nix
 
-NIX_ARGS="--extra-experimental-features nix-command --print-build-logs --option cores $(nproc) --option max-jobs $(nproc)"
-
 for ARCH in amd64 arm64 ppc64le riscv64 s390x; do
-    $RUNTIME run --init --rm $RUNTIME_EXTRA_ARGS --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} ${NIX_IMAGE} \
-        nix $NIX_ARGS build --max-jobs auto --file nix/default-${ARCH}.nix
-    cp ./result/bin/crun $OUTDIR/crun-$VERSION-linux-${ARCH}
-
+    "${BUILD_CMD[@]}" --file nix/default-${ARCH}.nix
+    cp ./result/bin/crun "$OUTDIR/crun-$VERSION-linux-${ARCH}"
     rm -rf result
 
-    $RUNTIME run --init --rm $RUNTIME_EXTRA_ARGS --privileged -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} ${NIX_IMAGE} \
-        nix $NIX_ARGS build --max-jobs auto --file nix/default-${ARCH}.nix --arg enableSystemd false
-    cp ./result/bin/crun $OUTDIR/crun-$VERSION-linux-${ARCH}-disable-systemd
-
+    "${BUILD_CMD[@]}" --file nix/default-${ARCH}.nix --arg enableSystemd false
+    cp ./result/bin/crun "$OUTDIR/crun-$VERSION-linux-${ARCH}-disable-systemd"
     rm -rf result
 done
 
-if test x$SKIP_GPG = x; then
-    for i in $OUTDIR/*; do
-        gpg2 -b --armour $i
+if test "$SKIP_GPG" = ""; then
+    for i in "$OUTDIR"/*; do
+        gpg2 -b --armour "$i"
     done
 fi

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -6,18 +6,18 @@ OCI_RUNTIME=${OCI_RUNTIME:-/usr/bin/crun}
 export INIT
 export OCI_RUNTIME
 
-rm -f *.trs
+rm -f -- *.trs
 
-COLOR=
+COLOR="no"
 if [ -t 1 ]; then
-    COLOR="--color-tests yes"
+    COLOR="yes"
 fi
 
 for i in test_*.py
 do
-    ./tap-driver.sh --test-name $i --log-file $i.log --trs-file $i.trs ${COLOR} --enable-hard-errors yes --expect-failure no -- /usr/bin/python $i
+    ./tap-driver.sh --test-name "$i" --log-file "$i.log" --trs-file "$i.trs" --color-tests "${COLOR}" --enable-hard-errors yes --expect-failure no -- /usr/bin/python "$i"
 done
 
-if grep FAIL *.trs; then
+if grep FAIL -- *.trs; then
     exit 1
 fi


### PR DESCRIPTION
1. Use env directive instead of adding to $GITHUB_ENV.
2. Use bash herefile to feed sha256sum instead of pipe to grep.
3. Use ubuntu-latest.
4. Add more files to shellcheck, fix warnings.

## Summary by Sourcery

Improve the shellcheck job in GitHub Actions workflow by updating environment variable handling and shell script verification

CI:
- Update shellcheck workflow to use environment directive instead of modifying GITHUB_ENV
- Upgrade Ubuntu runner from ubuntu-20.04 to ubuntu-latest
- Modify SHA256 verification method using bash herefile

## Summary by Sourcery

Improve shell script quality and CI workflow by updating shellcheck, enhancing script robustness, and modernizing shell scripting practices

Enhancements:
- Improve shell script quoting and variable handling
- Modernize shell script practices with more robust command execution

CI:
- Update shellcheck workflow to use environment directive instead of modifying GITHUB_ENV
- Upgrade shellcheck version and verification method
- Expand shellcheck coverage to additional shell scripts

Chores:
- Update release and test scripts to use more consistent shell scripting patterns