### PR TITLE
Fix python call to `libcrun_get_verbosity`

### DIFF
--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -450,15 +450,7 @@ container_spec (PyObject *self arg_unused, PyObject *args arg_unused)
 static PyObject *
 get_verbosity (PyObject *self arg_unused, PyObject *args)
 {
-  libcrun_error_t err;
-  PyObject *ctx_obj = NULL;
-  libcrun_context_t *ctx;
-  int verbosity;
-
-  if (!PyArg_ParseTuple (args, "i", &verbosity))
-    return NULL;
-
-  return PyLong_FromLong (libcrun_get_verbosity (verbosity));
+  return PyLong_FromLong (libcrun_get_verbosity());
 }
 
 static PyObject *
@@ -495,7 +487,7 @@ static PyMethodDef CrunMethods[] = {
   {"make_context", (PyCFunction) make_context, METH_VARARGS | METH_KEYWORDS,
    "Create a context object."},
   {"set_verbosity", set_verbosity, METH_VARARGS, "Set the logging verbosity."},
-  {"get_verbosity", get_verbosity, METH_VARARGS, "Get the logging verbosity."},
+  {"get_verbosity", get_verbosity, METH_NOARGS, "Get the logging verbosity."},
   {"spec", container_spec, METH_VARARGS,
    "Generate a new configuration file."},
   {NULL, NULL, 0, NULL}


### PR DESCRIPTION
Fixes erroneous call with an unused argument to a 0-argument function.
Current call fails with GCC 15.1:
```
python/crun_python.c: In function 'get_verbosity':
python/crun_python.c:461:27: error: too many arguments to function 'libcrun_get_verbosity'; expected 0, have 1
  461 |   return PyLong_FromLong (libcrun_get_verbosity (verbosity));
      |                           ^~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~
In file included from /home/user/.cache/yay/crun-krun/src/crun/src/libcrun/container.h:24:
/home/user/.cache/yay/crun-krun/src/crun/src/libcrun/error.h:109:20: note: declared here
  109 | LIBCRUN_PUBLIC int libcrun_get_verbosity ();
      |                    ^~~~~~~~~~~~~~~~~~~~~
```
as reported here: https://aur.archlinux.org/packages/crun-krun#comment-1023007

## Summary by Sourcery

Bug Fixes:
- Corrected the Python call to `libcrun_get_verbosity()` to remove an unnecessary argument that was causing a compilation error with GCC 15.1