### PR TITLE
utils: add bounds checking for Unix domain socket paths

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1102,7 +1102,11 @@ open_unix_domain_client_socket (const char *path, int dgram, libcrun_error_t *er
       path = name_buf;
     }
 
-  strcpy (addr.sun_path, path);
+  size_t path_len = strlen (path);
+  if (path_len >= sizeof (addr.sun_path))
+    return crun_make_error (err, ENAMETOOLONG, "socket path too long: `%s`", path);
+
+  memcpy (addr.sun_path, path, path_len + 1);
   addr.sun_family = AF_UNIX;
   ret = connect (fd, (struct sockaddr *) &addr, sizeof (addr));
   if (UNLIKELY (ret < 0))
@@ -1129,7 +1133,12 @@ open_unix_domain_socket (const char *path, int dgram, libcrun_error_t *err)
       get_proc_self_fd_path (name_buf, fd);
       path = name_buf;
     }
-  strcpy (addr.sun_path, path);
+
+  size_t path_len = strlen (path);
+  if (path_len >= sizeof (addr.sun_path))
+    return crun_make_error (err, ENAMETOOLONG, "socket path too long: `%s`", path);
+
+  memcpy (addr.sun_path, path, path_len + 1);
   addr.sun_family = AF_UNIX;
   ret = bind (fd, (struct sockaddr *) &addr, sizeof (addr));
   if (UNLIKELY (ret < 0))


### PR DESCRIPTION
Replace unsafe strcpy() with proper length validation and strncpy() to prevent buffer overflow when copying socket paths to sockaddr_un.sun_path.

This prevents potential buffer overflow vulnerabilities when handling long socket paths.

## Summary by Sourcery

Add bounds checking and safe copying for Unix domain socket paths in open_unix_domain_client_socket and open_unix_domain_socket to eliminate buffer overflow vulnerabilities.

Bug Fixes:
- Prevent potential buffer overflows when copying Unix domain socket paths by validating path length before copying

Enhancements:
- Replace unsafe strcpy() calls with bounded strncpy() and explicit null-termination
- Return ENAMETOOLONG error if socket path exceeds sockaddr_un.sun_path size