### PR TITLE
container: add missing crun_make_error

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3607,7 +3607,7 @@ exec_process_entrypoint (libcrun_context_t *context,
 
   ret = clearenv ();
   if (UNLIKELY (ret < 0))
-    return ret;
+    return crun_make_error (err, errno, "clearenv");
 
   if (process->env_len)
     {
@@ -3772,7 +3772,7 @@ exec_process_entrypoint (libcrun_context_t *context,
                                                exec_path,
                                                process->args);
       if (UNLIKELY (ret < 0))
-        return ret;
+        return crun_make_error (err, -ret, "exec container process failed with handler as `%s`", custom_handler->vtable->name);
 
       _exit (EXIT_FAILURE);
     }


### PR DESCRIPTION
It looks like the errors are missing. 

I reused the error message from here:
https://github.com/containers/crun/blob/92977c0fc843e4649fe4611a97ba12b06cb5073f/src/libcrun/container.c#L1668

Feel free to suggest another error message if it's bad to have exactly the same
error message.

## Summary by Sourcery

Add missing error creation calls to return descriptive errors for environment clearing and process execution failures

Bug Fixes:
- Wrap clearenv failure return with crun_make_error to include error message
- Wrap exec process failure return with crun_make_error to include handler name in error message