### PR TITLE
lua: fix build errors

### DIFF
--- a/lua/lua_crun.c
+++ b/lua/lua_crun.c
@@ -57,8 +57,8 @@ static const char *LUA_CRUN_TAG_CONTS_ITER = "crun-containers-iterator";
 #  define LUACRUN_NoRet [[noreturn]]
 #endif
 
-extern LUACRUN_NoRet int lua_error (lua_State *L);
-extern LUACRUN_NoRet int luaL_error (lua_State *L, const char *fmt, ...);
+extern int lua_error (lua_State *L);
+extern int luaL_error (lua_State *L, const char *fmt, ...);
 
 /* Build the error string, push onto stack. */
 LUA_API int
@@ -82,7 +82,7 @@ luacrun_error (lua_State *S, libcrun_error_t *err)
   return 1;
 }
 
-LUA_API LUACRUN_NoRet void
+LUA_API void
 luacrun_set_error (lua_State *S, libcrun_error_t *err)
 {
   luacrun_error (S, err);


### PR DESCRIPTION
Closes: https://github.com/containers/crun/issues/1804

## Summary by Sourcery

Fix build errors in Lua binding by removing incorrect noreturn attributes from function declarations

Bug Fixes:
- Remove LUACRUN_NoRet attribute from extern declarations of lua_error and luaL_error
- Remove LUACRUN_NoRet attribute from luacrun_set_error function signature