### PR TITLE
crun: print version even with invalid rundir

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -247,18 +247,17 @@ print_version (FILE *stream, struct argp_state *state arg_unused)
   cleanup_free char *rundir = NULL;
   int ret;
 
-  ret = libcrun_get_state_directory (&rundir, arguments.root, NULL, &err);
-  if (UNLIKELY (ret < 0))
-    {
-      libcrun_error_release (&err);
-      fprintf (stderr, "Failed to get state directory\n");
-      exit (EXIT_FAILURE);
-    }
-
   fprintf (stream, "%s version %s\n", PACKAGE_NAME, PACKAGE_VERSION);
   fprintf (stream, "commit: %s\n", GIT_VERSION);
-  fprintf (stream, "rundir: %s\n", rundir);
+
+  ret = libcrun_get_state_directory (&rundir, arguments.root, NULL, &err);
+  if (LIKELY (ret == 0))
+    fprintf (stream, "rundir: %s\n", rundir);
+  else
+    libcrun_error_release (&err);
+
   fprintf (stream, "spec: 1.0.0\n");
+
 #ifdef HAVE_SYSTEMD
   fprintf (stream, "+SYSTEMD ");
 #endif


### PR DESCRIPTION
Closes: https://github.com/containers/crun/issues/1816

## Summary by Sourcery

Ensure the version command always shows version information even if the state directory lookup fails, and only print the rundir path when it is successfully retrieved

Bug Fixes:
- Continue to display version info on invalid rundir instead of exiting

Enhancements:
- Suppress rundir retrieval errors and conditionally print the rundir path only on success