### PR TITLE
criu: fix c/r for container with bind mounts where dest is a symlink

### DIFF
--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -575,17 +575,11 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   /* Tell CRIU about external bind mounts. */
   for (i = 0; i < def->mounts_len; i++)
     {
-      size_t j;
-
-      for (j = 0; j < def->mounts[i]->options_len; j++)
+      if (is_bind_mount (def->mounts[i], NULL))
         {
-          if (strcmp (def->mounts[i]->options[j], "bind") == 0 || strcmp (def->mounts[i]->options[j], "rbind") == 0)
-            {
-              ret = libcriu_wrapper->criu_add_ext_mount (def->mounts[i]->destination, def->mounts[i]->destination);
-              if (UNLIKELY (ret < 0))
-                return crun_make_error (err, -ret, "CRIU: failed adding external mount to `%s`", def->mounts[i]->destination);
-              break;
-            }
+          ret = libcriu_wrapper->criu_add_ext_mount (def->mounts[i]->destination, def->mounts[i]->destination);
+          if (UNLIKELY (ret < 0))
+            return crun_make_error (err, -ret, "CRIU: failed adding external mount to `%s`", def->mounts[i]->destination);
         }
     }
 
@@ -742,16 +736,11 @@ prepare_restore_mounts (runtime_spec_schema_config_schema *def, char *root, libc
         continue;
 
       /* For bind mounts check if the source is a file or a directory. */
-      for (j = 0; j < def->mounts[i]->options_len; j++)
+      if (is_bind_mount (def->mounts[i], NULL))
         {
-          const char *opt = def->mounts[i]->options[j];
-          if (strcmp (opt, "bind") == 0 || strcmp (opt, "rbind") == 0)
-            {
-              is_dir = crun_dir_p (def->mounts[i]->source, false, err);
-              if (UNLIKELY (is_dir < 0))
-                return is_dir;
-              break;
-            }
+          is_dir = crun_dir_p (def->mounts[i]->source, false, err);
+          if (UNLIKELY (is_dir < 0))
+            return is_dir;
         }
 
       root_fd = open (root, O_RDONLY | O_CLOEXEC);
@@ -901,17 +890,11 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
   /* Tell CRIU about external bind mounts. */
   for (i = 0; i < def->mounts_len; i++)
     {
-      size_t j;
-
-      for (j = 0; j < def->mounts[i]->options_len; j++)
+      if (is_bind_mount (def->mounts[i], NULL))
         {
-          if (strcmp (def->mounts[i]->options[j], "bind") == 0 || strcmp (def->mounts[i]->options[j], "rbind") == 0)
-            {
-              ret = libcriu_wrapper->criu_add_ext_mount (def->mounts[i]->destination, def->mounts[i]->source);
-              if (UNLIKELY (ret < 0))
-                return crun_make_error (err, -ret, "CRIU: failed adding external mount to `%s`", def->mounts[i]->source);
-              break;
-            }
+          ret = libcriu_wrapper->criu_add_ext_mount (def->mounts[i]->destination, def->mounts[i]->source);
+          if (UNLIKELY (ret < 0))
+            return crun_make_error (err, -ret, "CRIU: failed adding external mount to `%s`", def->mounts[i]->source);
         }
     }
 

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -283,7 +283,8 @@ restore_cgroup_v1_mount (runtime_spec_schema_config_schema *def, libcrun_error_t
   /* First check if there is actually a cgroup mount in the container. */
   for (i = 0; i < def->mounts_len; i++)
     {
-      if (strcmp (def->mounts[i]->type, "cgroup") == 0)
+      char *type = def->mounts[i]->type;
+      if (type && strcmp (type, "cgroup") == 0)
         {
           has_cgroup_mount = true;
           break;
@@ -353,7 +354,8 @@ checkpoint_cgroup_v1_mount (runtime_spec_schema_config_schema *def, libcrun_erro
   /* First check if there is actually a cgroup mount in the container. */
   for (i = 0; i < def->mounts_len; i++)
     {
-      if (strcmp (def->mounts[i]->type, "cgroup") == 0)
+      char *type = def->mounts[i]->type;
+      if (type && strcmp (type, "cgroup") == 0)
         {
           has_cgroup_mount = true;
           break;
@@ -714,7 +716,7 @@ prepare_restore_mounts (runtime_spec_schema_config_schema *def, char *root, libc
       size_t j;
 
       /* cgroup restore should be handled by CRIU itself */
-      if (strcmp (type, "cgroup") == 0 || strcmp (type, "cgroup2") == 0)
+      if (type && (strcmp (type, "cgroup") == 0 || strcmp (type, "cgroup2") == 0))
         continue;
 
       /* Check if the mountpoint is on a tmpfs. CRIU restores
@@ -723,8 +725,11 @@ prepare_restore_mounts (runtime_spec_schema_config_schema *def, char *root, libc
         {
           cleanup_free char *dest_loop = NULL;
 
+          if (def->mounts[j]->type == NULL || strcmp (def->mounts[j]->type, "tmpfs") != 0)
+            continue;
+
           xasprintf (&dest_loop, "%s/", def->mounts[j]->destination);
-          if (strncmp (dest, dest_loop, strlen (dest_loop)) == 0 && strcmp (def->mounts[j]->type, "tmpfs") == 0)
+          if (strncmp (dest, dest_loop, strlen (dest_loop)) == 0)
             {
               /* This is a mountpoint which is on a tmpfs.*/
               on_tmpfs = true;

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -415,7 +415,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   cleanup_wrapper struct libcriu_wrapper_s *wrapper = NULL;
   cleanup_free char *descriptors_path = NULL;
   cleanup_free char *freezer_path = NULL;
-  cleanup_free char *path = NULL;
+  cleanup_free char *rootfs = NULL;
   cleanup_close int image_fd = -1;
   cleanup_close int work_fd = -1;
   int cgroup_mode;
@@ -554,13 +554,13 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   if (UNLIKELY (ret < 0))
     return crun_error_wrap (err, "error saving CRIU descriptors file");
 
-  ret = append_paths (&path, err, status->bundle, status->rootfs, NULL);
+  ret = append_paths (&rootfs, err, status->bundle, status->rootfs, NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = libcriu_wrapper->criu_set_root (path);
+  ret = libcriu_wrapper->criu_set_root (rootfs);
   if (UNLIKELY (ret != 0))
-    return crun_make_error (err, 0, "error setting CRIU root to `%s`", path);
+    return crun_make_error (err, 0, "error setting CRIU root to `%s`", rootfs);
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
   if (UNLIKELY (cgroup_mode < 0))

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -733,15 +733,13 @@ prepare_restore_mounts (runtime_spec_schema_config_schema *def, char *root, libc
 
       /* Check if the mountpoint is on a tmpfs. CRIU restores
        * all tmpfs. We do need to recreate directories on a tmpfs. */
+      size_t dest_len = strlen (dest);
       for (j = 0; j < def->mounts_len; j++)
         {
-          cleanup_free char *dest_loop = NULL;
-
           if (def->mounts[j]->type == NULL || strcmp (def->mounts[j]->type, "tmpfs") != 0)
             continue;
-
-          xasprintf (&dest_loop, "%s/", def->mounts[j]->destination);
-          if (strncmp (dest, dest_loop, strlen (dest_loop)) == 0)
+          size_t mount_len = strlen (def->mounts[j]->destination);
+          if (mount_len < dest_len && dest[mount_len] == '/' && strncmp (dest, def->mounts[j]->destination, mount_len) == 0)
             {
               /* This is a mountpoint which is on a tmpfs.*/
               on_tmpfs = true;

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -4002,7 +4002,7 @@ get_fd_map (libcrun_container_t *container)
   return mount_fds;
 }
 
-static bool
+bool
 is_bind_mount (runtime_spec_schema_defs_mount *mnt, bool *recursive)
 {
   size_t i;

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -149,6 +149,8 @@ int libcrun_safe_chdir (const char *path, libcrun_error_t *err);
 
 int get_bind_mount (int dirfd, const char *src, bool recursive, bool rdonly, libcrun_error_t *err);
 
+bool is_bind_mount (runtime_spec_schema_defs_mount *mnt, bool *recursive);
+
 int libcrun_make_runtime_mounts (libcrun_container_t *container, libcrun_container_status_t *status, runtime_spec_schema_defs_mount **mounts, size_t len, libcrun_error_t *err);
 
 int libcrun_destroy_runtime_mounts (libcrun_container_t *container, libcrun_container_status_t *status, runtime_spec_schema_defs_mount **mounts, size_t len, libcrun_error_t *err);


### PR DESCRIPTION
Two fixes and two slight improvements to the code handling c/r of a container
with a bind mount, including 1 case where mount destination is a symlink.

See individual commits for details.

No new tests added -- I plan to reuse existing runc tests here (once all the bugs are ironed out).

## Summary by Sourcery

Fix CRIU checkpoint/restore of containers with bind mounts, including those whose mount destinations are symlinks, by improving mount type checks, resolving symlinked paths under the rootfs, and cleaning up internal APIs.

Bug Fixes:
- Add null checks before string comparisons of mount types to prevent potential crashes when handling cgroup and tmpfs mounts.

Enhancements:
- Resolve bind mount destinations inside the container root using chroot_realpath so CRIU can correctly handle symlink targets during checkpoint and restore.
- Replace manual mount-option loops with the is_bind_mount helper and expose is_bind_mount in the public API.
- Rename internal variable path to rootfs for clarity when setting CRIU’s root.