### PR TITLE
Add tmt integration plan

### DIFF
--- a/plans/tmt.fmf
+++ b/plans/tmt.fmf
@@ -1,0 +1,9 @@
+/:
+  inherit: false
+
+summary: Run tmt's integration tests
+plan:
+  import:
+    url: https://github.com/teemtee/tmt
+    path: /plans/friends
+    name: /podman


### PR DESCRIPTION
See:
- https://github.com/teemtee/tmt/issues/4047
- https://github.com/teemtee/tmt/pull/4026
- https://github.com/containers/container-selinux/pull/410
- https://github.com/containers/podman/pull/27140

An alternative design is to add the tests in `.packit.yaml`. Let me know which approach would be preferred. I don't quite follow the steps you do with `podman-next*.repo`, maybe we could look into that as well?

(should use only one PR where we discuss and test these)

## Summary by Sourcery

New Features:
- Add a new FMF plan file for tmt-based integration testing