### PR TITLE
Followups to #1741

### DIFF
--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -480,7 +480,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
     {
       ret = mkdir (cr_options->work_path, 0700);
       if (UNLIKELY ((ret == -1) && (errno != EEXIST)))
-        return crun_make_error (err, errno, "error creating CRIU work directory `%s`", cr_options->image_path);
+        return crun_make_error (err, errno, "error creating CRIU work directory `%s`", cr_options->work_path);
 
       work_fd = open (cr_options->work_path, O_DIRECTORY | O_CLOEXEC);
       if (UNLIKELY (work_fd == -1))

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -861,6 +861,10 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
    * crun to set it if the user has not selected a specific directory. */
   if (cr_options->work_path != NULL)
     {
+      ret = mkdir (cr_options->work_path, 0700);
+      if (UNLIKELY ((ret == -1) && (errno != EEXIST)))
+        return crun_make_error (err, errno, "error creating CRIU work directory `%s`", cr_options->work_path);
+
       work_fd = open (cr_options->work_path, O_DIRECTORY | O_CLOEXEC);
       if (UNLIKELY (work_fd == -1))
         return crun_make_error (err, errno, "error opening CRIU work directory `%s`", cr_options->work_path);

--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -161,6 +161,7 @@ def test_cr_pre_dump():
 
     cid = None
     cr_dir = os.path.join(get_tests_root(), 'pre-dump')
+    work_dir = 'work-dir'
     try:
         _, cid = run_and_get_output(
             conf,
@@ -187,7 +188,6 @@ def test_cr_pre_dump():
 
         # Do the final dump. This dump should be much smaller.
         cr_dir = os.path.join(get_tests_root(), 'checkpoint')
-        work_dir = 'work-dir'
         run_crun_command([
             "checkpoint",
             "--parent-path=../pre-dump",


### PR DESCRIPTION
1. Fix error message added in #1741.

2. Commit 90ef9732 ("criu: create --work-path directory", PR #1741) forgot to add the same logic upon restore. If the --work-path used during restore differs from one that was used during checkpoint, criu fails.

3. Commit 0dceab0c did not define the work_dir for one of the cases.
