### PR TITLE
crun: fix the binary name displayed in the Usage info for commands.

### DIFF
--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -96,10 +96,17 @@ def test_multiple_containers_delete():
             return -1
     return 0
 
+def test_help_delete():
+    out = run_crun_command(["delete", "--help"])
+    if "Usage: crun [OPTION...] delete CONTAINER" not in out:
+        return -1
+    
+    return 0
 
 all_tests = {
     "test_simple_delete" : test_simple_delete,
     "test_multiple_containers_delete" : test_multiple_containers_delete,
+    "test_help_delete": test_help_delete,
 }
 
 if __name__ == "__main__":

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -464,6 +464,13 @@ def test_exec_getpgrp():
             run_crun_command(["delete", "-f", cid])
     return 0
 
+def test_exec_help():
+    out = run_crun_command(["exec", "--help"])
+    if "Usage: crun [OPTION...] exec CONTAINER cmd" not in out:
+        return -1
+    
+    return 0
+
 all_tests = {
     "exec" : test_exec,
     "exec-not-exists" : test_exec_not_exists,
@@ -479,6 +486,7 @@ all_tests = {
     "exec-test-uid-tty": test_uid_tty,
     "exec-cpu-affinity": test_exec_cpu_affinity,
     "exec-getpgrp": test_exec_getpgrp,
+    "exec-help" : test_exec_help,
 }
 
 if __name__ == "__main__":

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -669,6 +669,13 @@ def test_add_remove_mounts():
         shutil.rmtree(bind_dir)
     return 0
 
+def test_mount_help():
+    out = run_crun_command(["mounts", "--help"])
+    if "Usage: crun [OPTION...] mounts [add|remove] CONTAINER FILE" not in out:
+        return -1
+    
+    return 0
+
 all_tests = {
     "mount-ro" : test_mount_ro,
     "mount-rro" : test_mount_rro,
@@ -698,6 +705,7 @@ all_tests = {
     "mount-copy-symlink": test_copy_symlink,
     "mount-tmpfs-permissions": test_mount_tmpfs_permissions,
     "mount-add-remove-mounts": test_add_remove_mounts,
+    "mount-help": test_mount_help,
 }
 
 if __name__ == "__main__":

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -521,6 +521,13 @@ def test_home_unknown_id():
         return -1
     return 0
 
+def test_start_help():
+    out = run_crun_command(["start", "--help"])
+    if "Usage: crun [OPTION...] start CONTAINER" not in out:
+        return -1
+    
+    return 0
+
 all_tests = {
     "start" : test_start,
     "start-override-config" : test_start_override_config,
@@ -541,6 +548,7 @@ all_tests = {
     "run-keep": test_run_keep,
     "invalid-id": test_invalid_id,
     "home-unknown-id": test_home_unknown_id,
+    "help": test_start_help,
 }
 
 if __name__ == "__main__":

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -49,9 +49,16 @@ def test_update():
         shutil.rmtree(temp_dir)
     return 1
 
+def test_update_help():
+    out = run_crun_command(["update", "--help"])
+    if "Usage: crun [OPTION...] update [OPTION]... CONTAINER" not in out:
+        return -1
+    
+    return 0
 
 all_tests = {
     "test-update" : test_update,
+    "test-update-help": test_update_help,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch solves the bug where the Usage info for commands displays the command name instead of "crun" as the crun binary name. E.g. for `crun list --help` crun prints "Usage: list [OPTION...] list" while it should print "Usage: crun [OPTION...] list".

This fix clones and modifies the `argc` and `argv` for second `argp_parse` execution - the `parse_opt` of each command will now receive the binary name (crun) instead of command name in the `argv[0]`. The change is transparent to commands, because
- the command name is extracted and used in first `argp_parse` execution in crun, and
- the `argp_parse` does not call the `parse_opt` with `argv[0]` by default

## Summary by Sourcery

Fix the binary name displayed in the usage information for crun commands

New Features:
- Add a function to clone command arguments to preserve the original binary name

Bug Fixes:
- Correct the usage message to display 'crun' as the binary name instead of the command name

Tests:
- Add test cases to verify correct usage message for various crun commands