### PR TITLE
tests: fix mounts tests and improve error messages

### DIFF
--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -47,11 +47,12 @@ def test_mode_device():
             expected = "157"
             out = run_and_get_output(conf)
             if expected not in out[0]:
-                sys.stderr.write("wrong file mode, found %s instead of %s with userns=%s" % (out[0], expected, have_userns))
-                return True
-            return False
+                sys.stderr.write("# device mode test failed with userns=%s: expected '%s' in output\n" % (have_userns, expected))
+                sys.stderr.write("# actual output: %s\n" % out[0])
+                sys.stderr.write("# device config: %s\n" % conf['linux']['devices'][0])
+                return -1
         except Exception as e:
-            print(e)
+            sys.stderr.write("# device mode test failed with userns=%s: %s\n" % (have_userns, str(e)))
             return -1
     return 0
 
@@ -79,10 +80,12 @@ def test_owner_device():
             expected = "10:11"
             out = run_and_get_output(conf)
             if expected not in out[0]:
-                sys.stderr.write("wrong file owner, found %s instead of %s with userns=%s" % (out[0], expected, have_userns))
-                return True
-            return False
+                sys.stderr.write("# device owner test failed with userns=%s: expected '%s' in output\n" % (have_userns, expected))
+                sys.stderr.write("# actual output: %s\n" % out[0])
+                sys.stderr.write("# device config: %s\n" % conf['linux']['devices'][0])
+                return -1
         except Exception as e:
+            sys.stderr.write("# device owner test failed with userns=%s: %s\n" % (have_userns, str(e)))
             return -1
     return 0
 
@@ -136,7 +139,7 @@ def test_create_or_bind_mount_device():
     try:
         run_and_get_output(conf)
     except Exception as e:
-        sys.stderr.write(str(e) + "\n")
+        sys.stderr.write("# " + str(e) + "\n")
         return -1
     return 0
 
@@ -236,7 +239,7 @@ def test_net_devices():
 
     ip_path = shutil.which("ip")
     if ip_path is None:
-        sys.stderr.write("ip command not found\n")
+        sys.stderr.write("# ip command not found\n")
         return 77
 
     current_netns = os.open("/proc/self/ns/net", os.O_RDONLY)
@@ -270,15 +273,15 @@ def test_net_devices():
                 try:
                     out = run_and_get_output(conf)
                     if "address: 10.1.2.3" not in out[0]:
-                        sys.stderr.write("address not found in output\n")
+                        sys.stderr.write("# address not found in output\n")
                         return 1
                     if specify_broadcast:
                         if "broadcast: 10.1.2.254" not in out[0]:
-                            sys.stderr.write("broadcast address not found in output\n")
+                            sys.stderr.write("# broadcast address not found in output\n")
                             return 1
                     else:
                         if "broadcast" in out[0]:
-                            sys.stderr.write("broadcast address found in output\n")
+                            sys.stderr.write("# broadcast address found in output\n")
                             return 1
                 except Exception as e:
                     return -1
@@ -301,7 +304,7 @@ def test_mknod_fifo_device():
     try:
         run_and_get_output(conf)
     except Exception as e:
-        sys.stderr.write(f"test_mknod_fifo_device failed: %s\n" % e)
+        sys.stderr.write("# test_mknod_fifo_device failed: %s\n" % e)
         return -1
     return 0
 
@@ -318,7 +321,7 @@ def test_mknod_char_device():
     try:
         run_and_get_output(conf)
     except Exception as e:
-        sys.stderr.write(f"test_mknod_char_device failed: {e}\n")
+        sys.stderr.write("# test_mknod_char_device failed: {e}\n")
         return -1
     return 0
 
@@ -358,20 +361,20 @@ def test_allow_device_read_only():
     try:
         run_and_get_output(conf)
     except Exception as e:
-        sys.stderr.write(f"test_allow_device_read_only failed: %s\n" % e)
+        sys.stderr.write("# test_allow_device_read_only failed: %s\n" % e)
         return -1
 
     conf['process']['args'] = ['/init', 'openwronly', '/dev/controlledchar']
     try:
         run_and_get_output(conf)
