### PR TITLE
tests: fix compiler error

### DIFF
--- a/tests/tests_libcrun_fuzzer.c
+++ b/tests/tests_libcrun_fuzzer.c
@@ -463,7 +463,7 @@ LLVMFuzzerTestOneInput (uint8_t *buf, size_t len)
 }
 
 static void
-sig_chld (int)
+sig_chld (int sig arg_unused)
 {
   int status;
   pid_t p;


### PR DESCRIPTION
the build fails on RHEL 8 with:

tests/tests_libcrun_fuzzer.c: In function 'sig_chld': tests/tests_libcrun_fuzzer.c:466:11: error: parameter name omitted
 sig_chld (int)
           ^~~
make: *** [Makefile:2684: tests/tests_libcrun_fuzzer-tests_libcrun_fuzzer.o] Error 1

## Summary by Sourcery

Tests:
- Name the sig_chld function parameter and annotate it with arg_unused in tests/tests_libcrun_fuzzer.c to satisfy the compiler.