### PR TITLE
python: reset pointer after asprintf failure

### DIFF
--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -55,6 +55,8 @@ set_error (libcrun_error_t *err)
       ret = asprintf (&msg, "%s: %s", (*err)->msg, strerror ((*err)->status));
       if (LIKELY (ret >= 0))
         PyErr_SetString (PyExc_RuntimeError, msg);
+      else
+        msg = NULL;
     }
 
   libcrun_error_release (err);
@@ -405,6 +407,8 @@ container_update (PyObject *self arg_unused, PyObject *args)
       ret = asprintf (&msg, "cannot parse process: %s", parser_err);
       if (LIKELY (ret >= 0))
         PyErr_SetString (PyExc_RuntimeError, msg);
+      else
+        msg = NULL;
       free (parser_err);
       return NULL;
     }


### PR DESCRIPTION
Reset pointer after `asprintf()` failure to avoid `free()` triggered by `cleanup_free`

Quote from
https://man7.org/linux/man-pages/man3/vasprintf.3.html
"_If memory allocation wasn't possible, or some other error occurs, these functions will return -1, and the contents of strp are undefined._"
