### PR TITLE
linux: honor execCPUAffinity from main configuration file

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5078,12 +5078,9 @@ handle_pidfd_receiver (pid_t pid, libcrun_container_t *container, libcrun_error_
 }
 
 static bool
-has_exec_cpu_affinity (runtime_spec_schema_config_schema_process *process)
+has_exec_cpu_affinity (runtime_spec_schema_config_schema_process_exec_cpu_affinity *affinity)
 {
-  if (process == NULL || process->exec_cpu_affinity == NULL)
-    return false;
-  return (! is_empty_string (process->exec_cpu_affinity->initial))
-         || (! is_empty_string (process->exec_cpu_affinity->final));
+  return affinity && ((! is_empty_string (affinity->initial)) || (! is_empty_string (affinity->final)));
 }
 
 pid_t
@@ -5378,6 +5375,7 @@ join_process_parent_helper (libcrun_context_t *context,
   char res;
   pid_t pid;
   cleanup_close int sync_fd = sync_socket_fd;
+  runtime_spec_schema_config_schema_process_exec_cpu_affinity *cpu_affinity = NULL;
 
   if (terminal_fd)
     *terminal_fd = -1;
@@ -5400,13 +5398,18 @@ join_process_parent_helper (libcrun_context_t *context,
     return crun_make_error (err, errno, "waitpid for exec child pid");
 
   if (process && process->exec_cpu_affinity)
+    cpu_affinity = process->exec_cpu_affinity;
+  else if (container && container->container_def && container->container_def->process && container->container_def->process->exec_cpu_affinity)
+    cpu_affinity = container->container_def->process->exec_cpu_affinity;
+
+  if (cpu_affinity)
     {
-      ret = libcrun_set_cpu_affinity_from_string (pid, process->exec_cpu_affinity->initial, err);
+      ret = libcrun_set_cpu_affinity_from_string (pid, cpu_affinity->initial, err);
       if (UNLIKELY (ret < 0))
         return ret;
     }
 
-  if (! has_exec_cpu_affinity (process))
+  if (! has_exec_cpu_affinity (cpu_affinity))
     {
       ret = libcrun_reset_cpu_affinity_mask (pid, err);
       if (UNLIKELY (ret < 0))
@@ -5440,9 +5443,9 @@ join_process_parent_helper (libcrun_context_t *context,
         return ret;
     }
 
-  if (process && process->exec_cpu_affinity)
+  if (cpu_affinity)
     {
-      ret = libcrun_set_cpu_affinity_from_string (pid, process->exec_cpu_affinity->final, err);
+      ret = libcrun_set_cpu_affinity_from_string (pid, cpu_affinity->final, err);
       if (UNLIKELY (ret < 0))
         return ret;
     }

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -477,6 +477,66 @@ def test_exec_cpu_affinity():
         shutil.rmtree(tempdir)
     return 0
 
+def test_exec_cpu_affinity_config_file():
+    """Test that exec honors execCPUAffinity from container configuration when not specified in exec process"""
+    if len(os.sched_getaffinity(0)) < 4:
+        return 77
+
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'pause']
+    # Set execCPUAffinity in the container's main process configuration
+    conf['process']['execCPUAffinity'] = {"initial": "0-1", "final": "0-2"}
+    add_all_namespaces(conf)
+    cid = None
+    tempdir = tempfile.mkdtemp()
+
+    def cpu_mask_from_proc_status(status):
+        for l in status.split("\n"):
+            parts = l.split(":")
+            if parts[0] == "Cpus_allowed_list":
+                return parts[1].strip()
+        return ""
+
+    def exec_without_cpu_affinity_and_get_mask(cid):
+        """Execute a process without specifying execCPUAffinity and get its CPU mask"""
+        process_file = os.path.join(tempdir, "process.json")
+        with open(process_file, "w") as f:
+            process = {
+                "user": {
+                    "uid": 0,
+                    "gid": 0
+                },
+                "terminal": False,
+                "cwd": "/",
+                "args": [
+                    "/init",
+                    "cat",
+                    "/proc/self/status"
+                ]
+                # Note: No execCPUAffinity specified here - should fall back to container config
+            }
+            json.dump(process, f)
+
+        out = run_crun_command(["exec", "--process", process_file, cid])
+        return cpu_mask_from_proc_status(out)
+
+    try:
+        _, cid = run_and_get_output(conf, command='run', detach=True)
+
+        # Execute without specifying execCPUAffinity - should use container's config final value
+        mask = exec_without_cpu_affinity_and_get_mask(cid)
+        if mask != "0-2":
+            sys.stderr.write("# execCPUAffinity fallback test failed: cpu mask %s != 0-2\n" % mask)
+            sys.stderr.write("# expected to use container's execCPUAffinity.final value\n")
+            return -1
+
+        return 0
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+        shutil.rmtree(tempdir)
+    return 0
+
 def test_exec_getpgrp():
     conf = base_config()
     add_all_namespaces(conf)
@@ -553,6 +613,7 @@ all_tests = {
     "exec_populate_home_env_from_process_uid" : test_exec_populate_home_env_from_process_uid,
     "exec-test-uid-tty": test_uid_tty,
     "exec-cpu-affinity": test_exec_cpu_affinity,
+    "exec-cpu-affinity-config-file": test_exec_cpu_affinity_config_file,
     "exec-getpgrp": test_exec_getpgrp,
     "exec-help" : test_exec_help,
     "exec-error-propagation" : test_exec_error_propagation,


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/OCPBUGS-65579

## Summary by Sourcery

Support honoring execCPUAffinity values defined in the container’s main config file for `exec` commands and add a test to verify the fallback behavior

Bug Fixes:
- Honor execCPUAffinity settings from the container's main configuration when no execCPUAffinity is specified for exec processes

Enhancements:
- Refactor has_exec_cpu_affinity to accept an affinity pointer and simplify CPU affinity handling in join_process_parent_helper
- Add logic to fall back to container configuration’s execCPUAffinity when executing new processes

Tests:
- Add test_exec_cpu_affinity_config_file to verify fallback to container’s execCPUAffinity when not provided during exec