### PR TITLE
contrib: format contrib files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -330,7 +330,7 @@ generate-mount_flags.c: src/libcrun/mount_flags.perf
 
 clang-format:
 # do not format files that were copied into the source directory.
-	git ls-files src tests | grep -E "\\.[hc]" | grep -v "blake3\|chroot_realpath.c\|cloned_binary.c\|signals.c\|mount_flags.c" | xargs clang-format -style=file -i
+	git ls-files contrib src tests | grep -E "\\.[hc]" | grep -v "blake3\|chroot_realpath.c\|cloned_binary.c\|signals.c\|mount_flags.c" | xargs clang-format -style=file -i
 
 shellcheck:
 	shellcheck autogen.sh build-aux/release.sh tests/run_all_tests.sh tests/*/*.sh contrib/*.sh

--- a/contrib/notify-socket-server/notify-socket-server.c
+++ b/contrib/notify-socket-server/notify-socket-server.c
@@ -30,14 +30,16 @@
 #include <termios.h>
 #include <stdio.h>
 
-#define error(status, errno, fmt, ...) do{                              \
-    if (errno)                                                          \
-      fprintf (stderr, "crun: " fmt, ##__VA_ARGS__);                    \
-    else                                                                \
-      fprintf (stderr, "crun: %s:" fmt, strerror (errno), ##__VA_ARGS__); \
-    if (status)                                                         \
-      exit (status);                                                    \
-  } while(0)
+#define error(status, errno, fmt, ...)                                      \
+  do                                                                        \
+    {                                                                       \
+      if (errno)                                                            \
+        fprintf (stderr, "crun: " fmt, ##__VA_ARGS__);                      \
+      else                                                                  \
+        fprintf (stderr, "crun: %s:" fmt, strerror (errno), ##__VA_ARGS__); \
+      if (status)                                                           \
+        exit (status);                                                      \
+  } while (0)
 
 static int
 open_unix_domain_socket (const char *path)
@@ -46,7 +48,7 @@ open_unix_domain_socket (const char *path)
   int ret, fd;
   const int one = 1;
 
-  fd = socket (AF_UNIX, SOCK_DGRAM|SOCK_CLOEXEC, 0);
+  fd = socket (AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
   if (fd < 0)
     error (EXIT_FAILURE, errno, "socket");
 
@@ -97,7 +99,7 @@ main (int argc, char **argv)
       msg.msg_control = ctrl_buf;
       msg.msg_controllen = CTRL_SIZE;
 
-      ret = recvmsg (fd, &msg, MSG_CMSG_CLOEXEC|MSG_TRUNC);
+      ret = recvmsg (fd, &msg, MSG_CMSG_CLOEXEC | MSG_TRUNC);
       if (ret < 0 && errno == EINTR)
         continue;
       if (ret < 0)

--- a/contrib/seccomp-receiver/seccomp-receiver.c
+++ b/contrib/seccomp-receiver/seccomp-receiver.c
@@ -30,14 +30,16 @@
 #include <termios.h>
 #include <stdio.h>
 
-#define error(status, errno, fmt, ...) do {                             \
-    if (errno)                                                          \
-      fprintf (stderr, "crun: " fmt, ##__VA_ARGS__);                    \
-    else                                                                \
-      fprintf (stderr, "crun: %s:" fmt, strerror (errno), ##__VA_ARGS__); \
-    if (status)                                                         \
-      exit (status);                                                    \
-  } while(0)
+#define error(status, errno, fmt, ...)                                      \
+  do                                                                        \
+    {                                                                       \
+      if (errno)                                                            \
+        fprintf (stderr, "crun: " fmt, ##__VA_ARGS__);                      \
+      else                                                                  \
+        fprintf (stderr, "crun: %s:" fmt, strerror (errno), ##__VA_ARGS__); \
+      if (status)                                                           \
+        exit (status);                                                      \
+  } while (0)
 
 static int
 open_unix_domain_socket (const char *path)
@@ -47,10 +49,10 @@ open_unix_domain_socket (const char *path)
   int fd = socket (AF_UNIX, SOCK_STREAM, 0);
   if (fd < 0)
     error (EXIT_FAILURE, errno, "error creating UNIX socket");
-  
+
   if (strlen (path) >= sizeof (addr.sun_path))
     error (EXIT_FAILURE, 0, "invalid path");
-    
+
   strcpy (addr.sun_path, path);
   addr.sun_family = AF_UNIX;
   ret = bind (fd, (struct sockaddr *) &addr, sizeof (addr));


### PR DESCRIPTION
## Summary by Sourcery

Reformat contrib C files for consistent code style and extend clang-format target to include contrib directory

Enhancements:
- Apply consistent spacing and indentation in contrib/terminal-receiver, contrib/notify-socket-server, and contrib/seccomp-receiver C sources

Build:
- Include contrib directory in Makefile clang-format target