### PR TITLE
intelrdt: add support for EnableMonitoring

### DIFF
--- a/src/libcrun/intelrdt.c
+++ b/src/libcrun/intelrdt.c
@@ -243,7 +243,7 @@ intelrdt_clean_l3_cache_schema (const char *l3_cache_schema)
 }
 
 int
-resctl_create (const char *name, bool explicit_clos_id, bool *created, const char *l3_cache_schema, const char *mem_bw_schema, libcrun_error_t *err)
+resctl_create (const char *name, bool explicit_clos_id, bool *created, const char *l3_cache_schema, const char *mem_bw_schema, char *const *schemata, libcrun_error_t *err)
 {
   cleanup_free char *cleaned_l3_cache_schema = NULL;
   cleanup_free char *path = NULL;
@@ -269,9 +269,9 @@ resctl_create (const char *name, bool explicit_clos_id, bool *created, const cha
   if (l3_cache_schema && strstr (l3_cache_schema, "MB:"))
     l3_cache_schema = cleaned_l3_cache_schema = intelrdt_clean_l3_cache_schema (l3_cache_schema);
 
-  /* If the closID was specified and both l3cache and bwSchema are unset, the group
-     must exist.  */
-  if (explicit_clos_id && l3_cache_schema == NULL && mem_bw_schema == NULL)
+  /* If the closID was specified and both l3cache and bwSchema are unset, and schemata is empty,
+     the group must exist.  */
+  if (explicit_clos_id && is_empty_string (l3_cache_schema) && is_empty_string (mem_bw_schema) && (schemata == NULL))
     {
       if (exist)
         return 0;

--- a/src/libcrun/intelrdt.h
+++ b/src/libcrun/intelrdt.h
@@ -25,8 +25,11 @@
 #include "error.h"
 
 int resctl_create (const char *name, bool explicit_clos_id, bool *created, const char *l3_cache_schema, const char *mem_bw_schema, char *const *schemata, libcrun_error_t *err);
-int resctl_move_task_to (const char *name, pid_t pid, libcrun_error_t *err);
+int resctl_move_task_to (const char *name, const char *monitoring_name, pid_t pid, libcrun_error_t *err);
 int resctl_update (const char *name, const char *l3_cache_schema, const char *mem_bw_schema, char *const *schemata, libcrun_error_t *err);
 int resctl_destroy (const char *name, libcrun_error_t *err);
+
+int resctl_destroy_monitoring_group (const char *resctrl_group_name, const char *container_id, libcrun_error_t *err);
+int resctl_create_monitoring_group (const char *resctrl_group_name, const char *container_id, libcrun_error_t *err);
 
 #endif

--- a/src/libcrun/intelrdt.h
+++ b/src/libcrun/intelrdt.h
@@ -24,7 +24,7 @@
 #include <stdbool.h>
 #include "error.h"
 
-int resctl_create (const char *name, bool explicit_clos_id, bool *created, const char *l3_cache_schema, const char *mem_bw_schema, libcrun_error_t *err);
+int resctl_create (const char *name, bool explicit_clos_id, bool *created, const char *l3_cache_schema, const char *mem_bw_schema, char *const *schemata, libcrun_error_t *err);
 int resctl_move_task_to (const char *name, pid_t pid, libcrun_error_t *err);
 int resctl_update (const char *name, const char *l3_cache_schema, const char *mem_bw_schema, char *const *schemata, libcrun_error_t *err);
 int resctl_destroy (const char *name, libcrun_error_t *err);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5975,13 +5975,9 @@ libcrun_kill_linux (libcrun_container_status_t *status, int signal, libcrun_erro
   return 0;
 }
 
-const char *
-libcrun_get_intelrdt_name (const char *ctr_name, libcrun_container_t *container, bool *explicit)
+static const char *
+libcrun_get_intelrdt_name (const char *ctr_name, runtime_spec_schema_config_schema *def, bool *explicit)
 {
-  runtime_spec_schema_config_schema *def = NULL;
-
-  def = container->container_def;
-
   if (def == NULL || def->linux == NULL || def->linux->intel_rdt == NULL || def->linux->intel_rdt->clos_id == NULL)
     {
       if (explicit)
@@ -5998,6 +5994,7 @@ int
 libcrun_apply_intelrdt (const char *ctr_name, libcrun_container_t *container, pid_t pid, int actions, libcrun_error_t *err)
 {
   runtime_spec_schema_config_schema *def = NULL;
+  bool has_monitoring = false;
   bool explicit = false;
   bool created = false;
   const char *name;
@@ -6009,13 +6006,22 @@ libcrun_apply_intelrdt (const char *ctr_name, libcrun_container_t *container, pi
   if (def == NULL || def->linux == NULL || def->linux->intel_rdt == NULL)
     return 0;
 
-  name = libcrun_get_intelrdt_name (ctr_name, container, &explicit);
+  name = libcrun_get_intelrdt_name (ctr_name, def, &explicit);
 
   if (actions & LIBCRUN_INTELRDT_CREATE)
     {
       ret = resctl_create (name, explicit, &created, def->linux->intel_rdt->l3cache_schema, def->linux->intel_rdt->mem_bw_schema, def->linux->intel_rdt->schemata, err);
       if (UNLIKELY (ret < 0))
         return ret;
+
+      if (def->linux->intel_rdt->enable_monitoring)
+        {
+          ret = resctl_create_monitoring_group (name, ctr_name, err);
+          if (UNLIKELY (ret < 0))
+            goto fail;
+
+          has_monitoring = true;
+        }
     }
 
   if (actions & LIBCRUN_INTELRDT_UPDATE)
@@ -6027,7 +6033,8 @@ libcrun_apply_intelrdt (const char *ctr_name, libcrun_container_t *container, pi
 
   if (actions & LIBCRUN_INTELRDT_MOVE)
     {
-      ret = resctl_move_task_to (name, pid, err);
+      const char *monitoring_name = def->linux->intel_rdt->enable_monitoring ? ctr_name : NULL;
+      ret = resctl_move_task_to (name, monitoring_name, pid, err);
       if (UNLIKELY (ret < 0))
         goto fail;
     }
@@ -6035,6 +6042,16 @@ libcrun_apply_intelrdt (const char *ctr_name, libcrun_container_t *container, pi
   return 0;
 
 fail:
+  if (has_monitoring)
+    {
+      libcrun_error_t tmp_err = NULL;
+      int tmp_ret;
+
+      tmp_ret = resctl_destroy_monitoring_group (name, ctr_name, &tmp_err);
+      if (tmp_ret < 0)
+        crun_error_release (&tmp_err);
+    }
+
   /* Cleanup only if the resctl was created as part of this call.  */
   if (created)
     {
@@ -6049,17 +6066,40 @@ fail:
 }
 
 int
-libcrun_destroy_intelrdt (const char *name, libcrun_error_t *err)
+libcrun_destroy_intelrdt (const char *container_id, runtime_spec_schema_config_schema *def, libcrun_error_t *err)
 {
-  return resctl_destroy (name, err);
+  bool explicit = false;
+  const char *clos_id = libcrun_get_intelrdt_name (container_id, def, &explicit);
+
+  if (def && def->linux && def->linux->intel_rdt && def->linux->intel_rdt->enable_monitoring)
+    {
+      int ret;
+
+      ret = resctl_destroy_monitoring_group (clos_id, container_id, err);
+      if (ret < 0)
+        return ret;
+    }
+
+  /* Do not destroy the clos_id if the name was set explicitly.  */
+  if (explicit)
+    return 0;
+
+  return resctl_destroy (clos_id, err);
 }
 
 int
 libcrun_update_intel_rdt (const char *ctr_name, libcrun_container_t *container, const char *l3_cache_schema, const char *mem_bw_schema, char *const *schemata, libcrun_error_t *err)
 {
+  runtime_spec_schema_config_schema *def = NULL;
   const char *name;
 
-  name = libcrun_get_intelrdt_name (ctr_name, container, NULL);
+  if (container)
+    def = container->container_def;
+
+  if (def == NULL || def->linux == NULL || def->linux->intel_rdt == NULL)
+    return 0;
+
+  name = libcrun_get_intelrdt_name (ctr_name, def, NULL);
 
   return resctl_update (name, l3_cache_schema, mem_bw_schema, schemata, err);
 }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -6013,7 +6013,7 @@ libcrun_apply_intelrdt (const char *ctr_name, libcrun_container_t *container, pi
 
   if (actions & LIBCRUN_INTELRDT_CREATE)
     {
-      ret = resctl_create (name, explicit, &created, def->linux->intel_rdt->l3cache_schema, def->linux->intel_rdt->mem_bw_schema, err);
+      ret = resctl_create (name, explicit, &created, def->linux->intel_rdt->l3cache_schema, def->linux->intel_rdt->mem_bw_schema, def->linux->intel_rdt->schemata, err);
       if (UNLIKELY (ret < 0))
         return ret;
     }

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -127,23 +127,11 @@ enum
 
 #define LIBCRUN_INTELRDT_CREATE_UPDATE_MOVE (LIBCRUN_INTELRDT_CREATE | LIBCRUN_INTELRDT_UPDATE | LIBCRUN_INTELRDT_MOVE)
 
-static inline bool
-container_has_intelrdt (libcrun_container_t *container)
-{
-  runtime_spec_schema_config_schema *def = NULL;
-
-  def = container->container_def;
-
-  return def != NULL && def->linux != NULL && def->linux->intel_rdt != NULL;
-}
-
-const char *libcrun_get_intelrdt_name (const char *ctr_name, libcrun_container_t *container, bool *explicit);
-
 int libcrun_apply_intelrdt (const char *ctr_name, libcrun_container_t *container, pid_t pid, int actions, libcrun_error_t *err);
 
 int libcrun_move_network_devices (libcrun_container_t *container, pid_t pid, libcrun_error_t *err);
 
-int libcrun_destroy_intelrdt (const char *name, libcrun_error_t *err);
+int libcrun_destroy_intelrdt (const char *container_id, runtime_spec_schema_config_schema *def, libcrun_error_t *err);
 
 int libcrun_update_intel_rdt (const char *ctr_name, libcrun_container_t *container, const char *l3_cache_schema, const char *mem_bw_schema, char *const *schemata, libcrun_error_t *err);
 

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -272,15 +272,6 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   if (UNLIKELY (r != yajl_gen_status_ok))
     goto yajl_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("intelrdt"), strlen ("intelrdt"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
-
-  tmp = status->intelrdt ? status->intelrdt : "";
-  r = yajl_gen_string (gen, YAJL_STR (tmp), strlen (tmp));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
-
   r = yajl_gen_string (gen, YAJL_STR ("rootfs"), strlen ("rootfs"));
   if (UNLIKELY (r != yajl_gen_status_ok))
     goto yajl_error;
@@ -442,11 +433,6 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
     const char *scope[] = { "scope", NULL };
     tmp = yajl_tree_get (tree, scope, yajl_t_string);
     status->scope = tmp ? xstrdup (YAJL_GET_STRING (tmp)) : NULL;
-  }
-  {
-    const char *intelrdt[] = { "intelrdt", NULL };
-    tmp = yajl_tree_get (tree, intelrdt, yajl_t_string);
-    status->intelrdt = tmp ? xstrdup (YAJL_GET_STRING (tmp)) : NULL;
   }
   {
     const char *rootfs[] = { "rootfs", NULL };
@@ -622,7 +608,6 @@ libcrun_free_container_status (libcrun_container_status_t *status)
   free (status->external_descriptors);
   free (status->created);
   free (status->scope);
-  free (status->intelrdt);
   free (status->owner);
 }
 

--- a/src/libcrun/status.h
+++ b/src/libcrun/status.h
@@ -39,7 +39,6 @@ struct libcrun_container_status_s
   char *rootfs;
   char *cgroup_path;
   char *scope;
-  char *intelrdt;
   int systemd_cgroup;
   char *created;
   int detached;


### PR DESCRIPTION
completely untested, need access to the hardware, leaving as a Draft until then.

## Summary by Sourcery

Enable tracking of monitoring tasks under Intel RDT by adding mon_groups support and wiring enable_monitoring through resctrl operations and container lifecycle

New Features:
- Add support for creating and destroying Intel RDT monitoring sub-groups when enable_monitoring is set

Enhancements:
- Extend resctrl APIs to accept schemata arrays and optional monitoring group names
- Integrate monitoring group lifecycle into libcrun_apply_intelrdt and libcrun_destroy_intelrdt flows
- Remove deprecated intelrdt field from container status serialization and state management