### PR TITLE
criu: Add support for tcp-close

### DIFF
--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -188,6 +188,7 @@ struct libcrun_checkpoint_restore_s
   char *work_path;
   bool leave_running;
   bool tcp_established;
+  bool tcp_close;
   bool shell_job;
   bool ext_unix_sk;
   bool detach;

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -94,6 +94,7 @@ struct libcriu_wrapper_s
   int (*criu_add_cg_root) (const char *ctrl, const char *path);
   void (*criu_set_shell_job) (bool shell_job);
   void (*criu_set_tcp_established) (bool tcp_established);
+  void (*criu_set_tcp_close) (bool tcp_close);
   void (*criu_set_track_mem) (bool track_mem);
   void (*criu_set_work_dir_fd) (int fd);
   int (*criu_set_lsm_profile) (const char *name);
@@ -188,6 +189,7 @@ load_wrapper (struct libcriu_wrapper_s **wrapper_out, libcrun_error_t *err)
   LOAD_CRIU_FUNCTION (criu_add_cg_root, false);
   LOAD_CRIU_FUNCTION (criu_set_shell_job, false);
   LOAD_CRIU_FUNCTION (criu_set_tcp_established, false);
+  LOAD_CRIU_FUNCTION (criu_set_tcp_close, false);
   LOAD_CRIU_FUNCTION (criu_set_track_mem, false);
   LOAD_CRIU_FUNCTION (criu_set_work_dir_fd, false);
   LOAD_CRIU_FUNCTION (criu_set_lsm_profile, false);
@@ -1076,6 +1078,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
   libcriu_wrapper->criu_set_ext_unix_sk (cr_options->ext_unix_sk);
   libcriu_wrapper->criu_set_shell_job (cr_options->shell_job);
   libcriu_wrapper->criu_set_tcp_established (cr_options->tcp_established);
+  libcriu_wrapper->criu_set_tcp_close (cr_options->tcp_close);
   libcriu_wrapper->criu_set_file_locks (cr_options->file_locks);
   libcriu_wrapper->criu_set_orphan_pts_master (true);
 

--- a/src/restore.c
+++ b/src/restore.c
@@ -38,6 +38,7 @@ enum
   OPTION_IMAGE_PATH = 1000,
   OPTION_WORK_PATH,
   OPTION_TCP_ESTABLISHED,
+  OPTION_TCP_CLOSE,
   OPTION_SHELL_JOB,
   OPTION_EXT_UNIX_SK,
   OPTION_PID_FILE,
@@ -62,6 +63,7 @@ static struct argp_option options[]
         { "image-path", OPTION_IMAGE_PATH, "DIR", 0, "path for saving criu image files", 0 },
         { "work-path", OPTION_WORK_PATH, "DIR", 0, "path for saving work files and logs", 0 },
         { "tcp-established", OPTION_TCP_ESTABLISHED, 0, 0, "allow open tcp connections", 0 },
+        { "tcp-close", OPTION_TCP_CLOSE, 0, 0, "allow closed tcp connections", 0 },
         { "ext-unix-sk", OPTION_EXT_UNIX_SK, 0, 0, "allow external unix sockets", 0 },
         { "shell-job", OPTION_SHELL_JOB, 0, 0, "allow shell jobs", 0 },
         { "detach", 'd', 0, 0, "detach from the container's process", 0 },
@@ -101,6 +103,10 @@ parse_opt (int key, char *arg, struct argp_state *state)
 
     case OPTION_TCP_ESTABLISHED:
       cr_options.tcp_established = true;
+      break;
+
+    case OPTION_TCP_CLOSE:
+      cr_options.tcp_close = true;
       break;
 
     case OPTION_EXT_UNIX_SK:


### PR DESCRIPTION
Add support for criu's tcp-close functionality so that you can restore multiple copies of a checkpoint that had established tcp-connections.

This PR implements the following [issue](https://github.com/containers/crun/issues/1833)

## Summary by Sourcery

Add support for CRIU's tcp-close feature by introducing a new --tcp-close flag in the restore CLI and propagating the option through the container state and libcriu wrapper.

New Features:
- Add --tcp-close option to crun restore to enable closed TCP connection restoration.
- Propagate tcp_close flag through container state and into libcriu restore call.

Enhancements:
- Extend libcrun/container API and libcriu wrapper to load and call criu_set_tcp_close function.