### PR TITLE
cgroup-systemd: enable all accounting properties to ensure stats are readable

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1753,18 +1753,12 @@ enter_systemd_cgroup_scope (runtime_spec_schema_config_linux_resources *resource
 
   i = 0;
   boolean_opts[i++] = "Delegate";
-  if (resources)
-    {
-      if (resources->cpu)
-        boolean_opts[i++] = "CPUAccounting";
-      if (resources->memory)
-        boolean_opts[i++] = "MemoryAccounting";
-      if (resources->block_io)
-        boolean_opts[i++] = "IOAccounting";
-    }
-  /* Always enable TasksAccounting to ensure the pids controller is available.
-   * This allows container managers to read pids.current even when no explicit
-   * pids limit is set. */
+
+  /* Always enable all accounting to ensure stats are readable even
+   * without resource limits. */
+  boolean_opts[i++] = "CPUAccounting";
+  boolean_opts[i++] = "MemoryAccounting";
+  boolean_opts[i++] = "IOAccounting";
   boolean_opts[i++] = "TasksAccounting";
   boolean_opts[i++] = NULL;
 


### PR DESCRIPTION
Currently, `crun` conditionally enables `CPUAccounting`, `MemoryAccounting`, and `IOAccounting` only when corresponding resource limits are set. This breaks Kubernetes conformance tests and metrics collection for containers without resource limits. 

This PR enable those properties unconditionally to match `runc` behavior. This ensures cgroup stats are readable even for containers without resource limits.

## Summary by Sourcery

Unconditionally enable CPUAccounting, MemoryAccounting, and IOAccounting in the systemd cgroup driver to ensure container stats are always readable even without resource limits.

Bug Fixes:
- Fix broken metrics collection and Kubernetes conformance failures for containers without resource limits by matching runc behavior.

Enhancements:
- Always enable CPUAccounting, MemoryAccounting, and IOAccounting for systemd cgroup scopes.