### PR TITLE
container: fix error release

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1233,13 +1233,13 @@ setup_executable_path (struct container_entrypoint_s *entrypoint_args, runtime_s
         {
           if (entrypoint_args->custom_handler == NULL && crun_error_get_errno (err) == ENOENT)
             return ret;
-        }
 
-      /* If it fails for any other reason, ignore the failure.  We'll try again the lookup
-         once the process switched to the use that runs in the container.  This might be necessary
-         when opening a file that is on a network file system like NFS, where CAP_DAC_OVERRIDE
-         is not honored.  */
-      crun_error_release (err);
+          /* If it fails for any other reason, ignore the failure.  We'll try again the lookup
+             once the process switched to the use that runs in the container.  This might be necessary
+             when opening a file that is on a network file system like NFS, where CAP_DAC_OVERRIDE
+             is not honored.  */
+          crun_error_release (err);
+        }
     }
 
   return 0;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix potential misuse of error release by ensuring crun_error_release is only called when an error is present and within the appropriate conditional scope.