### PR TITLE
Revert "cgroup: do not create a sub-cgroup by default"

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -577,28 +577,26 @@ chown -R the_user.the_user /sys/fs/cgroup/systemd
 .EE
 
 .SH \fBrun.oci.systemd.subgroup=SUBGROUP\fR
-This configuration option allows you to define a sub-cgroup that will
-be created under a systemd-managed cgroup for your container.
-
-.PP
-When SUBGROUP is specified, the complete cgroup path will follow this
-structure:
+Override the name for the systemd sub cgroup created under the systemd
+scope, so the final cgroup will be like:
 
 .EX
 /sys/fs/cgroup/$PATH/$SUBGROUP
 .EE
 
 .PP
-If \fBSUBGROUP\fR is set to \fBcontainer\fR, a typical path could be:
-
-.EX
-/sys/fs/cgroup/system.slice/foo-352700.scope/container
-.EE
+When it is set to the empty string, a sub cgroup is not created.
 
 .PP
-If \fBSUBGROUP\fR is set to an empty string, no sub-cgroup will be
-created.  By default, this option is not configured, meaning no
-sub-cgroup is created unless explicitly set.
+If not specified, it defaults to \fBcontainer\fR on cgroup v2, and to \fB""\fR
+on cgroup v1.
+
+.PP
+e.g.
+
+.EX
+/sys/fs/cgroup//system.slice/foo-352700.scope/container
+.EE
 
 .SH \fBrun.oci.delegate-cgroup=DELEGATED-CGROUP\fR
 If the \fBrun.oci.systemd.subgroup\fR annotation is specified, yet another

--- a/crun.1.md
+++ b/crun.1.md
@@ -489,24 +489,23 @@ chown -R the_user.the_user /sys/fs/cgroup/systemd
 
 ## `run.oci.systemd.subgroup=SUBGROUP`
 
-This configuration option allows you to define a sub-cgroup that will
-be created under a systemd-managed cgroup for your container.
-
-When SUBGROUP is specified, the complete cgroup path will follow this
-structure:
+Override the name for the systemd sub cgroup created under the systemd
+scope, so the final cgroup will be like:
 
 ```
 /sys/fs/cgroup/$PATH/$SUBGROUP
 ```
 
-If `SUBGROUP` is set to `container`, a typical path could be:
-```
-/sys/fs/cgroup/system.slice/foo-352700.scope/container
-```
+When it is set to the empty string, a sub cgroup is not created.
 
-If `SUBGROUP` is set to an empty string, no sub-cgroup will be
-created.  By default, this option is not configured, meaning no
-sub-cgroup is created unless explicitly set.
+If not specified, it defaults to `container` on cgroup v2, and to `""`
+on cgroup v1.
+
+e.g.
+
+```
+/sys/fs/cgroup//system.slice/foo-352700.scope/container
+```
 
 ## `run.oci.delegate-cgroup=DELEGATED-CGROUP`
 

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1987,7 +1987,7 @@ find_systemd_subgroup (string_map *annotations)
       return annotation;
     }
 
-  return NULL;
+  return "container";
 }
 
 static int


### PR DESCRIPTION
Reverts containers/crun#1768

## Summary by Sourcery

Restore the default systemd sub-cgroup behavior by returning "container" when no subgroup is specified and update documentation to match the restored defaults.

Bug Fixes:
- Reinstate default sub-cgroup creation by returning "container" instead of NULL in find_systemd_subgroup.

Documentation:
- Update man page and markdown to document default SUBGROUP as "container" on cgroup v2 and empty on cgroup v1.