### PR TITLE
Revert "Disable criu support on riscv64"

### DIFF
--- a/rpm/crun.spec
+++ b/rpm/crun.spec
@@ -69,11 +69,9 @@ BuildRequires: libseccomp-devel
 BuildRequires: python3-libmount
 BuildRequires: libtool
 BuildRequires: protobuf-c-devel
-%ifnarch riscv64
 BuildRequires: criu-devel >= 3.17.1-2
 Recommends: criu >= 3.17.1
 Recommends: criu-libs
-%endif
 %if %{defined wasmedge_support}
 BuildRequires: wasmedge-devel
 %endif


### PR DESCRIPTION
This reverts commit 4ea62f2521984561d07ee30f32be81dae2ebe38a.

The support for riscv64 in criu was merged recently:  https://src.fedoraproject.org/rpms/criu/pull-request/14#
so we can remove this.

Thanks in advance for your consideration!

## Summary by Sourcery

Chores:
- Remove architecture-specific conditional for CRIU dependencies on riscv64