### PR TITLE
packit: drop centos9 stream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -66,13 +66,6 @@ jobs:
     packages: [crun-centos]
     notifications: *copr_build_failure_notification
     targets: &centos_copr_targets
-      # Need epel9 repos to fetch wasmedge build dependency
-      centos-stream-9-x86_64:
-        additional_repos:
-          - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/
-      centos-stream-9-aarch64:
-        additional_repos:
-          - https://dl.fedoraproject.org/pub/epel/9/Everything/aarch64/
       # TODO: build on CS10 with wasmedge once epel-10 is available
       centos-stream-10-x86_64: {}
       centos-stream-10-aarch64: {}
@@ -112,8 +105,6 @@ jobs:
     # Issue filed: https://github.com/containers/crun/issues/1759
     #targets: *centos_copr_targets
     targets:
-      - centos-stream-9-x86_64
-      - centos-stream-9-aarch64
       - centos-stream-10-aarch64
     tf_extra_params:
       environments:


### PR DESCRIPTION
These tests are broken most of the time and nobody looks at the failures anyway.

## Summary by Sourcery

Drop CentOS Stream 9 build targets and associated EPEL 9 repositories from packit configuration to avoid recurring test failures.

Chores:
- Remove centos-stream-9-x86_64 and centos-stream-9-aarch64 targets from copr build configuration
- Eliminate additional EPEL 9 repository entries for CentOS Stream 9