### PR TITLE
crun.1: fix "CPU controller" table rendering

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -836,10 +836,7 @@ allbox;
 l l l l 
 l l l l .
 \fBOCI (x)\fP	\fBcgroup 2 value (y)\fP	\fBconversion\fP	\fBcomment\fP
-shares	cpu.weight	T{
-y = (1 + ((x - 2) * 9999) / 262142)
-T}
-	T{
+shares	cpu.weight	y = (1 + ((x - 2) * 9999) / 262142)	T{
 convert from [2-262144] to [1-10000]
 T}
 period	cpu.max	y = x	T{

--- a/crun.1.md
+++ b/crun.1.md
@@ -704,7 +704,7 @@ they are converted when needed from the cgroup v1 configuration.
 
 | OCI (x) | cgroup 2 value (y) | conversion  |  comment |
 |---|---|---|---|
-| shares | cpu.weight | y = (1 + ((x - 2) * 9999) / 262142) | convert from [2-262144] to [1-10000]|
+| shares | cpu.weight | y = (1 + ((x - 2) \* 9999) / 262142) | convert from [2-262144] to [1-10000]|
 | period | cpu.max | y = x| period and quota are written together|
 | quota | cpu.max | y = x| period and quota are written together|
 


### PR DESCRIPTION
There is bug in go-md2man (https://github.com/cpuguy83/go-md2man/pull/141), resulting in wrong typesetting in this table, which is rendered as:

       ┌─────────┬────────────────────────┬────────────────────────┬────────────────────────┐
       │ OCI (x) │ cgroup 2 value (y)     │ conversion             │ comment                │
       ├─────────┼────────────────────────┼────────────────────────┼────────────────────────┤
       │ shares  │ cpu.weight             │ y = (1 + ((x  -  2)  * │                        │
       │         │                        │ 9999) / 262142)        │                        │
       ├─────────┼────────────────────────┼────────────────────────┼────────────────────────┤
       │         │ convert           from │                        │                        │
       │         │ [2-262144]          to │                        │                        │
       │         │ [1-10000]              │                        │                        │
       ├─────────┼────────────────────────┼────────────────────────┼────────────────────────┤

Apparently, escaping the * fixes things, so it looks like it's supposed to now:

       ┌─────────┬────────────────────┬─────────────────────────────────────┬────────────────────────┐
       │ OCI (x) │ cgroup 2 value (y) │ conversion                          │ comment                │
       ├─────────┼────────────────────┼─────────────────────────────────────┼────────────────────────┤
       │ shares  │ cpu.weight         │ y = (1 + ((x - 2) * 9999) / 262142) │ convert           from │
       │         │                    │                                     │ [2-262144]          to │
       │         │                    │                                     │ [1-10000]              │
       ├─────────┼────────────────────┼─────────────────────────────────────┼────────────────────────┤

## Summary by Sourcery

Bug Fixes:
- Fix the rendering of the "CPU controller" table in the crun man page by escaping the multiplication operator in the conversion formula.  This addresses an issue where the table was not typeset correctly due to the unescaped asterisk character in the markdown table used to generate the man page entry for crun.