### PR TITLE
Remove dead code after exit

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3597,7 +3597,6 @@ exec_process_entrypoint (libcrun_context_t *context,
         return ret;
 
       _exit (EXIT_FAILURE);
-      return 0;
     }
 
   /* Attempt to close all the files that are not needed to prevent execv to have access to them.
@@ -3610,9 +3609,6 @@ exec_process_entrypoint (libcrun_context_t *context,
 
   TEMP_FAILURE_RETRY (execv (exec_path, process->args));
   libcrun_fail_with_error (errno, "exec");
-  _exit (EXIT_FAILURE);
-
-  return 0;
 }
 
 int

--- a/tests/tests_libcrun_fuzzer.c
+++ b/tests/tests_libcrun_fuzzer.c
@@ -492,7 +492,6 @@ main (int argc, char **argv)
       if (read_all_file (argv[1], (char **) &content, &len, &err) < 0)
         {
           libcrun_fail_with_error (err->status, "%s", err->msg);
-          return -1;
         }
       return LLVMFuzzerTestOneInput (content, len);
     }


### PR DESCRIPTION
Remove dead code after exit.

Rationale:

`exit()` and `_exit()` do not return according to:

https://man7.org/linux/man-pages/man2/_exit.2.html
https://man7.org/linux/man-pages/man3/exit.3.html

## Summary by Sourcery

Remove unreachable return statements following non-returning exit() and _exit() calls to clean up dead code

Enhancements:
- Eliminate redundant return statements after _exit(EXIT_FAILURE) in exec_process_entrypoint()
- Remove unreachable return in fuzzer main after libcrun_fail_with_error exit call

## Summary by Sourcery

Enhancements:
- Remove redundant return statements following non-returning exit() and _exit() calls in exec_process_entrypoint and fuzzer main to clean up dead code