### PR TITLE
cgroup: do not create a sub-cgroup by default

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -577,26 +577,28 @@ chown -R the_user.the_user /sys/fs/cgroup/systemd
 .EE
 
 .SH \fBrun.oci.systemd.subgroup=SUBGROUP\fR
-Override the name for the systemd sub cgroup created under the systemd
-scope, so the final cgroup will be like:
+This configuration option allows you to define a sub-cgroup that will
+be created under a systemd-managed cgroup for your container.
+
+.PP
+When SUBGROUP is specified, the complete cgroup path will follow this
+structure:
 
 .EX
 /sys/fs/cgroup/$PATH/$SUBGROUP
 .EE
 
 .PP
-When it is set to the empty string, a sub cgroup is not created.
-
-.PP
-If not specified, it defaults to \fBcontainer\fR on cgroup v2, and to \fB""\fR
-on cgroup v1.
-
-.PP
-e.g.
+If \fBSUBGROUP\fR is set to \fBcontainer\fR, a typical path could be:
 
 .EX
-/sys/fs/cgroup//system.slice/foo-352700.scope/container
+/sys/fs/cgroup/system.slice/foo-352700.scope/container
 .EE
+
+.PP
+If \fBSUBGROUP\fR is set to an empty string, no sub-cgroup will be
+created.  By default, this option is not configured, meaning no
+sub-cgroup is created unless explicitly set.
 
 .SH \fBrun.oci.delegate-cgroup=DELEGATED-CGROUP\fR
 If the \fBrun.oci.systemd.subgroup\fR annotation is specified, yet another

--- a/crun.1.md
+++ b/crun.1.md
@@ -489,23 +489,24 @@ chown -R the_user.the_user /sys/fs/cgroup/systemd
 
 ## `run.oci.systemd.subgroup=SUBGROUP`
 
-Override the name for the systemd sub cgroup created under the systemd
-scope, so the final cgroup will be like:
+This configuration option allows you to define a sub-cgroup that will
+be created under a systemd-managed cgroup for your container.
+
+When SUBGROUP is specified, the complete cgroup path will follow this
+structure:
 
 ```
 /sys/fs/cgroup/$PATH/$SUBGROUP
 ```
 
-When it is set to the empty string, a sub cgroup is not created.
-
-If not specified, it defaults to `container` on cgroup v2, and to `""`
-on cgroup v1.
-
-e.g.
-
+If `SUBGROUP` is set to `container`, a typical path could be:
 ```
-/sys/fs/cgroup//system.slice/foo-352700.scope/container
+/sys/fs/cgroup/system.slice/foo-352700.scope/container
 ```
+
+If `SUBGROUP` is set to an empty string, no sub-cgroup will be
+created.  By default, this option is not configured, meaning no
+sub-cgroup is created unless explicitly set.
 
 ## `run.oci.delegate-cgroup=DELEGATED-CGROUP`
 

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1827,7 +1827,7 @@ find_systemd_subgroup (string_map *annotations)
       return annotation;
     }
 
-  return "container";
+  return NULL;
 }
 
 static int


### PR DESCRIPTION
The `run.oci.systemd.subgroup` annotation previously defaulted to creating a "container" sub-cgroup on cgroup v2 systems if the annotation was not specified.  This change alters the behavior so that no sub-cgroup is created by default.

A sub-cgroup will only be created if the
`run.oci.systemd.subgroup` annotation is explicitly provided with a non-empty value.

Closes: https://github.com/containers/crun/issues/1766

## Summary by Sourcery

Only create a systemd sub-cgroup when the run.oci.systemd.subgroup annotation is explicitly set, removing the previous default of “container” on cgroup v2.

Bug Fixes:
- Address issue where a default sub-cgroup was created unexpectedly on cgroup v2.

Enhancements:
- Remove automatic creation of a “container” sub-cgroup on cgroup v2 by returning NULL when the annotation is unset.
- Update documentation and man pages to clarify that no sub-cgroup is created unless the SUBGROUP value is explicitly provided.