### PR TITLE
linux: run createContainer hooks before making root RO

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1353,6 +1353,10 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
         return ret;
     }
 
+  ret = libcrun_finalize_mounts (entrypoint_args, container, rootfs, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   if (def->process)
     {
       ret = libcrun_set_selinux_label (container, def->process, false, err);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2802,6 +2802,14 @@ libcrun_set_mounts (struct container_entrypoint_s *entrypoint_args, libcrun_cont
   if (UNLIKELY (ret < 0))
     return ret;
 
+  return 0;
+}
+
+int
+libcrun_finalize_mounts (struct container_entrypoint_s *entrypoint_args, libcrun_container_t *container, const char *rootfs, libcrun_error_t *err)
+{
+  int ret;
+
   ret = finalize_mounts (container, err);
   if (UNLIKELY (ret < 0))
     return ret;

--- a/src/libcrun/linux.h
+++ b/src/libcrun/linux.h
@@ -65,6 +65,8 @@ int get_notify_fd (libcrun_context_t *context, libcrun_container_t *container, i
                    libcrun_error_t *err);
 int libcrun_set_mounts (struct container_entrypoint_s *args, libcrun_container_t *container, const char *rootfs,
                         set_mounts_cb_t cb, void *cb_data, libcrun_error_t *err);
+int libcrun_finalize_mounts (struct container_entrypoint_s *entrypoint_args, libcrun_container_t *container,
+                             const char *rootfs, libcrun_error_t *err);
 int libcrun_init_caps (libcrun_container_t *container, libcrun_error_t *err);
 int libcrun_do_pivot_root (libcrun_container_t *container, bool no_pivot, const char *rootfs, libcrun_error_t *err);
 int libcrun_reopen_dev_null (libcrun_error_t *err);


### PR DESCRIPTION
Closes: https://github.com/containers/crun/issues/1924

## Summary by Sourcery

Call root filesystem mount finalization earlier in container initialization to adjust hook execution order.

Bug Fixes:
- Ensure container hooks that depend on a writable root filesystem run before the root mount is made read-only.

Enhancements:
- Extract root filesystem mount finalization into a dedicated libcrun_do_finalize_mounts helper and wire it into container initialization flow.