### PR TITLE
tests: run all py tests with cgroupfs and systemd

### DIFF
--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -13,9 +13,19 @@ if [ -t 1 ]; then
     COLOR="yes"
 fi
 
-for i in test_*.py
-do
-    ./tap-driver.sh --test-name "$i" --log-file "$i.log" --trs-file "$i.trs" --color-tests "${COLOR}" --enable-hard-errors yes --expect-failure no -- /usr/bin/python "$i"
+managers="cgroupfs"
+if grep -q systemd /proc/1/comm && $OCI_RUNTIME --version | grep -qF +SYSTEMD; then
+	managers="$managers systemd"
+fi
+
+for cm in cgroupfs systemd; do
+    export CGROUP_MANAGER=$cm
+    echo "#"
+    echo "# CGROUP_MANAGER=$cm"
+    echo "#"
+    for i in test_*.py; do
+	    ./tap-driver.sh --test-name "$i" --log-file "${i}_${cm}.log" --trs-file "${i}_${cm}.trs" --color-tests "${COLOR}" --enable-hard-errors yes --expect-failure no -- /usr/bin/python "$i"
+    done
 done
 
 if grep FAIL -- *.trs; then


### PR DESCRIPTION
Many python tests do not run with systemd, and it makes sense to do so.

## Summary by Sourcery

Iterate over both cgroupfs and systemd managers when running all Python tests and propagate CGROUP_MANAGER into test utilities to support both cgroup backends.

New Features:
- Detect and include systemd cgroup manager in test runs when available
- Run each test under both cgroupfs and systemd, generating separate logs and TRS files

Enhancements:
- Default cgroup_manager in run_and_get_output to the CGROUP_MANAGER environment variable when not explicitly provided