### PR TITLE
Revert "chroot_realpath: do not return non-existing paths"

### DIFF
--- a/src/libcrun/chroot_realpath.c
+++ b/src/libcrun/chroot_realpath.c
@@ -133,6 +133,11 @@ char *chroot_realpath(const char *chroot, const char *path, char resolved_path[]
 		*new_path = '\0';
 		n = readlink(got_path, link_path, PATH_MAX - 1);
 		if (n < 0) {
+			/* If a component doesn't exist, then return what we could translate. */
+			if (errno == ENOENT) {
+				sprintf (resolved_path, "%s%s%s", got_path, path[0] == '/' || path[0] == '\0' ? "" : "/", path);
+				return resolved_path;
+			}
 			/* EINVAL means the file exists but isn't a symlink. */
 			if (errno != EINVAL)
 				return NULL;


### PR DESCRIPTION
This reverts commit 17135c1b2527fc77882d7e4295f76f093ebace22

It introduced a regression.

Closes: https://github.com/containers/crun/issues/1783

## Summary by Sourcery

Bug Fixes:
- Remove ENOENT special-case in chroot_realpath to stop returning partial paths for missing components and restore previous behavior