### PR TITLE
krun: avoid failing if sev/nitro are not available

### DIFF
--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -578,14 +578,24 @@ libkrun_configure_container (void *cookie, enum handler_configure_phase phase,
     {
       ret = libcrun_create_dev (container, devfd, -1, &sev_device, is_user_ns, true, err);
       if (UNLIKELY (ret < 0))
-        return ret;
+        {
+          ret = dlclose (kconf->handle_sev);
+          if (UNLIKELY (ret < 0))
+            return ret;
+          kconf->handle_sev = NULL;
+        }
     }
 
   if (create_nitro)
     {
       ret = libcrun_create_dev (container, devfd, -1, &nitro_device, is_user_ns, true, err);
       if (UNLIKELY (ret < 0))
-        return ret;
+        {
+          ret = dlclose (kconf->handle_nitro);
+          if (UNLIKELY (ret < 0))
+            return ret;
+          kconf->handle_nitro = NULL;
+        }
     }
 
   return 0;


### PR DESCRIPTION
It's possible for a user to accidentally install the sev or nitro flavors of libkrun even if their system doesn't actually support those features.

Before this change, having them installed on a system that doesn't support them would cause krun to stop working. Let's do the right thing and, if the bindings for "/dev/sev" or "/dev/nitro_enclaves" can't be created, close the handles to those library flavors and keep running with the generic one.

If sev or nitro where really needed by the workload, it'll fail gracefully in "libkrun_configure_flavor".

Fixes: #1120 #1300

## Summary by Sourcery

Allow krun to continue running with the generic flavor when /dev/sev or /dev/nitro_enclaves cannot be created by unloading the corresponding dynamic library instead of failing outright.

Enhancements:
- Fall back to the generic libkrun flavor by closing the SEV library handle when /dev/sev binding fails
- Fall back to the generic libkrun flavor by closing the Nitro library handle when /dev/nitro_enclaves binding fails