### PR TITLE
Fix getcwd error handling

### DIFF
--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -199,7 +199,7 @@ crun_command_checkpoint (struct crun_global_arguments *global_args, int argc, ch
 
       path = getcwd (NULL, 0);
       if (UNLIKELY (path == NULL))
-        libcrun_fail_with_error (0, "realloc failed");
+        libcrun_fail_with_error (errno, "getcwd failed");
 
       ret = asprintf (&cr_path, "%s/checkpoint", path);
       if (UNLIKELY (ret < 0))

--- a/src/create.c
+++ b/src/create.c
@@ -139,7 +139,11 @@ crun_command_create (struct crun_global_arguments *global_args, int argc, char *
 
   /* Make sure the bundle is an absolute path.  */
   if (bundle == NULL)
-    bundle = bundle_cleanup = getcwd (NULL, 0);
+    {
+      bundle = bundle_cleanup = getcwd (NULL, 0);
+      if (UNLIKELY (bundle == NULL))
+        libcrun_fail_with_error (errno, "getcwd failed");
+    }
   else
     {
       if (bundle[0] != '/')

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1847,6 +1847,8 @@ write_container_status (libcrun_container_t *container, libcrun_context_t *conte
                         libcrun_error_t *err)
 {
   cleanup_free char *cwd = getcwd (NULL, 0);
+  if (UNLIKELY (cwd == NULL))
+    libcrun_fail_with_error (errno, "getcwd failed");
   cleanup_free char *owner = get_user_name (geteuid ());
   cleanup_free char *intelrdt = NULL;
   char *external_descriptors = libcrun_get_external_descriptors (container);
@@ -1882,9 +1884,6 @@ write_container_status (libcrun_container_t *container, libcrun_context_t *conte
   };
 
   get_current_timestamp (created, sizeof (created));
-
-  if (cwd == NULL)
-    OOM ();
 
   if (cgroup_status)
     {

--- a/src/restore.c
+++ b/src/restore.c
@@ -195,7 +195,7 @@ crun_command_restore (struct crun_global_arguments *global_args, int argc, char 
 
       path = getcwd (NULL, 0);
       if (UNLIKELY (path == NULL))
-        libcrun_fail_with_error (0, "realloc failed");
+        libcrun_fail_with_error (errno, "getcwd failed");
 
       ret = asprintf (&cr_path, "%s/checkpoint", path);
       if (UNLIKELY (ret < 0))

--- a/src/run.c
+++ b/src/run.c
@@ -151,7 +151,11 @@ crun_command_run (struct crun_global_arguments *global_args, int argc, char **ar
 
   /* Make sure the bundle is an absolute path.  */
   if (bundle == NULL)
-    bundle = bundle_cleanup = getcwd (NULL, 0);
+    {
+      bundle = bundle_cleanup = getcwd (NULL, 0);
+      if (UNLIKELY (bundle == NULL))
+        libcrun_fail_with_error (errno, "getcwd failed");
+    }
   else
     {
       if (bundle[0] != '/')


### PR DESCRIPTION
Handle getcwd failure.
Fix getcwd error message.

## Summary by Sourcery

Improve error handling for getcwd() function calls across multiple source files

Bug Fixes:
- Properly handle getcwd() failure by checking for NULL return and using the correct error code
- Replace incorrect error messages with accurate 'getcwd failed' error reporting