### PR TITLE
tests: install catatonit package

### DIFF
--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -4,14 +4,14 @@ ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
 RUN dnf install -y awk golang python git gcc automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel go-md2man  \
+    systemd-devel yajl-devel libseccomp-devel go-md2man catatonit \
     glibc-static python3-libmount libtool make podman xz nmap-ncat procps-ng slirp4netns \
     device-mapper-devel containernetworking-plugins 'dnf-command(builddep)' && \
     dnf builddep -y podman && \
     chmod 755 /root && \
     git clone --depth=1 https://github.com/containers/podman /root/go/src/github.com/containers/podman && \
     cd /root/go/src/github.com/containers/podman && \
-    make .install.ginkgo install.catatonit && cp ./bin/ginkgo /usr/local/bin && \
+    make .install.ginkgo && cp ./bin/ginkgo /usr/local/bin && \
     make
 
 ## Change default log driver to k8s-file for tests


### PR DESCRIPTION
## Summary by Sourcery

Install catatonit via DNF in the Podman test image and remove the manual build target

Enhancements:
- Add 'catatonit' to the list of packages installed in tests/podman Dockerfile
- Remove the 'install.catatonit' make target in favor of the packaged binary