### PR TITLE
linux: handle openat error

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2662,9 +2662,11 @@ make_parent_mount_private (const char *rootfs, libcrun_error_t *err)
       parentfd = openat (rootfsfd, "..", O_PATH | O_CLOEXEC);
       if (parentfd < 0)
         {
+          int saved_errno = errno;
           ret = faccessat (rootfsfd, "..", X_OK, AT_EACCESS);
           if (ret != 0)
             return crun_make_error (err, EACCES, "make `%s` private: a component is not accessible", rootfs);
+          return crun_make_error (err, saved_errno, "make `%s` private: cannot open component", rootfs);
         }
 
       close_and_reset (&rootfsfd);


### PR DESCRIPTION
Fail early to make the code easier to read.

What do you think? Does it make sense?

## Summary by Sourcery

Bug Fixes:
- Return a specific error when opening the parent directory component fails instead of silently continuing after access checks.