### PR TITLE
src: improve dlopen error message

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -454,7 +454,7 @@ main (int argc, char **argv)
     }
   /* Resolve all libcrun weak dependencies.  */
   if (dlopen ("libcrun.so", RTLD_GLOBAL | RTLD_DEEPBIND | RTLD_LAZY) == NULL)
-    error (EXIT_FAILURE, 0, "dlopen: %s", dlerror ());
+    error (EXIT_FAILURE, 0, "could not load `libcrun.so`: `%s`", dlerror ());
 #endif
 
   fill_handler_from_argv0 (argv[0], &arguments);

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -145,7 +145,7 @@ load_wrapper (struct libcriu_wrapper_s **wrapper_out, libcrun_error_t *err)
 #  ifndef STATIC
   wrapper->handle = dlopen ("libcriu.so.2", RTLD_NOW);
   if (wrapper->handle == NULL)
-    return crun_make_error (err, 0, "could not load `libcriu.so.2`");
+    return crun_make_error (err, 0, "could not load `libcriu.so.2`: `%s`", dlerror ());
 #  endif
 
   LOAD_CRIU_FUNCTION (criu_add_ext_mount, false);

--- a/src/libcrun/handlers/mono.c
+++ b/src/libcrun/handlers/mono.c
@@ -100,7 +100,7 @@ mono_load (void **cookie, libcrun_error_t *err)
 
   handle = dlopen ("libmono-native.so", RTLD_NOW);
   if (handle == NULL)
-    return crun_make_error (err, 0, "could not load `libmono-2.0.so`: `%s`", dlerror ());
+    return crun_make_error (err, 0, "could not load `libmono-native.so`: `%s`", dlerror ());
   *cookie = handle;
 
   return 0;


### PR DESCRIPTION
Fix name  
`libmono-2.0.so` -> `libmono-native.so`

For the other two edits: make the error message more informative

## Summary by Sourcery

Improve dlopen error handling by correcting the Mono library name and making error messages more descriptive.

Enhancements:
- Add dlerror output to error messages when loading libcrun.so and libcriu.so.2 fails
- Correct the Mono handler to load libmono-native.so and include dlerror output on failure