### PR TITLE
krun: fix libkrun_exec return value

### DIFF
--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -430,7 +430,7 @@ libkrun_exec (void *cookie, libcrun_container_t *container, const char *pathname
         {
           ret = libkrun_enable_virtio_gpu (kconf);
           if (UNLIKELY (ret < 0))
-            return ret;
+            return -ret;
         }
     }
 


### PR DESCRIPTION
While reading the file krun.c I noticed a missing minus sign.