### PR TITLE
krun.1: regenerate

### DIFF
--- a/krun.1
+++ b/krun.1
@@ -2,18 +2,15 @@
 .TH crun 1 "User Commands"
 
 .SH NAME
-.PP
-krun - crun based OCI runtime using libkrun to run containerized programs in
+krun \- crun based OCI runtime using libkrun to run containerized programs in
 isolated KVM environments
 
 
 .SH SYNOPSIS
-.PP
 krun [global options] command [command options] [arguments...]
 
 
 .SH DESCRIPTION
-.PP
 krun is a sub package of the crun command line program for running Linux
 containers that follow the Open Container Initiative (OCI) format. The krun
 command is a symbolic link to the crun executable, that tells crun to run in
@@ -34,10 +31,8 @@ containers outside of the krun VM is more difficult.
 
 
 .SH COMMANDS
-.PP
 See crun.1 man page for the commands available to krun
 
 
 .SH SEE ALSO
-.PP
 crun.1


### PR DESCRIPTION
This fixes NAME section formatting for whatis parsing (fixed in go-md2man v2.0.5, see https://github.com/cpuguy83/go-md2man/pull/124).

A similar change to crun(1) was (implicitly) made by commit b5a566bf.

## Summary by Sourcery

Documentation:
- Reformat the krun.1 man page to remove unnecessary .PP macros and adjust formatting for better whatis parsing