### PR TITLE
Buffer Overflow Hardening

### DIFF
--- a/src/libcrun/chroot_realpath.c
+++ b/src/libcrun/chroot_realpath.c
@@ -47,7 +47,7 @@
 
 #define MAX_READLINKS 32
 
-char *chroot_realpath(const char *chroot, const char *path, char resolved_path[])
+char *chroot_realpath(const char *chroot, const char *path, char resolved_path[],unsigned long int size_resolved_path )
 {
 	char copy_path[PATH_MAX];
 	char link_path[PATH_MAX];
@@ -135,7 +135,7 @@ char *chroot_realpath(const char *chroot, const char *path, char resolved_path[]
 		if (n < 0) {
 			/* If a component doesn't exist, then return what we could translate. */
 			if (errno == ENOENT) {
-				int ret = snprintf (resolved_path, PATH_MAX, "%s%s%s", got_path, path[0] == '/' || path[0] == '\0' ? "" : "/", path);
+				int ret = snprintf (resolved_path, size_resolved_path, "%s%s%s", got_path, path[0] == '/' || path[0] == '\0' ? "" : "/", path);
 				if (ret >= PATH_MAX) {
 					__set_errno(ENAMETOOLONG);
 					return NULL;

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -52,7 +52,7 @@
 #  endif
 
 /* Defined in chroot_realpath.c  */
-char *chroot_realpath (const char *chroot, const char *path, char resolved_path[]);
+char *chroot_realpath (const char *chroot, const char *path, char resolved_path[],unsigned long int size_resolved_path);
 
 static const char *console_socket = NULL;
 
@@ -640,7 +640,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
           if (nofollow)
             return crun_make_error (err, 0, "CRIU does not support `src-nofollow` for bind mounts");
 
-          dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf);
+          dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf,sizeof(buf));
           if (UNLIKELY (dest_in_root == NULL))
             {
               if (errno != ENOENT)
@@ -971,7 +971,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
           if (nofollow)
             return crun_make_error (err, 0, "CRIU does not support `src-nofollow` for bind mounts");
 
-          dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf);
+          dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf,sizeof(buf));
           if (UNLIKELY (dest_in_root == NULL))
             {
               if (errno != ENOENT)

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -347,7 +347,7 @@ close_and_replace (int *oldfd, int newfd)
 }
 
 /* Defined in chroot_realpath.c  */
-char *chroot_realpath (const char *chroot, const char *path, char resolved_path[]);
+char *chroot_realpath (const char *chroot, const char *path, char resolved_path[],unsigned long int size_resolved_path);
 
 static int
 safe_openat_fallback (int dirfd, const char *rootfs, const char *path, int flags,
@@ -359,7 +359,7 @@ safe_openat_fallback (int dirfd, const char *rootfs, const char *path, int flags
   size_t rootfs_len = strlen (rootfs);
   int ret;
 
-  path_in_chroot = chroot_realpath (rootfs, path, buffer);
+  path_in_chroot = chroot_realpath (rootfs, path, buffer,sizeof(buffer));
   if (path_in_chroot == NULL)
     return crun_make_error (err, errno, "cannot resolve `%s` under rootfs", path);
 

--- a/tests/tests_libcrun_fuzzer.c
+++ b/tests/tests_libcrun_fuzzer.c
@@ -111,7 +111,7 @@ test_generate_ebpf (uint8_t *buf, size_t len)
   return 0;
 }
 
-char *chroot_realpath (const char *chroot, const char *path, char resolved_path[]);
+char *chroot_realpath (const char *chroot, const char *path, char resolved_path[],sizeof(),unsigned long int size_resolved_path);
 
 static int
 test_chroot_realpath (uint8_t *buf, size_t len)
@@ -123,7 +123,7 @@ test_chroot_realpath (uint8_t *buf, size_t len)
   if (path == NULL)
     return 0;
 
-  chroot_realpath (".", path, resolved_path);
+  chroot_realpath (".", path, resolved_path,sizeof(resolved_path));
   (void) resolved_path;
   return 0;
 }


### PR DESCRIPTION
Hardening against buffer overflow (BOF) vulnerabilities requires more than just limiting the scanfn function with PATH_MAX. This approach doesn't account for scenarios where the buffer is under-allocated