### PR TITLE
libcrun/cgroup: always enable TasksAccounting for systemd

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1761,9 +1761,11 @@ enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *resource
         boolean_opts[i++] = "MemoryAccounting";
       if (resources->block_io)
         boolean_opts[i++] = "IOAccounting";
-      if (resources->pids)
-        boolean_opts[i++] = "TasksAccounting";
     }
+  /* Always enable TasksAccounting to ensure the pids controller is available.
+   * This allows container managers to read pids.current even when no explicit
+   * pids limit is set. */
+  boolean_opts[i++] = "TasksAccounting";
   boolean_opts[i++] = NULL;
 
   ret = open_sd_bus_connection (&bus, err);


### PR DESCRIPTION
When using systemd cgroup driver with cgroup v2, unconditionally enable TasksAccounting. This ensures the pids controller is available even when no explicit pids resource limit is configured.

Without this, CRI-O cannot read pids.current from the cgroup, resulting in ProcessCount being reported as 0 for pod sandboxes. This causes Kubernetes Summary API conformance tests to fail.

The issue manifests specifically with pause/infra containers which typically do not have pids limits configured, leading to TasksAccounting not being enabled in the systemd scope properties.

This behavior matches what runc has been doing for a long time, where it unconditionally enables `TasksAccounting` for cgroup v2.

Fixes: https://github.com/cri-o/cri-o/issues/9536

## Summary by Sourcery

Unconditionally enable TasksAccounting in systemd cgroup v2 scopes to ensure the pids controller is available and fix ProcessCount reporting in CRI-O.

Bug Fixes:
- Always enable TasksAccounting in systemd cgroup scopes even when no pids limit is configured

Enhancements:
- Align libcrun behavior with runc by unconditionally enabling TasksAccounting for cgroup v2