### PR TITLE
BufferOverflow Hardening

### DIFF
--- a/src/libcrun/chroot_realpath.c
+++ b/src/libcrun/chroot_realpath.c
@@ -47,7 +47,7 @@
 
 #define MAX_READLINKS 32
 
-char *chroot_realpath(const char *chroot, const char *path, char resolved_path[])
+char *chroot_realpath(const char *chroot, const char *path, char resolved_path[],size_t size_resolved_path)
 {
 	char copy_path[PATH_MAX];
 	char link_path[PATH_MAX];
@@ -135,8 +135,8 @@ char *chroot_realpath(const char *chroot, const char *path, char resolved_path[]
 		if (n < 0) {
 			/* If a component doesn't exist, then return what we could translate. */
 			if (errno == ENOENT) {
-				int ret = snprintf (resolved_path, PATH_MAX, "%s%s%s", got_path, path[0] == '/' || path[0] == '\0' ? "" : "/", path);
-				if (ret >= PATH_MAX) {
+				int ret = snprintf (resolved_path, size_resolved_path, "%s%s%s", got_path, path[0] == '/' || path[0] == '\0' ? "" : "/", path);
+				if ((ret < 0 || (size_t)ret >= size_resolved_path)) {
 					__set_errno(ENAMETOOLONG);
 					return NULL;
 				}

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -52,7 +52,7 @@
 #  endif
 
 /* Defined in chroot_realpath.c  */
-char *chroot_realpath (const char *chroot, const char *path, char resolved_path[]);
+char *chroot_realpath (const char *chroot, const char *path, char resolved_path[], size_t size_resolved_path);
 
 static const char *console_socket = NULL;
 
@@ -640,7 +640,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
           if (nofollow)
             return crun_make_error (err, 0, "CRIU does not support `src-nofollow` for bind mounts");
 
-          dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf);
+          dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf, sizeof (buf));
           if (UNLIKELY (dest_in_root == NULL))
             {
               if (errno != ENOENT)
@@ -971,7 +971,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
           if (nofollow)
             return crun_make_error (err, 0, "CRIU does not support `src-nofollow` for bind mounts");
 
-          dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf);
+          dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf, sizeof (buf));
           if (UNLIKELY (dest_in_root == NULL))
             {
               if (errno != ENOENT)

--- a/src/libcrun/ebpf.c
+++ b/src/libcrun/ebpf.c
@@ -61,32 +61,32 @@ struct bpf_program
 #ifdef HAVE_EBPF
 
 #  define BPF_ALU32_IMM(OP, DST, IMM) \
-    ((struct bpf_insn) { .code = BPF_ALU | BPF_OP (OP) | BPF_K, .dst_reg = DST, .src_reg = 0, .off = 0, .imm = IMM })
+    ((struct bpf_insn){ .code = BPF_ALU | BPF_OP (OP) | BPF_K, .dst_reg = DST, .src_reg = 0, .off = 0, .imm = IMM })
 
 #  define BPF_LDX_MEM(SIZE, DST, SRC, OFF) \
-    ((struct bpf_insn) {                   \
+    ((struct bpf_insn){                    \
         .code = BPF_LDX | BPF_SIZE (SIZE) | BPF_MEM, .dst_reg = DST, .src_reg = SRC, .off = OFF, .imm = 0 })
 
 #  define BPF_MOV64_REG(DST, SRC) \
-    ((struct bpf_insn) { .code = BPF_ALU64 | BPF_MOV | BPF_X, .dst_reg = DST, .src_reg = SRC, .off = 0, .imm = 0 })
+    ((struct bpf_insn){ .code = BPF_ALU64 | BPF_MOV | BPF_X, .dst_reg = DST, .src_reg = SRC, .off = 0, .imm = 0 })
 
 #  define BPF_JMP_A(OFF) \
-    ((struct bpf_insn) { .code = BPF_JMP | BPF_JA, .dst_reg = 0, .src_reg = 0, .off = OFF, .imm = 0 })
+    ((struct bpf_insn){ .code = BPF_JMP | BPF_JA, .dst_reg = 0, .src_reg = 0, .off = OFF, .imm = 0 })
 
 #  define BPF_JMP_IMM(OP, DST, IMM, OFF) \
-    ((struct bpf_insn) { .code = BPF_JMP | BPF_OP (OP) | BPF_K, .dst_reg = DST, .src_reg = 0, .off = OFF, .imm = IMM })
+    ((struct bpf_insn){ .code = BPF_JMP | BPF_OP (OP) | BPF_K, .dst_reg = DST, .src_reg = 0, .off = OFF, .imm = IMM })
 
 #  define BPF_JMP_REG(OP, DST, SRC, OFF) \
-    ((struct bpf_insn) { .code = BPF_JMP | BPF_OP (OP) | BPF_X, .dst_reg = DST, .src_reg = SRC, .off = OFF, .imm = 0 })
+    ((struct bpf_insn){ .code = BPF_JMP | BPF_OP (OP) | BPF_X, .dst_reg = DST, .src_reg = SRC, .off = OFF, .imm = 0 })
 
 #  define BPF_MOV64_IMM(DST, IMM) \
-    ((struct bpf_insn) { .code = BPF_ALU64 | BPF_MOV | BPF_K, .dst_reg = DST, .src_reg = 0, .off = 0, .imm = IMM })
+    ((struct bpf_insn){ .code = BPF_ALU64 | BPF_MOV | BPF_K, .dst_reg = DST, .src_reg = 0, .off = 0, .imm = IMM })
 
 #  define BPF_MOV32_REG(DST, SRC) \
-    ((struct bpf_insn) { .code = BPF_ALU | BPF_MOV | BPF_X, .dst_reg = DST, .src_reg = SRC, .off = 0, .imm = 0 })
+    ((struct bpf_insn){ .code = BPF_ALU | BPF_MOV | BPF_X, .dst_reg = DST, .src_reg = SRC, .off = 0, .imm = 0 })
 
 #  define BPF_EXIT_INSN() \
-    ((struct bpf_insn) { .code = BPF_JMP | BPF_EXIT, .dst_reg = 0, .src_reg = 0, .off = 0, .imm = 0 })
+    ((struct bpf_insn){ .code = BPF_JMP | BPF_EXIT, .dst_reg = 0, .src_reg = 0, .off = 0, .imm = 0 })
 #endif
 
 #ifdef HAVE_EBPF

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -347,7 +347,7 @@ close_and_replace (int *oldfd, int newfd)
 }
 
 /* Defined in chroot_realpath.c  */
-char *chroot_realpath (const char *chroot, const char *path, char resolved_path[]);
+char *chroot_realpath (const char *chroot, const char *path, char resolved_path[], size_t size_resolved_path);
 
 static int
 safe_openat_fallback (int dirfd, const char *rootfs, const char *path, int flags,
@@ -359,7 +359,7 @@ safe_openat_fallback (int dirfd, const char *rootfs, const char *path, int flags
   size_t rootfs_len = strlen (rootfs);
   int ret;
 
-  path_in_chroot = chroot_realpath (rootfs, path, buffer);
+  path_in_chroot = chroot_realpath (rootfs, path, buffer, sizeof (buffer));
   if (path_in_chroot == NULL)
     return crun_make_error (err, errno, "cannot resolve `%s` under rootfs", path);
 
@@ -2297,9 +2297,9 @@ copy_recursive_fd_to_fd (int srcdirfd, int dfd, const char *srcname, const char 
       if (UNLIKELY (ret < 0))
         return crun_make_error (err, errno, "fchownat `%s/%s`", destname, de->d_name);
 
-      /*
-       * ALLPERMS is not defined by POSIX
-       */
+        /*
+         * ALLPERMS is not defined by POSIX
+         */
 #ifndef ALLPERMS
 #  define ALLPERMS (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO)
 #endif

--- a/tests/init.c
+++ b/tests/init.c
@@ -370,7 +370,7 @@ memhog (int megabytes)
   while (1)
     {
       /* change one page each 0.1 seconds */
-      nanosleep ((const struct timespec[]) { { 0, 100000000L } }, NULL);
+      nanosleep ((const struct timespec[]){ { 0, 100000000L } }, NULL);
       buf[pos] = 'c';
       pos += sysconf (_SC_PAGESIZE);
       if (pos > megabytes * 1024 * 1024)

--- a/tests/tests_libcrun_fuzzer.c
+++ b/tests/tests_libcrun_fuzzer.c
@@ -111,7 +111,7 @@ test_generate_ebpf (uint8_t *buf, size_t len)
   return 0;
 }
 
-char *chroot_realpath (const char *chroot, const char *path, char resolved_path[]);
+char *chroot_realpath (const char *chroot, const char *path, char resolved_path[], size_t size_resolved_path);
 
 static int
 test_chroot_realpath (uint8_t *buf, size_t len)
@@ -123,7 +123,7 @@ test_chroot_realpath (uint8_t *buf, size_t len)
   if (path == NULL)
     return 0;
 
-  chroot_realpath (".", path, resolved_path);
+  chroot_realpath (".", path, resolved_path, sizeof (resolved_path));
   (void) resolved_path;
   return 0;
 }
@@ -496,7 +496,7 @@ main (int argc, char **argv)
       return LLVMFuzzerTestOneInput (content, len);
     }
 #ifdef FUZZER
-  extern void HF_ITER (uint8_t **buf, size_t *len);
+  extern void HF_ITER (uint8_t * *buf, size_t * len);
   for (;;)
     {
       size_t len;


### PR DESCRIPTION
Added a new argument to chroot_realpath to support small buffers.
As discussed in the previous pull request, this change helps avoid technical debt and enforces a security boundary by design, rather than relying on the programmer to implement it correctly.

## Summary by Sourcery

Harden chroot_realpath against buffer overflows by adding an explicit buffer size parameter to its signature, updating all callers and the test harness to supply buffer length, and using the size in snprintf.

Enhancements:
- Add size_resolved_path parameter to chroot_realpath signature in criu.c, utils.c, and chroot_realpath.c
- Use size_resolved_path in snprintf calls within chroot_realpath to cap output length
- Update all chroot_realpath invocations to pass the buffer size argument

Tests:
- Update test_chroot_realpath in the fuzzer to supply buffer size to the new chroot_realpath signature