### PR TITLE
Fix incorrectly set cpu.max when quota is -1.

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1406,7 +1406,7 @@ append_resources (sd_bus_message *m,
   if (resources->cpu)
     {
       /* do not bother with systemd internal representation unless both values are specified */
-      if (resources->cpu->quota && resources->cpu->period)
+      if (resources->cpu->quota > 0 && resources->cpu->period)
         {
           uint64_t quota = resources->cpu->quota;
 


### PR DESCRIPTION
Since kubernetes 1.33, cpu quota is -1 when the pod is guaranteed QoS.

- https://github.com/kubernetes/kubernetes/pull/131966

With systemd-cgroup, crun can't correctly set pod resource quota.

crun
```
❯ cat /sys/fs/cgroup/kubepods.slice/kubepods-poda42d5875_23e6_41e2_86e1_e3c11d3f466b.slice/crio-11271ae07aa52bd47ef2e5f5ee4efe373f8819f7ec0fbe4d146de2344427486a.scope/cpu.max
1000 100000
```

runc
```
❯ cat /sys/fs/cgroup/kubepods.slice/kubepods-pod23108f55_25f0_41d2_aa3b_25011e87611a.slice/crio-aa40e91310e32d3063675955a565192e2ad1a2d31505b9b13af6baff3557a7a0.scope/cpu.max
max 100000
```

This PR fixes this issues.

ref:
- https://github.com/cri-o/cri-o/issues/9251
- https://issues.redhat.com/browse/OCPBUGS-57388

## Summary by Sourcery

Bug Fixes:
- Avoid treating cpu quota of -1 as a valid numeric limit by only applying cpu.max when quota is greater than zero.