### PR TITLE
cgroup-systemd: fix race condition

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -484,12 +484,13 @@ systemd_job_removed (sd_bus_message *m, void *userdata, sd_bus_error *error arg_
 
   if (strcmp (d->path, path) == 0)
     {
-      d->terminated = 1;
       if (strcmp (result, "done") != 0)
         {
           crun_make_error (&d->err, 0, "error `%s` systemd unit `%s`: got `%s`", d->op, unit, result);
+          d->terminated = 1;
           return -1;
         }
+        d->terminated = 1;
     }
   return 0;
 }


### PR DESCRIPTION
What do you think? Does this make sense?

I'm looking at

* https://github.com/containers/crun/blob/5d9977e01eaccd24c33e79a53de7f7b95f79f0be/src/libcrun/cgroup-systemd.c#L518-L536

and wonder if it could ever happen that `data->err` is `NULL` here

* https://github.com/containers/crun/blob/5d9977e01eaccd24c33e79a53de7f7b95f79f0be/src/libcrun/cgroup-systemd.c#L532

while another thread is about to create the error here:

https://github.com/containers/crun/blob/5d9977e01eaccd24c33e79a53de7f7b95f79f0be/src/libcrun/cgroup-systemd.c#L490

If those functions (`systemd_job_removed()` and `systemd_check_job_status()`) run independently of each other, it looks like such scenario could happen.

## Summary by Sourcery

Bug Fixes:
- Fix a race condition where the systemd job termination flag could be set before any associated error was recorded, potentially leaving the error state inconsistent.