### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# This is a top-most EditorConfig file.
+root = true
+
+[*.c]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+tab_width = 8
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This is an $EDITOR-neutral way to specify the basic editing rules, like tab width, tabs vs spaces etc. Supported out of the box by Vim, Neovim, Emacs, GitHub and GitLab built-in editors etc. For more info, see https://editorconfig.org/

Note some configs in tests/*.py use both tabs and spaces, and it looks the best with tab_width = 8, thus the value.