### PR TITLE
src: add NULL checks for free* functions

### DIFF
--- a/src/libcrun/custom-handler.c
+++ b/src/libcrun/custom-handler.c
@@ -121,6 +121,9 @@ handler_manager_free (struct custom_handler_manager_s *manager)
 {
   size_t i;
 
+  if (manager == NULL)
+    return;
+
   for (i = 0; i < manager->handlers_len; i++)
     {
 #ifdef HAVE_DLOPEN

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -4017,6 +4017,9 @@ cleanup_free_init_statusp (struct init_status_s *ns)
 {
   size_t i;
 
+  if (ns == NULL)
+    return;
+
   for (i = 0; i < ns->fd_len; i++)
     TEMP_FAILURE_RETRY (close (ns->fd[i]));
 }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -867,6 +867,8 @@ pivot_root (const char *new_root, const char *put_old)
 static void
 free_remount (struct remount_s *r)
 {
+  if (r == NULL)
+    return;
   if (r->targetfd >= 0)
     close (r->targetfd);
   free (r->data);

--- a/src/libcrun/string_map.c
+++ b/src/libcrun/string_map.c
@@ -149,6 +149,9 @@ free_string_map (string_map *map)
 {
   size_t i;
 
+  if (map == NULL)
+    return;
+
   if (map->htab_initialized)
     hdestroy_r (&map->htab);
 

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -189,6 +189,9 @@ cleanup_close_vecp (int **p)
   int *pp = *p;
   int i;
 
+  if (pp == NULL)
+    return;
+
   for (i = 0; pp[i] >= 0; i++)
     TEMP_FAILURE_RETRY (close (pp[i]));
 }


### PR DESCRIPTION
make these functions more uniform so that they won't cause a segfault if NULL is passed in

## Summary by Sourcery

Bug Fixes:
- Add NULL checks to free_remount, cleanup_free_init_statusp, handler_manager_free, free_string_map, and cleanup_close_vecp to avoid segfaults when passed NULL.