### PR TITLE
libcrun: prefer waitpid_ignore_stopped NULL argument

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2926,7 +2926,7 @@ libcrun_container_run (libcrun_context_t *context, libcrun_container_t *containe
       int status;
       close_and_reset (&pipefd1);
 
-      waitpid_ignore_stopped (ret, &status, 0);
+      waitpid_ignore_stopped (ret, NULL, 0);
 
       ret = TEMP_FAILURE_RETRY (read (pipefd0, &status, sizeof (status)));
       if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5038,7 +5038,7 @@ join_process_parent_helper (libcrun_context_t *context,
                             bool need_move_to_cgroup, const char *sub_cgroup,
                             int *terminal_fd, libcrun_error_t *err)
 {
-  int ret, pid_status;
+  int ret;
   char res;
   pid_t pid;
   cleanup_close int sync_fd = sync_socket_fd;
@@ -5059,7 +5059,7 @@ join_process_parent_helper (libcrun_context_t *context,
     return crun_make_error (err, errno, "read from sync socket");
 
   /* Wait for the child pid so we ensure the grandchild gets properly reparented.  */
-  ret = waitpid_ignore_stopped (child_pid, &pid_status, 0);
+  ret = waitpid_ignore_stopped (child_pid, NULL, 0);
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "waitpid for exec child pid");
 


### PR DESCRIPTION
If the status value is not needed, pass the argument `NULL`.

## Summary by Sourcery

Enhancements:
- Prefer passing NULL to waitpid_ignore_stopped for unused status values, removing redundant pid_status and status variables in linux.c and container.c