### PR TITLE
Add `src-nofollow` & `dest-nofollow` mount options

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,6 +122,7 @@ jobs:
                   unshare -r make check ASAN_OPTIONS=detect_leaks=false || (cat test-suite.log; exit 1)
 
                   git status
+                  git diff
 
                   # check that the working dir is clean
                   git describe --broken --dirty --all | grep -qv dirty

--- a/crun.1
+++ b/crun.1
@@ -661,6 +661,16 @@ destination instead of attempting a mount that would resolve the
 symlink itself.  If the destination already exists and it is not a
 symlink with the expected content, crun will return an error.
 
+.SH dest-nofollow
+When this option is specified for a bind mount, and the destination of
+the bind mount is a symbolic link, \fBcrun\fR will mount the symbolic link
+itself at the target destination.
+
+.SH src-nofollow
+When this option is specified for a bind mount, and the source of the
+bind mount is a symbolic link, \fBcrun\fR will use the symlink itself
+rather than the file or directory the symbolic link points to.
+
 .SH r$FLAG mount options
 If a \fBr$FLAG\fR mount option is specified then the flag \fB$FLAG\fR is set
 recursively for each children mount.

--- a/crun.1.md
+++ b/crun.1.md
@@ -571,6 +571,16 @@ destination instead of attempting a mount that would resolve the
 symlink itself.  If the destination already exists and it is not a
 symlink with the expected content, crun will return an error.
 
+## dest-nofollow
+When this option is specified for a bind mount, and the destination of
+the bind mount is a symbolic link, `crun` will mount the symbolic link
+itself at the target destination.
+
+## src-nofollow
+When this option is specified for a bind mount, and the source of the
+bind mount is a symbolic link, `crun` will use the symlink itself
+rather than the file or directory the symbolic link points to.
+
 ## r$FLAG mount options
 
 If a `r$FLAG` mount option is specified then the flag `$FLAG` is set

