### PR TITLE
libcrun: add crun_error_get_errno

### DIFF
--- a/src/libcrun/cgroup-setup.c
+++ b/src/libcrun/cgroup-setup.c
@@ -209,8 +209,9 @@ enter_cgroup_subsystem (pid_t pid, const char *subsystem, const char *path, bool
       ret = crun_ensure_directory (cgroup_path, 0755, false, err);
       if (UNLIKELY (ret < 0))
         {
+          errno = crun_error_get_errno (err);
           if (errno != EROFS)
-            return crun_make_error (err, errno, "creating cgroup directory `%s`", cgroup_path);
+            return ret;
 
           crun_error_release (err);
           return 0;

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1073,6 +1073,7 @@ do_masked_or_readonly_path (libcrun_container_t *container, const char *rel_path
   pathfd = safe_openat (get_private_data (container)->rootfsfd, rootfs, rel_path, O_PATH | O_CLOEXEC, 0, err);
   if (UNLIKELY (pathfd < 0))
     {
+      errno = crun_error_get_errno (err);
       if (errno != ENOENT && errno != EACCES)
         return pathfd;
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -246,6 +246,7 @@ ensure_directory_internal_at (int dirfd, char *path, size_t len, int mode, libcr
       if (ret == 0 || errno == EEXIST)
         return 0;
 
+      int saved_errno = errno;
       if (parent_created || errno != ENOENT)
         {
           libcrun_error_t tmp_err = NULL;
@@ -257,7 +258,7 @@ ensure_directory_internal_at (int dirfd, char *path, size_t len, int mode, libcr
           if (ret < 0)
             crun_error_release (&tmp_err);
 
-          return crun_make_error (err, errno, "create directory `%s`", path);
+          return crun_make_error (err, saved_errno, "create directory `%s`", path);
         }
 
       while (it > path && *it != '/')


### PR DESCRIPTION
## Summary by Sourcery

Improve error propagation by extracting and restoring original errnos from libcrun_error_t before errno-based condition checks and error reporting.

Bug Fixes:
- Fix clobbered errno in directory creation and masked path setup by restoring the original errno from libcrun errors.

Enhancements:
- Use crun_error_get_errno in cgroup-setup.c and linux.c to assign the stored errno back to errno before error checks and returns.
- Capture and use saved_errno in ensure_directory_internal_at to correctly propagate original error codes when wrapping errors.