-        sys.stderr.write("test_allow_device_read_only: write access was unexpectedly allowed.\n")
+        sys.stderr.write("# test_allow_device_read_only: write access was unexpectedly allowed.\n")
         return 1
     except Exception as e:
         output_str = getattr(e, 'output', b'').decode(errors='ignore')
         if "Operation not permitted" in output_str or "Permission denied" in output_str:
             return 0
         else:
-            sys.stderr.write(f"test_allow_device_read_only (write attempt) failed with: %s, output: %s\n" % (e, output_str))
+            sys.stderr.write("# test_allow_device_read_only (write attempt) failed with: %s, output: %s\n" % (e, output_str))
             return 1
 
     return 1

--- a/tests/test_domainname.py
+++ b/tests/test_domainname.py
@@ -35,7 +35,7 @@ def test_domainname():
         out, cid = run_and_get_output(conf)
         if out == "(none)\n":
             return 0
-        sys.stderr.write("unexpected success\n")
+        sys.stderr.write("# unexpected success\n")
         return -1
     except:
         return 0
@@ -56,7 +56,7 @@ def test_domainname_conflict_sysctl():
         out, cid = run_and_get_output(conf)
         if out == "(none)\n":
             return 0
-        sys.stderr.write("unexpected success\n")
+        sys.stderr.write("# unexpected success\n")
         return -1
     except:
         return 0

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -452,22 +452,22 @@ def test_exec_cpu_affinity():
 
         mask = exec_and_get_affinity_mask(cid)
         if mask != current_cpu_mask:
-            sys.stderr.write("current cpu mask %s != %s\n" % (current_cpu_mask, mask))
+            sys.stderr.write("# current cpu mask %s != %s\n" % (current_cpu_mask, mask))
             return -1
 
         mask = exec_and_get_affinity_mask(cid, {"initial" : "0-1"})
         if mask != "0-1":
-            sys.stderr.write("cpu mask %s != 0-1\n" % mask)
+            sys.stderr.write("# cpu mask %s != 0-1\n" % mask)
             return -1
 
         mask = exec_and_get_affinity_mask(cid, {"final" : "0-2"})
         if mask != "0-2":
-            sys.stderr.write("cpu mask %s != 0-2\n" % mask)
+            sys.stderr.write("# cpu mask %s != 0-2\n" % mask)
             return -1
 
         mask = exec_and_get_affinity_mask(cid, {"initial" : "1", "final" : "0-3"})
         if mask != "0-3":
-            sys.stderr.write("cpu mask %s != 0-2\n" % mask)
+            sys.stderr.write("# cpu mask %s != 0-2\n" % mask)
             return -1
         return 0
     finally:
@@ -490,7 +490,7 @@ def test_exec_getpgrp():
             out = run_crun_command([x for x in cmdline if x is not None])
             pgrp = int(out.split("\n")[0])
             if pgrp <= 0:
-                sys.stderr.write("invalid pgrp, got %d\n" % pgrp)
+                sys.stderr.write("# invalid pgrp, got %d\n" % pgrp)
                 return -1
     finally:
         if cid is not None:

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -20,12 +20,20 @@ from tests_utils import *
 def test_hostname():
     conf = base_config()
     conf['process']['args'] = ['/init', 'gethostname']
-    conf['hostname'] = "foomachine"
+    expected_hostname = "foomachine"
+    conf['hostname'] = expected_hostname
     add_all_namespaces(conf)
-    out, _ = run_and_get_output(conf)
-    if "foomachine" not in out:
+    try:
+        out, _ = run_and_get_output(conf)
+        if expected_hostname not in out:
+            sys.stderr.write("# hostname test failed: expected '%s' in output\n" % expected_hostname)
+            sys.stderr.write("# actual output: %s\n" % out.strip())
+            return -1
+        return 0
+    except Exception as e:
+        sys.stderr.write("# hostname test failed with exception: %s\n" % str(e))
+        sys.stderr.write("# expected hostname: %s\n" % expected_hostname)
         return -1
