### PR TITLE
krun: Add support to run AWS Nitro Enclaves

### DIFF
--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -144,6 +144,42 @@ libkrun_configure_kernel (uint32_t ctx_id, void *handle, yajl_val *config_tree, 
 }
 
 static int
+libkrun_configure_nitro (uint32_t ctx_id, void *handle, yajl_val *config_tree, libcrun_error_t *err)
+{
+  int32_t (*krun_nitro_set_image) (uint32_t ctx_id, const char *image_path, uint32_t image_type);
+  int32_t (*krun_nitro_set_start_flags) (uint32_t ctx_id, uint64_t start_flags);
+  const char *path_eif[] = { "eif_file", (const char *) 0 };
+  yajl_val val_eif_image = NULL;
+  uint64_t start_flags = 1;
+  char *eif_image = NULL;
+  int ret;
+
+  val_eif_image = yajl_tree_get (*config_tree, path_eif, yajl_t_string);
+  if (val_eif_image == NULL || ! YAJL_IS_STRING (val_eif_image))
+    return crun_make_error (err, 0, "invalid Enclave Image Format file parameter");
+
+  eif_image = YAJL_GET_STRING (val_eif_image);
+
+  krun_nitro_set_image = dlsym (handle, "krun_nitro_set_image");
+  if (krun_nitro_set_image == NULL)
+    return crun_make_error (err, 0, "could not find symbol in krun library");
+
+  krun_nitro_set_start_flags = dlsym (handle, "krun_nitro_set_start_flags");
+  if (krun_nitro_set_start_flags == NULL)
+    return crun_make_error (err, 0, "could not find symbol in krun library");
+
+  ret = krun_nitro_set_image (ctx_id, eif_image, KRUN_NITRO_IMG_TYPE_EIF);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, -ret, "could not configure a krun nitro EIF image");
+
+  ret = krun_nitro_set_start_flags (ctx_id, 1);
+  if (UNLIKELY (ret < 0))
+    return crun_make_error (err, -ret, "could not configure a krun nitro start flags");
+
+  return 0;
+}
+
+static int
 libkrun_read_vm_config (yajl_val *config_tree, libcrun_error_t *err)
 {
   int ret;
@@ -291,6 +327,7 @@ libkrun_exec (void *cookie, libcrun_container_t *container, const char *pathname
   int32_t (*krun_set_root) (uint32_t ctx_id, const char *root_path);
   int32_t (*krun_set_root_disk) (uint32_t ctx_id, const char *disk_path);
   int32_t (*krun_set_tee_config_file) (uint32_t ctx_id, const char *file_path);
+  int32_t (*krun_nitro_set_image) (uint32_t ctx_id, const char *image_path, uint32_t image_type);
   struct krun_config *kconf = (struct krun_config *) cookie;
   void *handle;
   uint32_t num_vcpus, ram_mib;
@@ -333,6 +370,12 @@ libkrun_exec (void *cookie, libcrun_container_t *container, const char *pathname
       ret = krun_set_tee_config_file (ctx_id, KRUN_SEV_FILE);
       if (UNLIKELY (ret < 0))
         error (EXIT_FAILURE, -ret, "could not set krun tee config file");
+    }
+  else if (kconf->nitro)
+    {
+      ret = libkrun_configure_nitro (ctx_id, handle, &config_tree, &err);
+      if (UNLIKELY (ret < 0))
+        error (EXIT_FAILURE, -ret, "could not configure krun nitro enclave");
     }
   else
     {

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -441,7 +441,10 @@ libkrun_configure_container (void *cookie, enum handler_configure_phase phase,
       for (i = 0; i < def->linux->devices_len; i++)
         {
           if (strcmp (def->linux->devices[i]->path, "/dev/sev") == 0)
-            create_sev = false;
+            {
+              create_sev = false;
+              break;
+            }
         }
     }
 


### PR DESCRIPTION
This adds support for the nitro flavor of libkrun (libkrun-nitro). libkrun-nitro allows users on supported AWS EC2 instances to run their container workloads isolated by [AWS Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/).

cc @slp

## Summary by Sourcery

Add support for AWS Nitro Enclaves in the libcrun krun handler by integrating libkrun-nitro, allowing workloads to run in Nitro enclaves.

New Features:
- Add an "aws-nitro" flavor to select Nitro Enclave isolation via libkrun-nitro.
- Expose enclave image and start flags configuration for Nitro workloads.

Enhancements:
- Dynamically load and manage a separate libkrun-nitro context alongside existing default and SEV backends.
- Extend flavor parsing to detect "aws-nitro" and switch to the Nitro handle and context.
- Configure container execution to only require /dev/kvm for non-nitro workloads and to invoke Nitro-specific setup when selected.
- Detect host support for /dev/nitro_enclaves, /dev/kvm, and /dev/sev and conditionally provision corresponding devices in the OCI spec.
- Consolidate handle cleanup logic by closing unused libkrun handles in a loop.