### PR TITLE
Fixup "criu: support mounts where dest is a symlink"

### DIFF
--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -418,7 +418,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   cleanup_wrapper struct libcriu_wrapper_s *wrapper = NULL;
   cleanup_free char *descriptors_path = NULL;
   cleanup_free char *freezer_path = NULL;
-  cleanup_free char *rootfs = NULL;
+  cleanup_free char *path = NULL;
   cleanup_close int image_fd = -1;
   cleanup_close int work_fd = -1;
   int cgroup_mode;
@@ -557,13 +557,13 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   if (UNLIKELY (ret < 0))
     return crun_error_wrap (err, "error saving CRIU descriptors file");
 
-  ret = append_paths (&rootfs, err, status->bundle, status->rootfs, NULL);
+  ret = append_paths (&path, err, status->bundle, status->rootfs, NULL);
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = libcriu_wrapper->criu_set_root (rootfs);
+  ret = libcriu_wrapper->criu_set_root (path);
   if (UNLIKELY (ret != 0))
-    return crun_make_error (err, 0, "error setting CRIU root to `%s`", rootfs);
+    return crun_make_error (err, 0, "error setting CRIU root to `%s`", path);
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
   if (UNLIKELY (cgroup_mode < 0))

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -586,10 +586,16 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
           char buf[PATH_MAX];
           const char *dest_in_root;
 
-          dest_in_root = chroot_realpath (rootfs, def->mounts[i]->destination, buf);
+          dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf);
           if (UNLIKELY (dest_in_root == NULL))
-            return crun_make_error (err, errno, "unable to resolve external bind mount `%s` under rootfs", def->mounts[i]->destination);
-          dest_in_root += strlen (rootfs);
+            {
+              if (errno != ENOENT)
+                return crun_make_error (err, errno, "unable to resolve external bind mount `%s` under rootfs", def->mounts[i]->destination);
+              else
+                dest_in_root = def->mounts[i]->destination;
+            }
+          else
+            dest_in_root += strlen (status->rootfs);
 
           ret = libcriu_wrapper->criu_add_ext_mount (dest_in_root, dest_in_root);
           if (UNLIKELY (ret < 0))
@@ -793,7 +799,6 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
   cleanup_close int inherit_new_pid_fd = -1;
   cleanup_close int image_fd = -1;
   cleanup_free char *root = NULL;
-  cleanup_free char *rootfs = NULL;
   cleanup_free char *bundle_cleanup = NULL;
   cleanup_close int work_fd = -1;
   int ret_out;
@@ -904,9 +909,6 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
     }
 
   /* Tell CRIU about external bind mounts. */
-  ret = append_paths (&rootfs, err, status->bundle, status->rootfs, NULL);
-  if (UNLIKELY (ret < 0))
-    return ret;
   for (i = 0; i < def->mounts_len; i++)
     {
       if (is_bind_mount (def->mounts[i], NULL))
@@ -915,10 +917,15 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
           char buf[PATH_MAX];
           const char *dest_in_root;
 
-          dest_in_root = chroot_realpath (rootfs, def->mounts[i]->destination, buf);
+          dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf);
           if (UNLIKELY (dest_in_root == NULL))
-            return crun_make_error (err, errno, "unable to resolve external bind mount `%s` under rootfs", def->mounts[i]->destination);
-          dest_in_root += strlen (rootfs);
+            {
+              if (errno != ENOENT)
+                return crun_make_error (err, errno, "unable to resolve external bind mount destination `%s` under rootfs", def->mounts[i]->destination);
+              dest_in_root = def->mounts[i]->destination;
+            }
+          else
+            dest_in_root += strlen (status->rootfs);
 
           ret = libcriu_wrapper->criu_add_ext_mount (dest_in_root, def->mounts[i]->source);
           if (UNLIKELY (ret < 0))

--- a/tests/tmt/podman/system-test.sh
+++ b/tests/tmt/podman/system-test.sh
@@ -14,3 +14,4 @@ rpm -q conmon containers-common crun podman podman-tests
 bats -t /usr/share/podman/test/system/030-run.bats
 bats -t /usr/share/podman/test/system/075-exec.bats
 bats -t /usr/share/podman/test/system/280-update.bats
+bats -t /usr/share/podman/test/system/520-checkpoint.bats


### PR DESCRIPTION
This fixes issues brought by #1747, and also cherry-picks #1756 so that the changes can be tested.

## Summary by Sourcery

Fix CRIU checkpoint and restore procedures to support bind mounts where the destination in rootfs is a symlink

Bug Fixes:
- Fall back to using the original mount destination when chroot_realpath fails with ENOENT instead of erroring out

Enhancements:
- Resolve mount destinations against status->rootfs directly and remove redundant path concatenation in restore
- Rename internal rootfs variable to path in checkpoint function