-    return 0
     
 all_tests = {
     "hostname" : test_hostname,

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -42,17 +42,24 @@ def helper_mount(options, tmpfs=True, userns=False, is_file=False):
     else:
         mount_opt = {"destination": "/var/dir", "type": "bind", "source": get_tests_root(), "options": ["bind", "rprivate"] + [options]}
     conf['mounts'].append(mount_opt)
-    out, _ = run_and_get_output(conf, hide_stderr=True)
-    with tempfile.NamedTemporaryFile(mode='w', delete=True) as f:
-        f.write(out)
-        f.flush()
-        t = libmount.Table(f.name)
-        if is_file:
-            m = t.find_target('/var/file')
-        else:
-            m = t.find_target('/var/dir')
-        return [m.vfs_options, m.fs_options]
-    return -1
+    try:
+        out, _ = run_and_get_output(conf, hide_stderr=True)
+        with tempfile.NamedTemporaryFile(mode='w', delete=True) as f:
+            f.write(out)
+            f.flush()
+            t = libmount.Table(f.name)
+            target = '/var/file' if is_file else '/var/dir'
+            m = t.find_target(target)
+            if m is None:
+                sys.stderr.write("# helper_mount failed: mount target '%s' not found in mountinfo\n" % target)
+                sys.stderr.write("# mount options: %s, tmpfs=%s, userns=%s, is_file=%s\n" % (options, tmpfs, userns, is_file))
+                sys.stderr.write("# mountinfo output: %s\n" % out[:300])
+                return -1
+            return [m.vfs_options, m.fs_options]
+    except Exception as e:
+        sys.stderr.write("# helper_mount failed with exception: %s\n" % str(e))
+        sys.stderr.write("# mount options: %s, tmpfs=%s, userns=%s, is_file=%s\n" % (options, tmpfs, userns, is_file))
+        return -1
 
 def test_mount_symlink():
     conf = base_config()
@@ -63,6 +70,8 @@ def test_mount_symlink():
     out, _ = run_and_get_output(conf, hide_stderr=True)
     if "Rome" in out:
         return 0
+    sys.stderr.write("# symlink mount test failed: expected 'Rome' in mountinfo output\n")
+    sys.stderr.write("# actual output: %s\n" % out[:200])
     return -1
 
 def test_mount_fifo():
@@ -79,6 +88,8 @@ def test_mount_fifo():
         conf['mounts'].append(mount_opt)
         out, _ = run_and_get_output(conf, hide_stderr=True)
         if "FIFO" not in out:
+            sys.stderr.write("# FIFO mount test failed with options %s: expected 'FIFO' in output\n" % options)
+            sys.stderr.write("# actual output: %s\n" % out)
             return 1
     return 0
 
@@ -97,6 +108,8 @@ def test_mount_unix_socket():
         conf['mounts'].append(mount_opt)
         out, _ = run_and_get_output(conf, hide_stderr=True)
         if "socket" not in out:
+            sys.stderr.write("# unix socket mount test failed with options %s: expected 'socket' in output\n" % options)
+            sys.stderr.write("# actual output: %s\n" % out)
             return 1
     return 0
 
@@ -113,6 +126,8 @@ def test_mount_tmpfs_permissions():
     out, _ = run_and_get_output(conf, hide_stderr=True, callback_prepare_rootfs=prepare_rootfs)
     if "712" in out:
         return 0
+    sys.stderr.write("# tmpfs permissions test failed: expected '712' in mode output\n")
+    sys.stderr.write("# actual output: %s\n" % out)
     return -1
 
 def test_mount_bind_to_rootfs():
@@ -470,7 +485,7 @@ def test_userns_bind_mount_symlink():
     ]
     conf['linux']['uidMappings'] = fullMapping
     conf['linux']['gidMappings'] = fullMapping
-    sys.stderr.write("start")
+    sys.stderr.write("# start\n")
 
     bind_dir_parent = os.path.join(get_tests_root(), "bind-mount-userns-symlink")
     bind_dir = os.path.join(bind_dir_parent, "m")
@@ -488,7 +503,7 @@ def test_userns_bind_mount_symlink():
         conf['process']['args'] = ['/init', 'cat', "/foo/content"]
         out, _ = run_and_get_output(conf, chown_rootfs_to=1)
         if out != "hello":
-            sys.stderr.write("wrong file owner, found %s instead of %s" % (out, "hello"))
+            sys.stderr.write("# wrong file owner, found %s instead of %s\n" % (out, "hello"))
             return -1
     finally:
         shutil.rmtree(bind_dir)
@@ -541,7 +556,7 @@ def test_idmapped_mounts():
             conf['mounts'].append(mount_opt)
             out = run_and_get_output(conf, chown_rootfs_to=1)
             if expected not in out[0]:
