### PR TITLE
cgroup, systemd: use BPFProgram=device if supported

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -233,7 +233,8 @@ PYTHON_TESTS = tests/test_capabilities.py \
 	tests/test_start.py \
 	tests/test_exec.py \
 	tests/test_seccomp.py \
-	tests/test_time.py
+	tests/test_time.py \
+	tests/test_bpf_devices.py
 
 TESTS = $(PYTHON_TESTS) $(UNIT_TESTS)
 

--- a/src/libcrun/cgroup-internal.h
+++ b/src/libcrun/cgroup-internal.h
@@ -41,6 +41,8 @@ struct libcrun_cgroup_status
   char *scope;
 
   int manager;
+
+  bool bpf_dev_set;
 };
 
 struct libcrun_cgroup_manager

--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -631,25 +631,25 @@ write_devices_resources_v1 (int dirfd, runtime_spec_schema_defs_linux_device_cgr
   return 0;
 }
 
-static int
-write_devices_resources_v2_internal (int dirfd, runtime_spec_schema_defs_linux_device_cgroup **devs, size_t devs_len,
-                                     libcrun_error_t *err)
+static struct bpf_program *
+create_dev_bpf (runtime_spec_schema_defs_linux_device_cgroup **devs, size_t devs_len,
+                libcrun_error_t *err)
 {
-  int i, ret;
-  cleanup_free struct bpf_program *program = NULL;
+  int i;
+  struct bpf_program *program;
 
   program = bpf_program_new (2048);
 
   program = bpf_program_init_dev (program, err);
   if (UNLIKELY (program == NULL))
-    return -1;
+    return NULL;
 
   for (i = (sizeof (default_devices) / sizeof (default_devices[0])) - 1; i >= 0; i--)
     {
       program = bpf_program_append_dev (program, default_devices[i].access, default_devices[i].type,
                                         default_devices[i].major, default_devices[i].minor, true, err);
       if (UNLIKELY (program == NULL))
-        return -1;
+        return NULL;
     }
   for (i = devs_len - 1; i >= 0; i--)
     {
@@ -665,43 +665,47 @@ write_devices_resources_v2_internal (int dirfd, runtime_spec_schema_defs_linux_d
 
       program = bpf_program_append_dev (program, devs[i]->access, type, major, minor, devs[i]->allow, err);
       if (UNLIKELY (program == NULL))
-        return -1;
+        return NULL;
     }
 
   program = bpf_program_complete_dev (program, err);
   if (UNLIKELY (program == NULL))
-    return -1;
+    return NULL;
 
-  ret = libcrun_ebpf_load (program, dirfd, NULL, err);
-  if (ret < 0)
-    return ret;
-
-  return 0;
+  return program;
 }
 
 static int
-write_devices_resources_v2 (int dirfd, runtime_spec_schema_defs_linux_device_cgroup **devs, size_t devs_len,
-                            libcrun_error_t *err)
+write_devices_resources_v2_internal (int dirfd, runtime_spec_schema_defs_linux_device_cgroup **devs, size_t devs_len,
+                                     libcrun_error_t *err)
 {
-  int ret;
+  cleanup_free struct bpf_program *program = NULL;
+
+  program = create_dev_bpf (devs, devs_len, err);
+  if (UNLIKELY (program == NULL))
+    return -1;
+
+  return libcrun_ebpf_load (program, dirfd, NULL, err);
+}
+
+static int
+can_skip_devices (bool *can_skip, runtime_spec_schema_defs_linux_device_cgroup **devs, size_t devs_len,
+                  libcrun_error_t *err)
+{
   size_t i;
-  bool can_skip = true;
 
-  ret = write_devices_resources_v2_internal (dirfd, devs, devs_len, err);
-  if (LIKELY (ret == 0))
-    return 0;
+  *can_skip = true;
 
-  /* If writing the resources ebpf failed, check if it is fine to ignore the error.  */
   for (i = 0; i < devs_len; i++)
     {
       if (devs[i]->allow_present && ! devs[i]->allow)
         {
-          can_skip = false;
+          *can_skip = false;
           break;
         }
     }
 
-  if (! can_skip)
+  if (! *can_skip)
     {
       libcrun_error_t tmp_err = NULL;
       int rootless;
@@ -711,11 +715,30 @@ write_devices_resources_v2 (int dirfd, runtime_spec_schema_defs_linux_device_cgr
         {
           crun_error_release (err);
           *err = tmp_err;
-          return ret;
+          return -1;
         }
       if (rootless)
-        can_skip = true;
+        *can_skip = true;
     }
+
+  return 0;
+}
+
+static int
+write_devices_resources_v2 (int dirfd, runtime_spec_schema_defs_linux_device_cgroup **devs, size_t devs_len,
+                            libcrun_error_t *err)
+{
+  int ret;
+  bool can_skip;
+
+  ret = write_devices_resources_v2_internal (dirfd, devs, devs_len, err);
+  if (LIKELY (ret == 0))
+    return 0;
+
+  /* If writing the resources ebpf failed, check if it is fine to ignore the error.  */
+  ret = can_skip_devices (&can_skip, devs, devs_len, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   if (can_skip)
     {

--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -1397,7 +1397,7 @@ write_unified_resources (int cgroup_dirfd, runtime_spec_schema_config_linux_reso
 }
 
 static int
-update_cgroup_v2_resources (runtime_spec_schema_config_linux_resources *resources, const char *path, libcrun_error_t *err)
+update_cgroup_v2_resources (runtime_spec_schema_config_linux_resources *resources, const char *path, bool need_bpf_dev, libcrun_error_t *err)
 {
   cleanup_free char *cgroup_path = NULL;
   cleanup_close int cgroup_dirfd = -1;
@@ -1414,7 +1414,7 @@ update_cgroup_v2_resources (runtime_spec_schema_config_linux_resources *resource
   if (UNLIKELY (cgroup_dirfd < 0))
     return crun_make_error (err, errno, "open `%s`", cgroup_path);
 
-  if (resources->devices_len)
+  if (need_bpf_dev && resources->devices_len)
     {
       ret = write_devices_resources (cgroup_dirfd, true, resources->devices, resources->devices_len, err);
       if (UNLIKELY (ret < 0))
@@ -1473,6 +1473,7 @@ int
 update_cgroup_resources (const char *path,
                          const char *state_root,
                          runtime_spec_schema_config_linux_resources *resources,
+                         bool need_bpf_dev,
                          libcrun_error_t *err)
 {
   int cgroup_mode;
@@ -1508,7 +1509,7 @@ update_cgroup_resources (const char *path,
   switch (cgroup_mode)
     {
     case CGROUP_MODE_UNIFIED:
-      return update_cgroup_v2_resources (resources, path, err);
+      return update_cgroup_v2_resources (resources, path, need_bpf_dev, err);
 
     case CGROUP_MODE_LEGACY:
     case CGROUP_MODE_HYBRID:

--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -631,7 +631,7 @@ write_devices_resources_v1 (int dirfd, runtime_spec_schema_defs_linux_device_cgr
   return 0;
 }
 
-static struct bpf_program *
+struct bpf_program *
 create_dev_bpf (runtime_spec_schema_defs_linux_device_cgroup **devs, size_t devs_len,
                 libcrun_error_t *err)
 {

--- a/src/libcrun/cgroup-resources.h
+++ b/src/libcrun/cgroup-resources.h
@@ -34,6 +34,7 @@ struct default_dev_s *get_default_devices ();
 int update_cgroup_resources (const char *path,
                              const char *state_root,
                              runtime_spec_schema_config_linux_resources *resources,
+                             bool need_devices,
                              libcrun_error_t *err);
 
 struct bpf_program *create_dev_bpf (runtime_spec_schema_defs_linux_device_cgroup **devs, size_t devs_len,

--- a/src/libcrun/cgroup-resources.h
+++ b/src/libcrun/cgroup-resources.h
@@ -36,4 +36,7 @@ int update_cgroup_resources (const char *path,
                              runtime_spec_schema_config_linux_resources *resources,
                              libcrun_error_t *err);
 
+struct bpf_program *create_dev_bpf (runtime_spec_schema_defs_linux_device_cgroup **devs, size_t devs_len,
+                                    libcrun_error_t *err);
+
 #endif

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -227,7 +227,7 @@ libcrun_update_cgroup_resources (struct libcrun_cgroup_status *cgroup_status,
       if (UNLIKELY (ret < 0))
         return ret;
     }
-  return update_cgroup_resources (cgroup_status->path, state_root, resources, err);
+  return update_cgroup_resources (cgroup_status->path, state_root, resources, ! cgroup_status->bpf_dev_set, err);
 }
 
 static int
@@ -364,7 +364,7 @@ libcrun_cgroup_enter (struct libcrun_cgroup_args *args, struct libcrun_cgroup_st
 
       if (args->resources)
         {
-          ret = update_cgroup_resources (status->path, args->state_root, args->resources, err);
+          ret = update_cgroup_resources (status->path, args->state_root, args->resources, ! status->bpf_dev_set, err);
           if (UNLIKELY (ret < 0))
             return ret;
         }

--- a/src/libcrun/ebpf.c
+++ b/src/libcrun/ebpf.c
@@ -527,9 +527,12 @@ libcrun_ebpf_load (struct bpf_program *program, int dirfd, const char *pin, libc
         }
     }
 
-  ret = ebpf_attach_program (fd, dirfd, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
+  if (dirfd >= 0)
+    {
+      ret = ebpf_attach_program (fd, dirfd, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+    }
 
   /* Optionally pin the program to the specified path.  */
   if (pin)

--- a/src/libcrun/ebpf.h
+++ b/src/libcrun/ebpf.h
@@ -41,5 +41,7 @@ struct bpf_program *bpf_program_append_dev (struct bpf_program *program, const c
 struct bpf_program *bpf_program_complete_dev (struct bpf_program *program, libcrun_error_t *err);
 
 int libcrun_ebpf_load (struct bpf_program *program, int dirfd, const char *pin, libcrun_error_t *err);
+int libcrun_ebpf_read_program (struct bpf_program **program, const char *path, libcrun_error_t *err);
+bool libcrun_ebpf_cmp_programs (struct bpf_program *program1, struct bpf_program *program2);
 
 #endif

--- a/src/libcrun/ebpf.h
+++ b/src/libcrun/ebpf.h
@@ -27,6 +27,9 @@
 #include <ocispec/runtime_spec_schema_config_schema.h>
 #include "container.h"
 
+#define SYS_FS_BPF "/sys/fs/bpf"
+#define CRUN_BPF_DIR SYS_FS_BPF "/crun"
+
 struct bpf_program;
 
 struct bpf_program *bpf_program_new (size_t size);

--- a/tests/test_bpf_devices.py
+++ b/tests/test_bpf_devices.py
@@ -1,0 +1,140 @@
+#!/bin/env python3
+# crun - OCI runtime written in C
+#
+# Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+# crun is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# crun is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with crun.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+import sys
+import json
+import os
+from tests_utils import *
+
+def has_bpf_fs():
+    """Check if BPF filesystem is mounted"""
+    try:
+        return os.path.exists("/sys/fs/bpf") and os.path.ismount("/sys/fs/bpf")
+    except:
+        return False
+
+def get_systemd_version():
+    """Get systemd version number"""
+    try:
+        output = subprocess.check_output(["systemctl", "--version"], universal_newlines=True)
+        # First line format: "systemd 250 (250.3-2-arch)"
+        first_line = output.split('\n')[0]
+        version_str = first_line.split()[1]
+        return int(version_str)
+    except:
+        return 0
+
+def systemd_supports_bpf_program():
+    """Check if systemd version supports BPFProgram property (>= 249)"""
+    return get_systemd_version() >= 249
+
+def check_bpf_prerequisites():
+    """Check all prerequisites for BPF device tests. Returns 77 (skip) if not met, 0 if OK"""
+    # Skip if not root
+    if is_rootless():
+        return 77
+
+    # Skip if not cgroup v2
+    if not is_cgroup_v2_unified():
+        return 77
+
+    # Skip if systemd not available
+    if 'SYSTEMD' not in get_crun_feature_string():
+        return 77
+
+    # Skip if not running on systemd
+    if not running_on_systemd():
+        return 77
+
+    # Skip if no BPF support
+    if not has_bpf_fs():
+        return 77
+
+    # Skip if systemd doesn't support BPFProgram
+    if not systemd_supports_bpf_program():
+        return 77
+
+    return 0
+
+def test_bpf_devices_systemd():
+    """Test BPF device handling with systemd: property set, file created, and cleanup"""
+    ret = check_bpf_prerequisites()
+    if ret != 0:
+        return ret
+
+    conf = base_config()
+    conf['linux']['resources'] = {}
+    add_all_namespaces(conf, cgroupns=True)
+    conf['process']['args'] = ['/init', 'pause']
+
+    cid = None
+    bpf_path = None
+    try:
+        # Run container with systemd cgroup manager.
+        _, cid = run_and_get_output(conf, command='run', detach=True, cgroup_manager="systemd")
+
+        # Get systemd scope.
+        state = run_crun_command(['state', cid])
+        scope = json.loads(state)['systemd-scope']
+
+        # Test 1: Check that BPFProgram property is set on the scope.
+
+        output = subprocess.check_output(['systemctl', 'show', '-PBPFProgram', scope], close_fds=False).decode().strip()
+        if output == "":
+            sys.stderr.write("# BPFProgram property not found or empty\n")
+            return -1
+
+        # Should look like "device:/sys/fs/bpf/crun/crun-xxx_scope".
+        if "device:/sys/fs/bpf/crun/" not in output:
+            sys.stderr.write("# Bad BPFProgram property value: `%s`\n" % output)
+            return -1
+
+        # Test 2: Check that BPF program file was created.
+
+        # Extract the path.
+        bpf_path = output.split("device:", 1)[1]
+        if not os.path.exists(bpf_path):
+            sys.stderr.write("# BPF program file `%s` not found\n" % bpf_path)
+            return -1
+
+        # Test 3: Check that BPF program is cleaned up.
+
+        # Delete the container.
+        run_crun_command(["delete", "-f", cid])
+        cid = None
+        if os.path.exists(bpf_path):
+            sys.stderr.write("# BPF program `%s` still exist after crun delete\n" % bpf_path)
+            return -1
+
+        return 0
+
+    except Exception as e:
+        sys.stderr.write("# Test failed with exception: %s\n" % str(e))
+        return -1
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+
+    return 0
+
+all_tests = {
+    "bpf-devices-systemd": test_bpf_devices_systemd,
+}
+
+if __name__ == "__main__":
+    tests_main(all_tests)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -21,9 +21,6 @@ import time
 from tests_utils import *
 
 
-def is_cgroup_v2_unified():
-    return subprocess.check_output("stat -c%T -f /sys/fs/cgroup".split()).decode("utf-8").strip() == "cgroup2fs"
-
 def test_resources_fail_with_enoent():
     if is_rootless():
         return 77

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -370,6 +370,9 @@ def is_rootless():
             return False
     return True
 
+def is_cgroup_v2_unified():
+    return subprocess.check_output("stat -c%T -f /sys/fs/cgroup".split()).decode("utf-8").strip() == "cgroup2fs"
+
 def get_crun_feature_string():
     for i in run_crun_command(['--version']).split('\n'):
         if i.startswith('+'):


### PR DESCRIPTION
This adds initial support for using `BPFProgram=device` systemd unit property
to manage devices, **instead** of adding AllowDevice/DevicePolicy properties to systemd
and then own bpf program to `/container` sub-cgroup.

This includes some basic tests. I also did some manual testing, and ran [runc's dev.bats tests](https://github.com/opencontainers/runc/blob/c3d127f6e8d9f6c06d78b8329cafa8dd39f6236e/tests/integration/dev.bats), which mostly check that device rules are being properly applied.
 
TODO (not in this PR):
  - figure out a way to support device updates
  
Please see individual commits for details.
  
Fixes: #1765.

## Summary by Sourcery

Enable device management via systemd's BPFProgram property by generating, loading, and pinning eBPF programs for container scopes, falling back to legacy cgroup device policies when unsupported, and cleaning up on teardown.

New Features:
- Add support for using systemd's BPFProgram=device property to enforce container device rules via eBPF

Enhancements:
- Detect BPF filesystem presence and generate per-scope eBPF program paths under /sys/fs/bpf/crun
- Refactor device policy handling to create and load eBPF programs and fall back to legacy cgroup rules when needed
- Cleanup pinned BPF program on container destruction and track whether BPF-based device filtering was applied

Tests:
- Add integration test for systemd BPFProgram-based device filtering and update test utils for cgroup v2 and BPF prerequisites handling