### PR TITLE
linux: treats empty path to safe_openat as root

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -4303,7 +4303,7 @@ prepare_and_send_dev_mounts (libcrun_container_t *container, int sync_socket_hos
     return ret;
 
   ret = mkdir (devs_path, 0700);
-  if (UNLIKELY (ret < 0) && errno != EEXIST)
+  if (UNLIKELY (ret < 0 && errno != EEXIST))
     return crun_make_error (err, errno, "mkdir `%s`", devs_path);
 
   current_mountns = open ("/proc/self/ns/mnt", O_RDONLY | O_CLOEXEC);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1227,6 +1227,17 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
           if (UNLIKELY (fd < 0))
             return fd;
 
+          /* We are replacing the rootfs, reopen it.  */
+          if (is_empty_string (target))
+            {
+              int tmp = dup (fd);
+              if (UNLIKELY (tmp < 0))
+                return crun_make_error (err, errno, "dup");
+
+              TEMP_FAILURE_RETRY (close (get_private_data (container)->rootfsfd));
+              get_private_data (container)->rootfsfd = tmp;
+            }
+
 #ifdef HAVE_FGETXATTR
           if (label_how == LABEL_XATTR)
             {

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -449,7 +449,11 @@ crun_safe_ensure_at (bool do_open, bool dir, int dirfd, const char *dirpath,
 
   /* Empty path, nothing to do.  */
   if (*path == '\0')
-    return 0;
+    {
+      if (do_open)
+        return open (dirpath, O_CLOEXEC | O_PATH, 0);
+      return 0;
+    }
 
   npath = xstrdup (path);
 
@@ -577,12 +581,12 @@ crun_safe_ensure_at (bool do_open, bool dir, int dirfd, const char *dirpath,
 int
 crun_safe_create_and_open_ref_at (bool dir, int dirfd, const char *dirpath, const char *path, int mode, libcrun_error_t *err)
 {
-  int fd;
+  int ret;
 
   /* If the file/dir already exists, just open it.  */
-  fd = safe_openat (dirfd, dirpath, path, O_PATH | O_CLOEXEC, 0, err);
-  if (LIKELY (fd >= 0))
-    return fd;
+  ret = safe_openat (dirfd, dirpath, path, O_PATH | O_CLOEXEC, 0, err);
+  if (LIKELY (ret >= 0))
+    return ret;
 
   crun_error_release (err);
   return crun_safe_ensure_at (true, dir, dirfd, dirpath, path, mode, MAX_READLINKS, err);

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -115,6 +115,33 @@ def test_mount_tmpfs_permissions():
         return 0
     return -1
 
+def test_mount_bind_to_rootfs():
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'true']
+    add_all_namespaces(conf)
+    tmpdir = tempfile.mkdtemp()
+    shutil.copy(get_init_path(), tmpdir)
+
+    mounts = [
+        {"destination": "/", "type": "bind", "source": tmpdir, "options": ["bind"]},
+    ]
+    conf['mounts'] = mounts + conf['mounts']
+    _, _ = run_and_get_output(conf, hide_stderr=True)
+    return 0
+
+def test_mount_tmpfs_to_rootfs():
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'true']
+    add_all_namespaces(conf)
+    tmpdir = tempfile.mkdtemp()
+
+    mounts = [
+        {"destination": "/", "type": "tmpfs", "source": "tmpfs", "options": ["tmpcopyup"]},
+    ]
+    conf['mounts'] = mounts + conf['mounts']
+    _, _ = run_and_get_output(conf, hide_stderr=True)
+    return 0
+
 def test_ro_cgroup():
     for cgroupns in [True, False]:
         for netns in [True, False]:
@@ -693,6 +720,8 @@ all_tests = {
     "mount-unix-socket" : test_mount_unix_socket,
     "mount-symlink-not-existing" : test_mount_symlink_not_existing,
     "mount-dev" : test_mount_dev,
+    "mount-bind-to-rootfs": test_mount_bind_to_rootfs,
+    "mount-tmpfs-to-rootfs": test_mount_tmpfs_to_rootfs,
     "mount-nodev" : test_mount_nodev,
     "mount-path-with-multiple-slashes" : test_mount_path_with_multiple_slashes,
     "mount-userns-bind-mount" : test_userns_bind_mount,

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -109,7 +109,7 @@ def test_mount_tmpfs_permissions():
     conf = base_config()
     conf['process']['args'] = ['/init', 'mode', '/tmp']
     add_all_namespaces(conf)
-    mount_opt = {"destination": "/tmp", "type": "tmpfs", "source": "tmpfs", "options": ["bind", "ro"]}
+    conf['mounts'].append({"destination": "/tmp", "type": "tmpfs", "source": "tmpfs", "options": ["bind", "ro"]})
     out, _ = run_and_get_output(conf, hide_stderr=True, callback_prepare_rootfs=prepare_rootfs)
     if "712" in out:
         return 0

--- a/tests/tests_libcrun_intelrdt.c
+++ b/tests/tests_libcrun_intelrdt.c
@@ -84,6 +84,8 @@ test_get_rdt_value ()
     {                                                    \
       char *result = NULL;                               \
       int r = get_rdt_value (&result, L3, MB, SCHEMATA); \
+      if (strlen (result) != r)                          \
+        return 1;                                        \
       int cmp = strcmp (result, EXPECTED);               \
       free (result);                                     \
       if (cmp != 0)                                      \


### PR DESCRIPTION
When an empty string is provided as the `path` argument to `safe_openat`, it is now explicitly treated as "/".

Closes: https://github.com/containers/crun/issues/1752

## Summary by Sourcery

Treat empty paths as root in safe_openat and streamline rootfsfd handling across mounting and device creation code, ensure proper cleanup of the rootfs file descriptor, add helper for validating fd targets, and expand tests for root-level bind and tmpfs mounts and rdt value length checks.

Bug Fixes:
- Treat empty path passed to safe_openat as referring to the root directory of the container.
- Close and reset the stored rootfs file descriptor properly after mounting operations.

Enhancements:
- Consolidate use of rootfsfd by fetching it directly from private_data in various mount and device-creation routines.
- Remove redundant local rootfsfd parameters and simplify do_mounts and libcrun_set_mounts signatures.

Tests:
- Add tests for bind and tmpfs mounts targeting root (‘/’).
- Add a check in Intel RDT tests to verify that get_rdt_value’s return length matches the output string.

Chores:
- Introduce check_fd_is_path helper to verify that an open file descriptor points to a given directory.