### PR TITLE
linux: use syscall getcwd return value to set error

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5822,7 +5822,7 @@ libcrun_safe_chdir (const char *path, libcrun_error_t *err)
   buffer = xmalloc (PATH_MAX);
   ret = syscall_getcwd (buffer, PATH_MAX);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "getcwd");
+    return crun_make_error (err, -ret, "getcwd");
 
   /* Enforce that the returned path is an absolute path.  */
   if (ret == 0 || buffer[0] != '/')


### PR DESCRIPTION
In the Linux source code there is some example code for how to use the Linux system call __NR_getcwd 

https://github.com/torvalds/linux/blob/df67cb4c58fbb80399a99d47a554a67829f90dda/fs/d_path.c#L394-L411

At this line
https://github.com/torvalds/linux/blob/df67cb4c58fbb80399a99d47a554a67829f90dda/fs/d_path.c#L408
 `errno` is being set.


Maybe we can't rely on `errno` being set inside the system call? 
This PR uses the return value instead as suggested by the example code.

## Summary by Sourcery

Bug Fixes:
- Fixed error handling for getcwd syscall by using the negative return value as the error code