### PR TITLE
Revert "Packit: Disable osh_diff_scan"

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -52,8 +52,6 @@ jobs:
     targets: &fedora_copr_targets
       - fedora-all-x86_64
       - fedora-all-aarch64
-    # https://github.com/containers/crun/issues/1729
-    osh_diff_scan_after_copr_build: false
 
   - job: copr_build
     trigger: pull_request


### PR DESCRIPTION
After checking further with Siteshwar, disabling this job in #1731 was a rather hasty decision. The Packit osh diff scan job hasn't caused any actual noise upstream because of false positives and on the contrary has found out actual issues.
Refs:
[0] https://github.com/containers/crun/pull/1708#issuecomment-2761459459
[1] https://github.com/containers/crun/pull/1689#issuecomment-2706391593
[2] https://github.com/containers/crun/pull/1695#issuecomment-2737525652

A false positive result in a Packit osh diff scan would pass with a warning sign:
Ref: https://github.com/stratis-storage/stratisd/pull/3811/checks?check_run_id=41436634933

So not really any annoyance upstream.

Siteshwar will disable crun in the mass scans, so that should suffice.

This reverts commit dd8e1af5aa23855d2733bf10bb175a7096e25c1e.

## Summary by Sourcery

Chores:
- Remove the configuration that disabled the osh_diff_scan job in .packit.yaml