### PR TITLE
[RFC] Revert partially "criu: handle symlink mount dests"

### DIFF
--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -587,9 +587,10 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
           const char *dest_in_root;
 
           dest_in_root = chroot_realpath (rootfs, def->mounts[i]->destination, buf);
-          if (UNLIKELY (dest_in_root == NULL))
-            return crun_make_error (err, errno, "unable to resolve external bind mount `%s` under rootfs", def->mounts[i]->destination);
-          dest_in_root += strlen (rootfs);
+          if (LIKELY (dest_in_root != NULL))
+            dest_in_root += strlen (rootfs);
+          else
+            dest_in_root = def->mounts[i]->destination;
 
           ret = libcriu_wrapper->criu_add_ext_mount (dest_in_root, dest_in_root);
           if (UNLIKELY (ret < 0))
@@ -916,9 +917,10 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
           const char *dest_in_root;
 
           dest_in_root = chroot_realpath (rootfs, def->mounts[i]->destination, buf);
-          if (UNLIKELY (dest_in_root == NULL))
-            return crun_make_error (err, errno, "unable to resolve external bind mount `%s` under rootfs", def->mounts[i]->destination);
-          dest_in_root += strlen (rootfs);
+          if (LIKELY (dest_in_root != NULL))
+            dest_in_root += strlen (rootfs);
+          else
+            dest_in_root = def->mounts[i]->destination;
 
           ret = libcriu_wrapper->criu_add_ext_mount (dest_in_root, def->mounts[i]->source);
           if (UNLIKELY (ret < 0))


### PR DESCRIPTION
commit e0b01580754fdabb73508cd2cfa658c10e975dc6 introduced a regression with podman system tests.

When the lookup in the chroot fails, fallback to the previous behavior of using the verbatim destination path.

## Summary by Sourcery

Restore previous mount destination handling in CRIU integration by falling back to the original destination path when chroot_realpath fails, preventing regressions in Podman system tests.

Bug Fixes:
- Fallback to the verbatim mount destination path when chroot_realpath lookup fails instead of aborting.
- Apply the same fallback behavior for both checkpoint and restore CRIU operations.