### PR TITLE
linux: nits to mounting code

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1243,17 +1243,11 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
         }
     }
 
-  if (mountflags & ALL_PROPAGATIONS)
+  if (mountflags & ALL_PROPAGATIONS_NO_REC)
     {
-      unsigned long rec = mountflags & MS_REC;
-      unsigned long propagation = mountflags & ALL_PROPAGATIONS_NO_REC;
-
-      if (propagation)
-        {
-          ret = mount (NULL, real_target, NULL, rec | propagation, NULL);
-          if (UNLIKELY (ret < 0))
-            return crun_make_error (err, errno, "set propagation for `%s`", target);
-        }
+      ret = mount (NULL, real_target, NULL, mountflags & ALL_PROPAGATIONS, NULL);
+      if (UNLIKELY (ret < 0))
+        return crun_make_error (err, errno, "set propagation for `%s`", target);
     }
 
   if (mountflags & (MS_BIND | MS_RDONLY))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1246,7 +1246,7 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
   if (mountflags & ALL_PROPAGATIONS)
     {
       unsigned long rec = mountflags & MS_REC;
-      unsigned long propagation = mountflags & (MS_SHARED | MS_PRIVATE | MS_SLAVE | MS_UNBINDABLE);
+      unsigned long propagation = mountflags & ALL_PROPAGATIONS_NO_REC;
 
       if (propagation)
         {
@@ -2595,7 +2595,7 @@ libcrun_set_mounts (struct container_entrypoint_s *entrypoint_args, libcrun_cont
   if (def->linux->rootfs_propagation)
     rootfs_propagation = get_mount_flags (def->linux->rootfs_propagation, 0, NULL, NULL, NULL, NULL);
 
-  if ((rootfs_propagation & (MS_SHARED | MS_SLAVE | MS_PRIVATE | MS_UNBINDABLE)) == 0)
+  if ((rootfs_propagation & ALL_PROPAGATIONS_NO_REC) == 0)
     rootfs_propagation = MS_REC | MS_PRIVATE;
 
   get_private_data (container)->rootfs_propagation = rootfs_propagation;


### PR DESCRIPTION
I was looking through the mounting code and made some minor changes, which should not result in any change in functionality, but slightly simpler code.

Feel free to close it is's not worth it.

## Summary by Sourcery

Simplify mounting code by streamlining propagation flag handling and reducing redundancy.

Enhancements:
- Consolidate propagation mount handling into a single mount call using ALL_PROPAGATIONS_NO_REC.
- Use ALL_PROPAGATIONS_NO_REC to check and default rootfs propagation flags instead of explicit flag checks.