### PR TITLE
status: simplify libcrun_status_check_directories

### DIFF
--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -494,18 +494,8 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
 int
 libcrun_status_check_directories (const char *state_root, const char *id, libcrun_error_t *err)
 {
-  cleanup_free char *run_directory = NULL;
   cleanup_free char *dir = NULL;
   int ret;
-
-  ret = get_run_directory (&run_directory, state_root, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
-
-  libcrun_debug ("Checking run directory: %s", run_directory);
-  ret = crun_ensure_directory (run_directory, 0700, false, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
 
   ret = libcrun_get_state_directory (&dir, state_root, id, err);
   if (UNLIKELY (ret < 0))


### PR DESCRIPTION
Remove redundant code.


This is possible because `get_run_directory()` is called by `libcrun_get_state_directory()` and `crun_ensure_directory()` is called by `get_run_directory()`

Note, this source code line is removed
```
libcrun_debug ("Checking run directory: %s", run_directory);
```
so that debug message will no longer be logged.

## Summary by Sourcery

Simplify libcrun_status_check_directories by relying on libcrun_get_state_directory to handle run directory setup and eliminate unnecessary code.

Enhancements:
- Remove redundant get_run_directory() and crun_ensure_directory() calls in libcrun_status_check_directories
- Remove obsolete debug message for run directory