### PR TITLE
status: fix error check

### DIFF
--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -349,7 +349,7 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
     goto yajl_error;
 
   ret = safe_write (fd_write, "status file", buf, len, err);
-  if (UNLIKELY (r < 0))
+  if (UNLIKELY (ret < 0))
     goto exit;
 
   close_and_reset (&fd_write);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the error check to use 'ret' instead of undefined 'r' when verifying safe_write's result