### PR TITLE
krun: do not leak handles on error

### DIFF
--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -635,10 +635,7 @@ libkrun_load (void **cookie, libcrun_error_t *err)
     {
       ret = libkrun_create_context (kconf->handle, err);
       if (UNLIKELY (ret < 0))
-        {
-          free (kconf);
-          return ret;
-        }
+        goto error;
       kconf->ctx_id = ret;
     }
 
@@ -646,26 +643,30 @@ libkrun_load (void **cookie, libcrun_error_t *err)
     {
       ret = libkrun_create_context (kconf->handle_sev, err);
       if (UNLIKELY (ret < 0))
-        {
-          free (kconf);
-          return ret;
-        }
+        goto error;
       kconf->ctx_id_sev = ret;
     }
   if (kconf->handle_nitro)
     {
       ret = libkrun_create_context (kconf->handle_nitro, err);
       if (UNLIKELY (ret < 0))
-        {
-          free (kconf);
-          return ret;
-        }
+        goto error;
       kconf->ctx_id_nitro = ret;
     }
 
   *cookie = kconf;
 
   return 0;
+
+error:
+  if (kconf->handle)
+    dlclose (kconf->handle);
+  if (kconf->handle_sev)
+    dlclose (kconf->handle_sev);
+  if (kconf->handle_nitro)
+    dlclose (kconf->handle_nitro);
+  free (kconf);
+  return ret;
 }
 
 static int
@@ -682,6 +683,19 @@ libkrun_unload (void *cookie, libcrun_error_t *err)
           if (UNLIKELY (r != 0))
             return crun_make_error (err, 0, "could not unload handle: `%s`", dlerror ());
         }
+      if (kconf->handle_sev != NULL)
+        {
+          r = dlclose (kconf->handle_sev);
+          if (UNLIKELY (r != 0))
+            return crun_make_error (err, 0, "could not unload handle_sev: `%s`", dlerror ());
+        }
+      if (kconf->handle_nitro != NULL)
+        {
+          r = dlclose (kconf->handle_nitro);
+          if (UNLIKELY (r != 0))
+            return crun_make_error (err, 0, "could not unload handle_nitro: `%s`", dlerror ());
+        }
+      free (kconf);
     }
   return 0;
 }


### PR DESCRIPTION
## Summary by Sourcery

Ensure libkrun contexts and associated handles are properly cleaned up on errors and unload.

Bug Fixes:
- Prevent handle leaks by centralizing error cleanup in libkrun_load and closing all opened handles on failure.
- Close sev and nitro libkrun handles in libkrun_unload to avoid leaking library handles and memory.