--- a/src/libcrun/cloned_binary.c
+++ b/src/libcrun/cloned_binary.c
@@ -370,7 +370,7 @@ static int seal_execfd(int *fd, int fdtype)
 static int try_bindfd_mount_api(void)
 {
 	libcrun_error_t err;
-	int mountfd = get_bind_mount (-1, "/proc/self/exe", false, true, &err);
+	int mountfd = get_bind_mount (-1, "/proc/self/exe", false, true, false, &err);
 	if (mountfd < 0) {
 		crun_error_release (&err);
 		return -1;

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -580,7 +580,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   /* Tell CRIU about external bind mounts. */
   for (i = 0; i < def->mounts_len; i++)
     {
-      if (is_bind_mount (def->mounts[i], NULL))
+      if (is_bind_mount (def->mounts[i], NULL, NULL))
         {
           /* We need to resolve mount destination inside container's root for CRIU to handle. */
           char buf[PATH_MAX];
@@ -757,7 +757,7 @@ prepare_restore_mounts (runtime_spec_schema_config_schema *def, char *root, libc
         continue;
 
       /* For bind mounts check if the source is a file or a directory. */
-      if (is_bind_mount (def->mounts[i], NULL))
+      if (is_bind_mount (def->mounts[i], NULL, NULL))
         {
           is_dir = crun_dir_p (def->mounts[i]->source, false, err);
           if (UNLIKELY (is_dir < 0))
@@ -911,7 +911,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
   /* Tell CRIU about external bind mounts. */
   for (i = 0; i < def->mounts_len; i++)
     {
-      if (is_bind_mount (def->mounts[i], NULL))
+      if (is_bind_mount (def->mounts[i], NULL, NULL))
         {
           /* We need to resolve mount destination inside container's root for CRIU to handle. */
           char buf[PATH_MAX];

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2336,8 +2336,7 @@ libcrun_container_do_bind_mount (libcrun_container_t *container, char *mount_sou
 
   targetfd = ret;
 
-  int label_how = LABEL_MOUNT;
-  ret = do_mount (container, mount_source, targetfd, target, "bind", flags, data, label_how, err);
+  ret = do_mount (container, mount_source, targetfd, target, "bind", flags, data, LABEL_MOUNT, err);
   if (UNLIKELY (ret < 0))
     return ret;
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -168,9 +168,6 @@ cleanup_private_data (void *private_data)
   if (p->dev_fds)
     cleanup_close_mapp (&(p->dev_fds));
 
-  if (p->rootfsfd >= 0)
-    close (p->rootfsfd);
-
   free (p->unified_cgroup_path);
   free (p->host_notify_socket_path);
   free (p->container_notify_socket_path);

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -149,7 +149,7 @@ int libcrun_update_intel_rdt (const char *ctr_name, libcrun_container_t *contain
 
 int libcrun_safe_chdir (const char *path, libcrun_error_t *err);
 
-int get_bind_mount (int dirfd, const char *src, bool recursive, bool rdonly, libcrun_error_t *err);
+int get_bind_mount (int dirfd, const char *src, bool recursive, bool rdonly, bool nofollow, libcrun_error_t *err);
 
 bool is_bind_mount (runtime_spec_schema_defs_mount *mnt, bool *recursive);
 

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -151,7 +151,7 @@ int libcrun_safe_chdir (const char *path, libcrun_error_t *err);
 
 int get_bind_mount (int dirfd, const char *src, bool recursive, bool rdonly, bool nofollow, libcrun_error_t *err);
 
-bool is_bind_mount (runtime_spec_schema_defs_mount *mnt, bool *recursive);
+bool is_bind_mount (runtime_spec_schema_defs_mount *mnt, bool *recursive, bool *src_nofollow);
 
 int libcrun_make_runtime_mounts (libcrun_container_t *container, libcrun_container_status_t *status, runtime_spec_schema_defs_mount **mounts, size_t len, libcrun_error_t *err);
 

--- a/src/libcrun/mount_flags.c
+++ b/src/libcrun/mount_flags.c
@@ -48,14 +48,14 @@
 struct propagation_flags_s;
 enum
   {
-    TOTAL_KEYWORDS = 57,
+    TOTAL_KEYWORDS = 59,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 14,
     MIN_HASH_VALUE = 2,
-    MAX_HASH_VALUE = 74
+    MAX_HASH_VALUE = 79
   };
 
-/* maximum key range = 73, duplicates = 0 */
+/* maximum key range = 78, duplicates = 0 */
 
 #ifdef __GNUC__
 __inline
@@ -69,32 +69,32 @@ hash (register const char *str, register size_t len)
 {
   static const unsigned char asso_values[] =
     {
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75,  8, 29, 12,
-       3, 21,  0, 75, 31,  0, 75, 75, 15, 10,
-       0,  4, 16, 75,  0, 19,  8, 17, 26,  0,
-      16, 26, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75, 75, 75, 75, 75,
-      75, 75, 75, 75, 75, 75
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 24, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 11, 35,  9,
+       3, 20,  3, 80, 35,  0, 80, 80, 17, 17,
+       0,  4, 21, 80,  0,  9,  4, 25, 24,  0,
+      23, 33, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+      80, 80, 80, 80, 80, 80
     };
   register unsigned int hval = len;
 
@@ -138,100 +138,104 @@ static const struct propagation_flags_s wordlist[] =
     {"nodiratime", 0, MS_NODIRATIME, 0},
 #line 85 "src/libcrun/mount_flags.perf"
     {"rnodiratime", 0, MS_NODIRATIME, OPTION_RECURSIVE},
-#line 55 "src/libcrun/mount_flags.perf"
-    {"diratime", 1, MS_NODIRATIME, 0},
-#line 83 "src/libcrun/mount_flags.perf"
-    {"rnoatime", 0, MS_NOATIME, OPTION_RECURSIVE},
-#line 81 "src/libcrun/mount_flags.perf"
-    {"rnomand", 1, MS_MANDLOCK, OPTION_RECURSIVE},
-#line 82 "src/libcrun/mount_flags.perf"
-    {"ratime", 1, MS_NOATIME, OPTION_RECURSIVE},
-#line 80 "src/libcrun/mount_flags.perf"
-    {"rmand", 0, MS_MANDLOCK, OPTION_RECURSIVE},
-#line 66 "src/libcrun/mount_flags.perf"
-    {"rprivate", 0, MS_REC|MS_PRIVATE, 0},
-#line 51 "src/libcrun/mount_flags.perf"
-    {"mand", 0, MS_MANDLOCK, 0},
-#line 91 "src/libcrun/mount_flags.perf"
-    {"idmap", 0, 0, OPTION_IDMAP},
-#line 54 "src/libcrun/mount_flags.perf"
-    {"noatime", 0, MS_NOATIME, 0},
-#line 52 "src/libcrun/mount_flags.perf"
-    {"nomand", 1, MS_MANDLOCK, 0},
 #line 49 "src/libcrun/mount_flags.perf"
     {"dirsync", 0, MS_DIRSYNC, 0},
 #line 72 "src/libcrun/mount_flags.perf"
     {"rnosuid", 0, MS_NOSUID, OPTION_RECURSIVE},
-#line 53 "src/libcrun/mount_flags.perf"
-    {"atime", 1, MS_NOATIME, 0},
-#line 76 "src/libcrun/mount_flags.perf"
-    {"rnoexec", 0, MS_NOEXEC, OPTION_RECURSIVE},
-#line 44 "src/libcrun/mount_flags.perf"
-    {"nodev", 0, MS_NODEV, 0},
-#line 38 "src/libcrun/mount_flags.perf"
-    {"rbind", 0, MS_REC|MS_BIND, 0},
-#line 58 "src/libcrun/mount_flags.perf"
-    {"norelatime", 1, MS_RELATIME, 0},
-#line 37 "src/libcrun/mount_flags.perf"
-    {"bind", 0, MS_BIND, 0},
-#line 89 "src/libcrun/mount_flags.perf"
-    {"rnostrictatime", 1, MS_STRICTATIME, OPTION_RECURSIVE},
+#line 82 "src/libcrun/mount_flags.perf"
+    {"ratime", 1, MS_NOATIME, OPTION_RECURSIVE},
+#line 55 "src/libcrun/mount_flags.perf"
+    {"diratime", 1, MS_NODIRATIME, 0},
+#line 83 "src/libcrun/mount_flags.perf"
+    {"rnoatime", 0, MS_NOATIME, OPTION_RECURSIVE},
 #line 59 "src/libcrun/mount_flags.perf"
     {"strictatime", 0, MS_STRICTATIME, 0},
 #line 88 "src/libcrun/mount_flags.perf"
     {"rstrictatime", 0, MS_STRICTATIME, OPTION_RECURSIVE},
-#line 36 "src/libcrun/mount_flags.perf"
-    {"defaults", 0, 0, 0},
-#line 71 "src/libcrun/mount_flags.perf"
-    {"rsuid", 1, MS_NOSUID, OPTION_RECURSIVE},
-#line 50 "src/libcrun/mount_flags.perf"
-    {"remount", 0, MS_REMOUNT, 0},
-#line 41 "src/libcrun/mount_flags.perf"
-    {"suid", 1, MS_NOSUID, 0},
+#line 54 "src/libcrun/mount_flags.perf"
+    {"noatime", 0, MS_NOATIME, 0},
+#line 89 "src/libcrun/mount_flags.perf"
+    {"rnostrictatime", 1, MS_STRICTATIME, OPTION_RECURSIVE},
+#line 81 "src/libcrun/mount_flags.perf"
+    {"rnomand", 1, MS_MANDLOCK, OPTION_RECURSIVE},
+#line 66 "src/libcrun/mount_flags.perf"
+    {"rprivate", 0, MS_REC|MS_PRIVATE, 0},
 #line 60 "src/libcrun/mount_flags.perf"
     {"nostrictatime", 1, MS_STRICTATIME, 0},
-#line 86 "src/libcrun/mount_flags.perf"
-    {"rrelatime", 0, MS_RELATIME, OPTION_RECURSIVE},
-#line 42 "src/libcrun/mount_flags.perf"
-    {"nosuid", 0, MS_NOSUID, 0},
-#line 46 "src/libcrun/mount_flags.perf"
-    {"noexec", 0, MS_NOEXEC, 0},
+#line 76 "src/libcrun/mount_flags.perf"
+    {"rnoexec", 0, MS_NOEXEC, OPTION_RECURSIVE},
+#line 44 "src/libcrun/mount_flags.perf"
+    {"nodev", 0, MS_NODEV, 0},
+#line 80 "src/libcrun/mount_flags.perf"
+    {"rmand", 0, MS_MANDLOCK, OPTION_RECURSIVE},
+#line 58 "src/libcrun/mount_flags.perf"
+    {"norelatime", 1, MS_RELATIME, 0},
+#line 51 "src/libcrun/mount_flags.perf"
+    {"mand", 0, MS_MANDLOCK, 0},
+#line 91 "src/libcrun/mount_flags.perf"
+    {"idmap", 0, 0, OPTION_IDMAP},
+#line 53 "src/libcrun/mount_flags.perf"
+    {"atime", 1, MS_NOATIME, 0},
+#line 52 "src/libcrun/mount_flags.perf"
+    {"nomand", 1, MS_MANDLOCK, 0},
+#line 71 "src/libcrun/mount_flags.perf"
+    {"rsuid", 1, MS_NOSUID, OPTION_RECURSIVE},
+#line 38 "src/libcrun/mount_flags.perf"
+    {"rbind", 0, MS_REC|MS_BIND, 0},
+#line 41 "src/libcrun/mount_flags.perf"
+    {"suid", 1, MS_NOSUID, 0},
+#line 37 "src/libcrun/mount_flags.perf"
+    {"bind", 0, MS_BIND, 0},
 #line 64 "src/libcrun/mount_flags.perf"
     {"rslave", 0, MS_REC|MS_SLAVE, 0},
-#line 65 "src/libcrun/mount_flags.perf"
-    {"private", 0, MS_PRIVATE, 0},
+#line 42 "src/libcrun/mount_flags.perf"
+    {"nosuid", 0, MS_NOSUID, 0},
+#line 36 "src/libcrun/mount_flags.perf"
+    {"defaults", 0, 0, 0},
+#line 86 "src/libcrun/mount_flags.perf"
+    {"rrelatime", 0, MS_RELATIME, OPTION_RECURSIVE},
 #line 77 "src/libcrun/mount_flags.perf"
     {"rsync", 0, MS_SYNCHRONOUS, OPTION_RECURSIVE},
-#line 57 "src/libcrun/mount_flags.perf"
-    {"relatime", 0, MS_RELATIME, 0},
+#line 50 "src/libcrun/mount_flags.perf"
+    {"remount", 0, MS_REMOUNT, 0},
+#line 94 "src/libcrun/mount_flags.perf"
+    {"dest-nofollow", 0, 0, OPTION_DEST_NOFOLLOW},
 #line 43 "src/libcrun/mount_flags.perf"
     {"dev", 1, MS_NODEV, 0},
 #line 73 "src/libcrun/mount_flags.perf"
     {"rdev", 1, MS_NODEV, OPTION_RECURSIVE},
-#line 90 "src/libcrun/mount_flags.perf"
-    {"tmpcopyup", 0, 0, OPTION_TMPCOPYUP},
-#line 67 "src/libcrun/mount_flags.perf"
-    {"unbindable", 0, MS_UNBINDABLE, 0},
-#line 68 "src/libcrun/mount_flags.perf"
-    {"runbindable", 0, MS_REC|MS_UNBINDABLE, 0},
+#line 65 "src/libcrun/mount_flags.perf"
+    {"private", 0, MS_PRIVATE, 0},
+#line 46 "src/libcrun/mount_flags.perf"
+    {"noexec", 0, MS_NOEXEC, 0},
+#line 93 "src/libcrun/mount_flags.perf"
+    {"src-nofollow", 0, 0, OPTION_SRC_NOFOLLOW},
+#line 47 "src/libcrun/mount_flags.perf"
+    {"sync", 0, MS_SYNCHRONOUS, 0},
+#line 57 "src/libcrun/mount_flags.perf"
+    {"relatime", 0, MS_RELATIME, 0},
 #line 48 "src/libcrun/mount_flags.perf"
     {"async", 1, MS_SYNCHRONOUS, 0},
 #line 78 "src/libcrun/mount_flags.perf"
     {"rasync", 1, MS_SYNCHRONOUS, OPTION_RECURSIVE},
-#line 47 "src/libcrun/mount_flags.perf"
-    {"sync", 0, MS_SYNCHRONOUS, 0},
-#line 75 "src/libcrun/mount_flags.perf"
-    {"rexec", 1, MS_NOEXEC, OPTION_RECURSIVE},
+#line 90 "src/libcrun/mount_flags.perf"
+    {"tmpcopyup", 0, 0, OPTION_TMPCOPYUP},
 #line 61 "src/libcrun/mount_flags.perf"
     {"shared", 0, MS_SHARED, 0},
 #line 62 "src/libcrun/mount_flags.perf"
     {"rshared", 0, MS_REC|MS_SHARED, 0},
-#line 92 "src/libcrun/mount_flags.perf"
-    {"copy-symlink", 0, 0, OPTION_COPY_SYMLINK},
 #line 63 "src/libcrun/mount_flags.perf"
     {"slave", 0, MS_SLAVE, 0},
+#line 75 "src/libcrun/mount_flags.perf"
+    {"rexec", 1, MS_NOEXEC, OPTION_RECURSIVE},
+#line 67 "src/libcrun/mount_flags.perf"
+    {"unbindable", 0, MS_UNBINDABLE, 0},
+#line 68 "src/libcrun/mount_flags.perf"
+    {"runbindable", 0, MS_REC|MS_UNBINDABLE, 0},
 #line 45 "src/libcrun/mount_flags.perf"
-    {"exec", 1, MS_NOEXEC, 0}
+    {"exec", 1, MS_NOEXEC, 0},
+#line 92 "src/libcrun/mount_flags.perf"
+    {"copy-symlink", 0, 0, OPTION_COPY_SYMLINK}
   };
 
 const struct propagation_flags_s *
@@ -373,22 +377,22 @@ libcrun_mount_flag_in_word_set (register const char *str, register size_t len)
               case 48:
                 resword = &wordlist[41];
                 goto compare;
-              case 50:
+              case 49:
                 resword = &wordlist[42];
                 goto compare;
-              case 51:
+              case 50:
                 resword = &wordlist[43];
                 goto compare;
-              case 52:
+              case 51:
                 resword = &wordlist[44];
                 goto compare;
-              case 53:
+              case 52:
                 resword = &wordlist[45];
                 goto compare;
-              case 54:
+              case 53:
                 resword = &wordlist[46];
                 goto compare;
-              case 55:
+              case 54:
                 resword = &wordlist[47];
                 goto compare;
               case 56:
@@ -397,26 +401,32 @@ libcrun_mount_flag_in_word_set (register const char *str, register size_t len)
               case 57:
                 resword = &wordlist[49];
                 goto compare;
-              case 59:
+              case 58:
                 resword = &wordlist[50];
                 goto compare;
-              case 61:
+              case 59:
                 resword = &wordlist[51];
                 goto compare;
-              case 62:
+              case 60:
                 resword = &wordlist[52];
                 goto compare;
-              case 63:
+              case 64:
                 resword = &wordlist[53];
                 goto compare;
-              case 68:
+              case 66:
                 resword = &wordlist[54];
                 goto compare;
-              case 71:
+              case 68:
                 resword = &wordlist[55];
                 goto compare;
-              case 72:
+              case 69:
                 resword = &wordlist[56];
+                goto compare;
+              case 74:
+                resword = &wordlist[57];
+                goto compare;
+              case 77:
+                resword = &wordlist[58];
                 goto compare;
             }
           return 0;
@@ -431,7 +441,7 @@ libcrun_mount_flag_in_word_set (register const char *str, register size_t len)
     }
   return 0;
 }
-#line 93 "src/libcrun/mount_flags.perf"
+#line 95 "src/libcrun/mount_flags.perf"
 
 
 const struct propagation_flags_s *

--- a/src/libcrun/mount_flags.h
+++ b/src/libcrun/mount_flags.h
@@ -25,6 +25,8 @@ enum
   OPTION_RECURSIVE = (1 << 1),
   OPTION_IDMAP = (1 << 2),
   OPTION_COPY_SYMLINK = (1 << 3),
+  OPTION_SRC_NOFOLLOW = (1 << 4),
+  OPTION_DEST_NOFOLLOW = (1 << 5),
 };
 
 struct propagation_flags_s

--- a/src/libcrun/mount_flags.perf
+++ b/src/libcrun/mount_flags.perf
@@ -90,6 +90,8 @@ rnostrictatime, 1, MS_STRICTATIME, OPTION_RECURSIVE
 tmpcopyup, 0, 0, OPTION_TMPCOPYUP
 idmap, 0, 0, OPTION_IDMAP
 copy-symlink, 0, 0, OPTION_COPY_SYMLINK
+src-nofollow, 0, 0, OPTION_SRC_NOFOLLOW
+dest-nofollow, 0, 0, OPTION_DEST_NOFOLLOW
 %%
 
 const struct propagation_flags_s *

--- a/tests/test_oci_features.py
+++ b/tests/test_oci_features.py
@@ -106,6 +106,8 @@ def test_crun_features():
                 "defaults",
                 "async",
                 "rasync",
+                "dest-nofollow",
+                "src-nofollow",
                 "private",
                 "tmpcopyup",
                 "rexec",


### PR DESCRIPTION
Introduce `src-nofollow` and `dest-nofollow` bind mount options for more precise control over symbolic link handling.

The `src-nofollow` option enables mounting the source symbolic link itself, rather than its target.

The `dest-nofollow` option ensures that if the destination path is a symbolic link, the mount operation replaces the symbolic link itself, instead of dereferencing it and mounting to its target.

More details here: https://github.com/containers/podman/issues/25947

## Summary by Sourcery

Introduce a new `at_symlink_nofollow` bind mount option that mounts symlinks themselves instead of their targets by passing the `AT_SYMLINK_NOFOLLOW` flag to the `open_tree(2)` syscall.

New Features:
- Add `at_symlink_nofollow` mount option to bind mounts to prevent dereferencing of source symlinks.

Enhancements:
- Extend `get_bind_mount` and mounting logic to accept and handle the nofollow flag.
- Update mount_flags parser and keyword tables to recognize `at_symlink_nofollow`. 

Documentation:
- Document `at_symlink_nofollow` option in the man page and Markdown reference.

Tests:
- Add `test_bind_mount_symlink_nofollow` to verify bind mounting of symlinks without following them.

## Summary by Sourcery

Introduce `src-nofollow` and `dest-nofollow` bind mount options to control whether source or destination symlinks are mounted directly rather than dereferenced, and propagate these flags through the mounting logic.

New Features:
- Add `src-nofollow` mount option to bind mounts to prevent dereferencing source symlinks
- Add `dest-nofollow` mount option to bind mounts to replace destination symlinks instead of dereferencing

Enhancements:
- Extend `get_bind_mount`, `do_mounts`, `is_bind_mount`, and CRIU integration to accept and handle nofollow flags
- Update mount flags parser and keyword tables to recognize `src-nofollow` and `dest-nofollow`

CI:
- Add a `git diff` check to the CI workflow

Documentation:
- Document `src-nofollow` and `dest-nofollow` options in the man page and Markdown reference

Tests:
- Add `test_bind_mount_symlink_nofollow` and `test_bind_mount_file_nofollow` to verify nofollow behavior under various user namespaces

Chores:
- Ensure CRIU returns an error when `src-nofollow` is used, since it isn’t supported