### PR TITLE
Packit: Disable osh_diff_scan

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -52,6 +52,8 @@ jobs:
     targets: &fedora_copr_targets
       - fedora-all-x86_64
       - fedora-all-aarch64
+    # https://github.com/containers/crun/issues/1729
+    osh_diff_scan_after_copr_build: false
 
   - job: copr_build
     trigger: pull_request


### PR DESCRIPTION
The differential scans run by Packit currently report false positives.

Fixes: #1729

## Summary by Sourcery

Chores:
- Disabled osh_diff_scan in Packit configuration to address false positive scanning issues

## Summary by Sourcery

Chores:
- Disabled osh_diff_scan after Copr build to prevent false positive reports