### PR TITLE
cgroup: change conversion  from CPU shares to weight

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -269,6 +269,41 @@ AS_IF([test "x$enable_criu" != "xno"], [
 
 ], [AC_MSG_NOTICE([CRIU support disabled per user request])])
 
+AC_MSG_CHECKING([for log2])
+AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([
+        #include <math.h>
+        #include <stdlib.h>
+    ], [
+        double result = log2 ((double) rand ());
+        return (int) result;
+    ])
+], [
+    # log2 works without -lm (musl libc)
+    AC_MSG_RESULT([yes])
+    AC_DEFINE([HAVE_LOG2], [1], [Define if log2 is available])
+], [
+    # Try with -lm (glibc)
+    LIBS="$LIBS -lm"
+    AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([
+            #include <math.h>
+            #include <stdlib.h>
+        ], [
+            double result = log2 ((double) rand ());
+            return (int) result;
+        ])
+    ], [
+        # log2 works with -lm
+        AC_MSG_RESULT([yes (with -lm)])
+        AC_DEFINE([HAVE_LOG2], [1], [Define if log2 is available])
+    ], [
+        # log2 not available - restore LIBS and fail
+        AC_MSG_RESULT([no])
+        AC_MSG_ERROR([*** log2 function is required but not found])
+    ])
+])
+
 FOUND_LIBS=$LIBS
 LIBS=""
 

--- a/crun.1
+++ b/crun.1
@@ -846,7 +846,10 @@ allbox;
 l l l l 
 l l l l .
 \fBOCI (x)\fP	\fBcgroup 2 value (y)\fP	\fBconversion\fP	\fBcomment\fP
-shares	cpu.weight	y = (1 + ((x - 2) * 9999) / 262142)	T{
+shares	cpu.weight	T{
+y=10^((log2(x)^2 + 125 * log2(x)) / 612.0 - 7.0 / 34.0)
+T}
+	T{
 convert from [2-262144] to [1-10000]
 T}
 period	cpu.max	y = x	T{

--- a/crun.1.md
+++ b/crun.1.md
@@ -712,11 +712,11 @@ they are converted when needed from the cgroup v1 configuration.
 
 ## CPU controller
 
-| OCI (x) | cgroup 2 value (y) | conversion  |  comment |
-|---|---|---|---|
-| shares | cpu.weight | y = (1 + ((x - 2) \* 9999) / 262142) | convert from [2-262144] to [1-10000]|
-| period | cpu.max | y = x| period and quota are written together|
-| quota | cpu.max | y = x| period and quota are written together|
+| OCI (x) | cgroup 2 value (y) | conversion                                              | comment                               |
+|---------|--------------------|---------------------------------------------------------|---------------------------------------|
+| shares  | cpu.weight         | y=10^((log2(x)^2 + 125 * log2(x)) / 612.0 - 7.0 / 34.0) | convert from [2-262144] to [1-10000]  |
+| period  | cpu.max            | y = x                                                   | period and quota are written together |
+| quota   | cpu.max            | y = x                                                   | period and quota are written together |
 
 ## blkio controller
 

--- a/tests/alpine-build/Dockerfile
+++ b/tests/alpine-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 RUN apk add gcc automake autoconf libtool gettext pkgconf git make musl-dev \
-    python3 libcap-dev libseccomp-dev yajl-dev argp-standalone go-md2man
+    python3 libcap-dev libseccomp-dev yajl-dev argp-standalone go-md2man gperf
 
 COPY run-tests.sh /usr/local/bin
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -291,24 +291,26 @@ def test_resources_cpu_weight_systemd():
             sys.stderr.write("# found wrong CPUWeight for the systemd scope\n")
             return 1
 
-        cpu_shares = 4321
-        run_crun_command(['update', '--cpu-share', str(cpu_shares), cid])
-        # this is the expected cpu weight after the conversion from the CPUShares
-        expected_weight = str(max(1, min(10000, cpu_shares * 100 // 1024)))
+        for values in [(2, 1), (3, 2), (1024, 100), (260000, 9929), (262144, 10000)]:
+            cpu_shares = values[0]
+            # this is the expected cpu weight after the conversion from the CPUShares
+            expected_weight = str(values[1])
 
-        out = run_crun_command(["exec", cid, "/init", "cat", "/sys/fs/cgroup/cpu.weight"])
-        if expected_weight not in out:
-            sys.stderr.write("found wrong CPUWeight %s instead of %s for the container cgroup\n" % (out, expected_weight))
-            return -1
+            run_crun_command(['update', '--cpu-share', str(cpu_shares), cid])
 
-        out = subprocess.check_output(['systemctl', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
-        # as above
-        if out != expected_weight:
-            out = subprocess.check_output(['systemctl', '--user', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
+            out = run_crun_command(["exec", cid, "/init", "cat", "/sys/fs/cgroup/cpu.weight"])
+            if expected_weight not in out:
+                sys.stderr.write("found wrong CPUWeight %s instead of %s for the container cgroup\n" % (out, expected_weight))
+                return -1
 
-        if out != expected_weight:
-            sys.stderr.write("# found wrong CPUWeight for the systemd scope\n")
-            return 1
+            out = subprocess.check_output(['systemctl', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
+            # as above
+            if out != expected_weight:
+                out = subprocess.check_output(['systemctl', '--user', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
+
+            if out != expected_weight:
+                sys.stderr.write("found wrong CPUWeight for the systemd scope\n")
+                return 1
     finally:
         if cid is not None:
             run_crun_command(["delete", "-f", cid])

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -291,13 +291,14 @@ def test_resources_cpu_weight_systemd():
             sys.stderr.write("# found wrong CPUWeight for the systemd scope\n")
             return 1
 
-        run_crun_command(['update', '--cpu-share', '4321', cid])
+        cpu_shares = 4321
+        run_crun_command(['update', '--cpu-share', str(cpu_shares), cid])
         # this is the expected cpu weight after the conversion from the CPUShares
-        expected_weight = "165"
+        expected_weight = str(max(1, min(10000, cpu_shares * 100 // 1024)))
 
         out = run_crun_command(["exec", cid, "/init", "cat", "/sys/fs/cgroup/cpu.weight"])
         if expected_weight not in out:
-            sys.stderr.write("# found wrong CPUWeight %s for the container cgroup\n" % out)
+            sys.stderr.write("found wrong CPUWeight %s instead of %s for the container cgroup\n" % (out, expected_weight))
             return -1
 
         out = subprocess.check_output(['systemctl', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()


### PR DESCRIPTION
The OCI CPU shares (range [2-262144]) to cgroup v2 `cpu.weight` (range [1-10000]) conversion formula has been updated

Closes: https://github.com/containers/crun/issues/1721

## Summary by Sourcery

Update the CPU shares to cgroup v2 cpu.weight conversion to use a log-quadratic function, ensure log2 availability at build time, and refresh tests and documentation to reflect the new mapping

Enhancements:
- Change CPU shares to cpu.weight conversion to use a log-quadratic formula with proper edge-case handling

Build:
- Add autoconf checks for availability of the log2 function and fail if missing

Documentation:
- Update CPU weight conversion formula in man page and Markdown documentation

Tests:
- Extend CPU weight conversion tests to cover boundary values

Chores:
- Add gperf to Alpine test Dockerfile