### PR TITLE
configure.ac: check if error function is available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,11 +26,13 @@ AC_PATH_PROG(MD2MAN, go-md2man)
 
 AM_CONDITIONAL([HAVE_MD2MAN], [test "x$ac_cv_path_MD2MAN" != x])
 
-AC_CHECK_HEADERS([error.h linux/openat2.h stdatomic.h linux/ioprio.h])
+AC_CHECK_HEADERS([linux/openat2.h stdatomic.h linux/ioprio.h])
 
 AC_CHECK_TYPES([atomic_int], [], [], [[#include <stdatomic.h>]])
 
 AC_CHECK_FUNCS(eaccess hsearch_r copy_file_range fgetxattr statx fgetpwent_r issetugid memfd_create)
+
+AC_CHECK_HEADER([error.h], [AC_CHECK_FUNC([error], AC_DEFINE([HAVE_ERROR_H], [1], [Define if error.h is usable]))])
 
 case "${lt_cv_prog_compiler_static_works}" in
 	yes) build_tests=true ;;


### PR DESCRIPTION
The configure script is checking if <error.h> is present, but not if error
is actually provided by the library (which is the case with musl).

Add a check for usable error function.

This fixes an issue (https://github.com/containers/crun/issues/1886)
