### PR TITLE
container: fix error release

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1825,6 +1825,7 @@ container_delete_internal (libcrun_context_t *context, runtime_spec_schema_confi
           crun_error_release (&tmp_err);
           return 0;
         }
+      crun_error_release (err);
       return libcrun_container_delete_status (state_root, id, err);
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Release the error object prior to returning from container delete status handling to avoid leaking error state.