### PR TITLE
cgroup-systemd: Always set traditional device rules as backup when using BPF

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1627,7 +1627,7 @@ append_resources (sd_bus_message *m,
 #  undef APPEND_UINT64
 #  undef APPEND_UINT64_VALUE
 
-  if (! *devices_set && (! is_update || resources->devices))
+  if (! is_update || resources->devices)
     {
       ret = append_devices (m, resources, err);
       if (UNLIKELY (ret < 0))


### PR DESCRIPTION
The current logic only sets traditional device rules when BPF is not attempted (*devices_set == false). However, systemd can fail internally to apply BPF programs due to permission issues, SELinux policies, or other environment-specific restrictions, while still accepting the BPF program via D-Bus without error.

xref: https://issues.redhat.com/browse/OCPBUGS-60663

## Summary by Sourcery

Bug Fixes:
- Always append fallback device rules when resources->devices is set, even if BPF programs were attempted