### PR TITLE
RPM: Disable wasmedge for centos

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -66,16 +66,10 @@ jobs:
     packages: [crun-centos]
     notifications: *copr_build_failure_notification
     targets: &centos_copr_targets
-      # Need epel9 repos to fetch wasmedge build dependency
-      centos-stream-9-x86_64:
-        additional_repos:
-          - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/
-      centos-stream-9-aarch64:
-        additional_repos:
-          - https://dl.fedoraproject.org/pub/epel/9/Everything/aarch64/
-      # TODO: build on CS10 with wasmedge once epel-10 is available
-      centos-stream-10-x86_64: {}
-      centos-stream-10-aarch64: {}
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
+      - centos-stream-10-x86_64
+      - centos-stream-10-aarch64
 
   # Run on commit to main branch
   - job: copr_build

--- a/rpm/crun.spec
+++ b/rpm/crun.spec
@@ -9,18 +9,15 @@
 # krun and wasm support only on aarch64 and x86_64
 %ifarch aarch64 || x86_64
 
-# Disable wasmedge on rhel 10 until EPEL10 is in place, otherwise it causes
-# build issues on copr
-%if %{defined fedora} || (%{defined copr_build} && %{defined rhel} && 0%{?rhel} < 10)
+%if %{defined fedora}
+# krun only exists on fedora
+%global krun_support 1
+%global krun_opts --with-libkrun
+
+# Keep wasmedge enabled only on Fedora. It breaks a lot on EPEL.
 %global wasm_support 1
 %global wasmedge_support 1
 %global wasmedge_opts --with-wasmedge
-%endif
-
-# krun only exists on fedora
-%if %{defined fedora}
-%global krun_support 1
-%global krun_opts --with-libkrun
 %endif
 
 %endif


### PR DESCRIPTION
## Summary by Sourcery

Disable wasmedge for CentOS builds, simplify CentOS CI configuration, and quiet rpmlint checks

Enhancements:
- Restrict wasmedge and wasm support to Fedora-only builds and remove previous RHEL/CentOS conditional logic in crun.spec
- Add a placeholder `%check` section in crun.spec to silence rpmlint

CI:
- Simplify CentOS Copr build targets in .packit.yaml to a flat list of CentOS Stream 9 and 10 for x86_64 and aarch64
- Set the propose_downstream job trigger to ignore until migrating CentOS packaging to Packit