### PR TITLE
status: add cleanup_free

### DIFF
--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -113,7 +113,7 @@ static int
 get_state_directory_status_file (char **out, const char *state_root, const char *id, libcrun_error_t *err)
 {
   cleanup_free char *root = NULL;
-  char *path = NULL;
+  cleanup_free char *path = NULL;
   int ret;
 
   ret = validate_id (id, err);


### PR DESCRIPTION
The `path` variable is handled by  `STEAL_POINTER()`

* https://github.com/containers/crun/blob/d89542c61520ac5c971090dfa3201e9c4ce18ad1/src/libcrun/status.c#L131

but `cleanup_free`was missing.

## Summary by Sourcery

Bug Fixes:
- Annotate `path` with `cleanup_free` in status.c to prevent potential memory leaks.