### PR TITLE
Move notify handler before mounts to primary uid namespace

### DIFF
--- a/src/libcrun/container.h
+++ b/src/libcrun/container.h
@@ -29,6 +29,7 @@ enum handler_configure_phase
   HANDLER_CONFIGURE_BEFORE_MOUNTS = 1,
   HANDLER_CONFIGURE_AFTER_MOUNTS,
   HANDLER_CONFIGURE_MOUNTS,
+  HANDLER_CONFIGURE_BEFORE_USERNS
 };
 
 struct custom_handler_manager_s;

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -467,7 +467,7 @@ libkrun_configure_container (void *cookie, enum handler_configure_phase phase,
         return crun_make_error (err, errno, "open `%s`", rootfs);
     }
 
-  if (phase == HANDLER_CONFIGURE_BEFORE_MOUNTS)
+  if (phase == HANDLER_CONFIGURE_BEFORE_USERNS)
     {
       cleanup_free char *origin_config_path = NULL;
       cleanup_free char *state_dir = NULL;

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5033,6 +5033,11 @@ libcrun_run_linux_container (libcrun_container_t *container, container_entrypoin
   if (UNLIKELY (ret < 0))
     return ret;
 
+  ret = libcrun_container_notify_handler (args, HANDLER_CONFIGURE_BEFORE_USERNS, container,
+                                          container->container_def->root ? container->container_def->root->path : NULL, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   /* If a new user namespace must be created, but there are other namespaces to join, then delay
      the userns creation after the namespaces are joined.  */
   init_status.delayed_userns_create


### PR DESCRIPTION
containers/podman#27822

In `krun`, the `clone3` call places the process in the mapped namespace where it lacks sufficient permissions to read or write the container's definition file. This issue can be resolved by moving the handler invocation to occur before the `clone3` call. 

Existing handlers in `crun` are unaffected, as none—except for `krun`—process actions in `HANDLER_CONFIGURE_BEFORE_MOUNTS`, so should not break other handlers.