-                sys.stderr.write("wrong file owner, found %s instead of %s" % (out[0], expected))
+                sys.stderr.write("# wrong file owner, found %s instead of %s\n" % (out[0], expected))
                 return True
             return False
 
@@ -618,14 +633,14 @@ def test_cgroup_mount_without_netns():
         conf['mounts'] = mounts
 
         out, _ = run_and_get_output(conf)
-        print(out)
+        # print(out)
         # validate there are two mounts
         count = 0
         for i in out.split("\n"):
             if i.find("/sys/fs/cgroup") >= 0:
                 count = count + 1
         if count < 2:
-            print("fail with cgroupns=%s, got %s" % (cgroupns, out))
+            sys.stderr.write("# fail with cgroupns=%s, got %s\n" % (cgroupns, out))
             return -1
     return 0
 
@@ -656,9 +671,9 @@ def test_add_remove_mounts():
         if exists == expected:
             return True
         if expected:
-            sys.stderr.write("test file not found")
+            sys.stderr.write("# test file not found\n")
         else:
-            sys.stderr.write("test file found")
+            sys.stderr.write("# test file found\n")
         return False
 
     new_mounts = [{"destination": parent_dir_in_container, "type": "bind", "source": bind_dir, "options": ["bind", "ro"]},
@@ -679,7 +694,7 @@ def test_add_remove_mounts():
             return -1
         out = run_crun_command(["exec", cid, "/init", "cat", "/proc/self/mountinfo"])
         if not re.search(r".*/ /foo/tmpfs .*tmpfs.*", out):
-            sys.stderr.write("/foo/tmpfs not found as a tmpfs\n")
+            sys.stderr.write("# /foo/tmpfs not found as a tmpfs\n")
             return -1
 
         run_crun_command(["mounts", "remove", cid, mounts_path])
@@ -688,7 +703,7 @@ def test_add_remove_mounts():
 
         out = run_crun_command(["exec", cid, "/init", "cat", "/proc/self/mountinfo"])
         if re.search(r".*/ /foo/tmpfs .*tmpfs.*", out):
-            sys.stderr.write("/foo/tmpfs still mounted\n")
+            sys.stderr.write("# /foo/tmpfs still mounted\n")
             return -1
     finally:
         if cid is not None:
@@ -700,7 +715,7 @@ def test_mount_help():
     out = run_crun_command(["mounts", "--help"])
     if "Usage: crun [OPTION...] mounts [add|remove] CONTAINER FILE" not in out:
         return -1
-    
+
     return 0
 
 def test_bind_mount_symlink_nofollow():
@@ -749,11 +764,11 @@ def test_bind_mount_symlink_nofollow():
 
             try:
                 out, _ = run_and_get_output(conf, hide_stderr=True,callback_prepare_rootfs=prepare_rootfs)
-                sys.stderr.write("got output %s with configuration userns=%s, src-nofollow=%s\n" % (out, userns, src_nofollow))
+                sys.stderr.write("# got output %s with configuration userns=%s, src-nofollow=%s\n" % (out, userns, src_nofollow))
                 if expected not in out:
                     return -1
             except Exception as e:
-                sys.stderr.write("error %s\n" % e)
+                sys.stderr.write("# error %s\n" % e)
                 return -1
 
     return 0
@@ -776,7 +791,7 @@ def test_bind_mount_symlink_nofollow_procfs():
         out, _ = run_and_get_output(conf, hide_stderr=True,callback_prepare_rootfs=prepare_rootfs)
         return -1
     except Exception as e:
-        sys.stderr.write("error %s\n" % e)
+        sys.stderr.write("# error %s\n" % e)
         return 0
 
     return 0
@@ -819,11 +834,11 @@ def test_bind_mount_file_nofollow():
 
             try:
                 out, _ = run_and_get_output(conf, hide_stderr=True,callback_prepare_rootfs=prepare_rootfs)
-                sys.stderr.write("got output %s with configuration userns=%s, src-nofollow=%s\n" % (out, userns, src_nofollow))
+                sys.stderr.write("# got output %s with configuration userns=%s, src-nofollow=%s\n" % (out, userns, src_nofollow))
                 if target_content not in out:
                     return 1
             except Exception as e:
-                sys.stderr.write("error %s\n" % e)
+                sys.stderr.write("# error %s\n" % e)
     return 0
 
 all_tests = {

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -109,7 +109,7 @@ def test_mount_tmpfs_permissions():
     conf = base_config()
     conf['process']['args'] = ['/init', 'mode', '/tmp']
     add_all_namespaces(conf)
-    conf['mounts'].append({"destination": "/tmp", "type": "tmpfs", "source": "tmpfs", "options": ["bind", "ro"]})
+    conf['mounts'].append({"destination": "/tmp", "type": "tmpfs", "source": "tmpfs", "options": ["ro"]})
     out, _ = run_and_get_output(conf, hide_stderr=True, callback_prepare_rootfs=prepare_rootfs)
     if "712" in out:
         return 0

--- a/tests/test_oci_features.py
+++ b/tests/test_oci_features.py
@@ -198,31 +198,31 @@ def test_crun_features():
 
             if key == "annotations":
                 if "annotations" not in features:
-                    sys.stderr.write("Annotations section is missing\n")
+                    sys.stderr.write("# annotations section is missing\n")
                     return -1
 
                 annotations = features["annotations"]
                 if annotations.get("run.oci.crun.commit") != get_crun_commit():
-                    sys.stderr.write("wrong value for run.oci.crun.commit\n")
+                    sys.stderr.write("# wrong value for run.oci.crun.commit\n")
                     return -1
 
                 if ('WASM' in get_crun_feature_string()
                     and annotations.get("run.oci.crun.wasm") != "true"):
-                    sys.stderr.write("wrong value for run.oci.crun.wasm\n")
+                    sys.stderr.write("# wrong value for run.oci.crun.wasm\n")
                     return -1
 
                 if 'CRIU' in get_crun_feature_string():
                     if annotations.get("org.opencontainers.runc.checkpoint.enabled") != "true":
-                        sys.stderr.write("wrong value for org.opencontainers.runc.checkpoint.enabled\n")
+                        sys.stderr.write("# wrong value for org.opencontainers.runc.checkpoint.enabled\n")
                         return -1
                     if annotations.get("run.oci.crun.checkpoint.enabled") != "true":
-                        sys.stderr.write("wrong value for run.oci.crun.checkpoint.enabled\n")
+                        sys.stderr.write("# wrong value for run.oci.crun.checkpoint.enabled\n")
                         return -1
             else:
                 if key not in features or sorted(features[key]) != sorted(value):
-                    sys.stderr.write(f"Mismatch in feature: {key}\n")
-                    sys.stderr.write(f"Expected: {value}\n")
-                    sys.stderr.write(f"Actual: {features.get(key)}\n")
+                    sys.stderr.write(f"# Mismatch in feature: {key}\n")
+                    sys.stderr.write(f"# Expected: {value}\n")
+                    sys.stderr.write(f"# Actual: {features.get(key)}\n")
                     return -1
         return 0
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -59,7 +59,7 @@ def test_resources_pid_limit():
 
     out, _ = run_and_get_output(conf)
     if "1024" not in out:
-        sys.stderr.write("found %s instead of 1024\n" % out)
+        sys.stderr.write("# found %s instead of 1024\n" % out)
         return -1
     return 0
 
@@ -102,7 +102,7 @@ def test_resources_pid_limit_userns():
 
     out, _ = run_and_get_output(conf)
     if "1024" not in out:
-        sys.stderr.write("found %s instead of 1024\n" % out)
+        sys.stderr.write("# found %s instead of 1024\n" % out)
         return -1
     return 0
 
@@ -276,7 +276,7 @@ def test_resources_cpu_weight_systemd():
         _, cid = run_and_get_output(conf, command='run', detach=True, cgroup_manager="systemd")
         out = run_crun_command(["exec", cid, "/init", "cat", "/sys/fs/cgroup/cpu.weight"])
         if "1234" not in out:
-            sys.stderr.write("found wrong CPUWeight for the container cgroup\n")
+            sys.stderr.write("# found wrong CPUWeight for the container cgroup\n")
             return -1
 
         state = run_crun_command(['state', cid])
@@ -288,7 +288,7 @@ def test_resources_cpu_weight_systemd():
             out = subprocess.check_output(['systemctl', '--user', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
 
         if out != "1234":
-            sys.stderr.write("found wrong CPUWeight for the systemd scope\n")
+            sys.stderr.write("# found wrong CPUWeight for the systemd scope\n")
             return 1
 
         run_crun_command(['update', '--cpu-share', '4321', cid])
@@ -297,7 +297,7 @@ def test_resources_cpu_weight_systemd():
 
         out = run_crun_command(["exec", cid, "/init", "cat", "/sys/fs/cgroup/cpu.weight"])
         if expected_weight not in out:
-            sys.stderr.write("found wrong CPUWeight %s for the container cgroup\n" % out)
+            sys.stderr.write("# found wrong CPUWeight %s for the container cgroup\n" % out)
             return -1
 
         out = subprocess.check_output(['systemctl', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
@@ -306,7 +306,7 @@ def test_resources_cpu_weight_systemd():
             out = subprocess.check_output(['systemctl', '--user', 'show','-PCPUWeight', scope ], close_fds=False).decode().strip()
 
         if out != expected_weight:
-            sys.stderr.write("found wrong CPUWeight for the systemd scope\n")
+            sys.stderr.write("# found wrong CPUWeight for the systemd scope\n")
             return 1
     finally:
         if cid is not None:
@@ -331,7 +331,7 @@ def test_resources_exec_cgroup():
             if i == "":
                 continue
             if "/foo" not in i:
-                sys.stderr.write("/foo not found in the output")
+                sys.stderr.write("# /foo not found in the output\n")
                 return -1
         return 0
     except Exception as e:

--- a/tests/test_rlimits.py
+++ b/tests/test_rlimits.py
@@ -57,7 +57,7 @@ def test_rlimits():
     for v in rlimits:
         limit = limits.get(v['type'])
         if str(limit[1]) != str(v['soft']) or str(limit[2]) != str(v['hard']):
-            sys.stderr.write("%s: %s %s\n" % (limit[0], limit[1], limit[2]))
+            sys.stderr.write("# %s: %s %s\n" % (limit[0], limit[1], limit[2]))
             return -1
     return 0
 

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -35,7 +35,7 @@ def test_not_allowed_ipc_sysctl():
     cid = None
     try:
         _, cid = run_and_get_output(conf)
-        sys.stderr.write("unexpected success\n")
+        sys.stderr.write("# unexpected success\n")
         return -1
     except:
         pass
@@ -50,7 +50,7 @@ def test_not_allowed_ipc_sysctl():
     cid = None
     try:
         _, cid = run_and_get_output(conf)
-        sys.stderr.write("unexpected success\n")
+        sys.stderr.write("# unexpected success\n")
         return -1
     except:
         pass
@@ -66,7 +66,7 @@ def test_not_allowed_ipc_sysctl():
     try:
         _, cid = run_and_get_output(conf)
     except Exception as e:
-        sys.stderr.write("setting msgmax with new ipc namespace failed\n")
+        sys.stderr.write("# setting msgmax with new ipc namespace failed\n")
         return -1
     finally:
         if cid is not None:
@@ -83,7 +83,7 @@ def test_not_allowed_net_sysctl():
     cid = None
     try:
         _, cid = run_and_get_output(conf)
-        sys.stderr.write("unexpected success\n")
+        sys.stderr.write("# unexpected success\n")
         return -1
     except:
         pass
@@ -99,7 +99,7 @@ def test_not_allowed_net_sysctl():
     try:
         _, cid = run_and_get_output(conf)
     except Exception as e:
-        sys.stderr.write("setting net.ipv4.ping_group_range with new net namespace failed\n")
+        sys.stderr.write("# setting net.ipv4.ping_group_range with new net namespace failed\n")
         return -1
     finally:
         if cid is not None:
@@ -119,7 +119,7 @@ def test_unknown_sysctl():
         cid = None
         try:
             _, cid = run_and_get_output(conf)
-            sys.stderr.write("unexpected success\n")
+            sys.stderr.write("# unexpected success\n")
             return -1
         except:
             return 0
@@ -141,7 +141,7 @@ def test_uts_sysctl():
         cid = None
         try:
             _, cid = run_and_get_output(conf)
-            sys.stderr.write("unexpected success\n")
+            sys.stderr.write("# unexpected success\n")
             return -1
         except:
             return 0
@@ -156,7 +156,7 @@ def test_uts_sysctl():
     cid = None
     try:
         _, cid = run_and_get_output(conf)
-        sys.stderr.write("unexpected success\n")
+        sys.stderr.write("# unexpected success\n")
         return -1
     except:
         return 0
@@ -460,21 +460,21 @@ def test_run_keep():
     try:
         out, cid = run_and_get_output(conf, command='run')
     except:
-        sys.stderr.write("failed to create container\n")
+        sys.stderr.write("# failed to create container\n")
         return -1
 
     # without --keep, we must be able to recreate the container with the same id
     try:
         out, cid = run_and_get_output(conf, command='run', keep=True, id_container=cid)
     except:
-        sys.stderr.write("failed to create container\n")
+        sys.stderr.write("# failed to create container\n")
         return -1
 
     # now it must fail
     try:
         try:
             out, cid = run_and_get_output(conf, command='run', keep=True, id_container=cid)
-            sys.stderr.write("run --keep succeeded twice\n")
+            sys.stderr.write("# run --keep succeeded twice\n")
             return -1
         except:
             # expected
@@ -483,7 +483,7 @@ def test_run_keep():
         try:
             s = run_crun_command(["state", cid])
         except:
-            sys.stderr.write("crun state failed on --keep container\n")
+            sys.stderr.write("# crun state failed on --keep container\n")
             return -1
     finally:
         run_crun_command(["delete", "-f", cid])
@@ -502,7 +502,7 @@ def test_invalid_id():
         err = e.output.decode()
         if "invalid character `/` in the ID" in err:
             return 0
-        sys.stderr.write("Got error: %s\n" % err)
+        sys.stderr.write("# got error: %s\n" % err)
         return -1
     return 0
 
@@ -517,7 +517,7 @@ def test_home_unknown_id():
     add_all_namespaces(conf)
     out, _ = run_and_get_output(conf)
     if out != "/":
-        sys.stderr.write("expected: `/`, got output: `%s`\n" % out)
+        sys.stderr.write("# expected: `/`, got output: `%s`\n" % out)
         return -1
     return 0
 

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -180,6 +180,10 @@ def run_all_tests(all_tests, allowed_tests):
         cur = cur + 1
         ret = -1
         try:
+            # recreate the tests_root() directory for each test
+            shutil.rmtree(get_tests_root())
+            os.mkdir(get_tests_root())
+
             ret = v()
             if ret == 0:
                 print("ok %d - %s" % (cur, k))

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -21,6 +21,8 @@ import sys
 import os
 import tempfile
 import subprocess
+import traceback
+import time
 
 default_umask = 0o22
 
@@ -179,24 +181,32 @@ def run_all_tests(all_tests, allowed_tests):
     for k, v in tests.items():
         cur = cur + 1
         ret = -1
+        test_start_time = time.time()
         try:
             # recreate the tests_root() directory for each test
             shutil.rmtree(get_tests_root())
             os.mkdir(get_tests_root())
 
             ret = v()
+            test_duration = time.time() - test_start_time
             if ret == 0:
-                print("ok %d - %s" % (cur, k))
+                print("ok %d - %s # %.3fs" % (cur, k, test_duration))
             elif ret == 77:
-                print("ok %d - %s #SKIP" % (cur, k))
+                print("ok %d - %s #SKIP # %.3fs" % (cur, k, test_duration))
             else:
-                print("not ok %d - %s" % (cur, k))
+                print("not ok %d - %s # %.3fs" % (cur, k, test_duration))
+                sys.stderr.write("# Test '%s' failed with return code %d\n" % (k, ret))
         except Exception as e:
+            test_duration = time.time() - test_start_time
+            sys.stderr.write("# Test '%s' failed with exception after %.3fs:\n" % (k, test_duration))
             if hasattr(e, 'output'):
-                sys.stderr.write(str(e.output) + "\n")
-            sys.stderr.write(str(e) + "\n")
+                sys.stderr.write("# Container output: %s\n" % str(e.output))
+            sys.stderr.write("# Exception: %s\n" % str(e))
+            sys.stderr.write("# Traceback:\n")
+            for line in traceback.format_exc().splitlines():
+                sys.stderr.write("# %s\n" % line)
             ret = -1
-            print("not ok %d - %s" % (cur, k))
+            print("not ok %d - %s # %.3fs" % (cur, k, test_duration))
 
 def get_tests_root():
     return '%s/.testsuite-run-%d' % (os.getcwd(), os.getpid())
@@ -215,7 +225,7 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
                        keep=False,
                        command='run', env=None, use_popen=False, hide_stderr=False, cgroup_manager='cgroupfs',
                        all_dev_null=False, id_container=None, relative_config_path="config.json",
-                       chown_rootfs_to=None, callback_prepare_rootfs=None):
+                       chown_rootfs_to=None, callback_prepare_rootfs=None, debug_on_error=None):
 
     # Some tests require that the container user, which might not be the
     # same user as the person running the tests, is able to resolve the full path
@@ -290,6 +300,7 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
         stdin = subprocess.DEVNULL
         stdout = subprocess.DEVNULL
         stderr = subprocess.DEVNULL
+
     if use_popen:
         if not stdout:
             stdout=subprocess.PIPE
@@ -299,20 +310,44 @@ def run_and_get_output(config, detach=False, preserve_fds=None, pid_file=None,
                                 stderr=stderr, stdin=stdin, env=env,
                                 close_fds=False), id_container
     else:
-        return subprocess.check_output(args, cwd=temp_dir, stderr=stderr, env=env, close_fds=False, umask=default_umask).decode(), id_container
+        try:
+            return subprocess.check_output(args, cwd=temp_dir, stderr=stderr, env=env, close_fds=False, umask=default_umask).decode(), id_container
+        except subprocess.CalledProcessError as e:
+            sys.stderr.write("# Command failed: %s\n" % ' '.join(args))
+            sys.stderr.write("# Working directory: %s\n" % temp_dir)
+            sys.stderr.write("# Container ID: %s\n" % id_container)
+            sys.stderr.write("# Return code: %d\n" % e.returncode)
+            if e.output:
+                sys.stderr.write("# Output: %s\n" % e.output.decode('utf-8', errors='ignore'))
+            sys.stderr.write("# Config file saved at: %s\n" % config_path)
+            if not keep:
+                sys.stderr.write("# Note: temporary directory will be cleaned up\n")
+            raise
 
 def run_crun_command(args):
     root = get_tests_root_status()
     crun = get_crun_path()
-    args = [crun, "--root", root] + args
-    return subprocess.check_output(args, close_fds=False).decode()
+    cmd_args = [crun, "--root", root] + args
+    try:
+        return subprocess.check_output(cmd_args, close_fds=False).decode()
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write("# crun command failed: %s\n" % ' '.join(cmd_args))
+        sys.stderr.write("# Return code: %d\n" % e.returncode)
+        if e.output:
+            sys.stderr.write("# Output: %s\n" % e.output.decode('utf-8', errors='ignore'))
+        raise
 
 # Similar as run_crun_command but does not performs decode of output and relays error message for further matching
 def run_crun_command_raw(args):
     root = get_tests_root_status()
     crun = get_crun_path()
-    args = [crun, "--root", root] + args
-    return subprocess.check_output(args, close_fds=False, stderr=subprocess.STDOUT)
+    cmd_args = [crun, "--root", root] + args
+    try:
+        return subprocess.check_output(cmd_args, close_fds=False, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write("# crun command failed: %s\n" % ' '.join(cmd_args))
+        sys.stderr.write("# Return code: %d\n" % e.returncode)
+        raise
 
 def running_on_systemd():
     with open('/proc/1/comm') as f:


### PR DESCRIPTION
fix a couple of errors in the mounts tests and improve the error messages.

Beside the first few patches, they are mostly mechanical changes.

## Summary by Sourcery

Improve test suite error reporting and robustness by adding detailed diagnostics, exception handling, and timing, and fix a couple of mount test errors.

Bug Fixes:
- Fix mounts tests by correcting tmpfs bind options for /tmp and handling missing mount targets in helper_mount.

Enhancements:
- Standardize and enrich stderr error messages across tests with contextual information (options, container IDs, output snippets) and "#" prefixes.
- Wrap key helper functions (helper_mount, run_and_get_output, run_crun_command) in try/catch to log command, working directory, return code, and exception details.
- Add warnings for cleanup failures when deleting containers or sockets.
- Extend tests runner to recreate the test root per test, measure and print test durations, and dump tracebacks on unexpected exceptions.

Tests:
- Augment individual tests (mounts, seccomp, exec, limits, devices, capabilities, start, hostname, oci_features, resources, domainname, rlimits) with richer failure diagnostics and context.