### PR TITLE
container: fix error leak

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -808,6 +808,10 @@ do_hooks (runtime_spec_schema_config_schema *def, pid_t pid, const char *id, boo
       if (hooks[i]->env)
         env = hooks[i]->env;
 
+      /* Release the error from the previous iteration, if any.  */
+      if (err && *err)
+        crun_error_release (err);
+
       ret = run_process_with_stdin_timeout_envp (hooks[i]->path, hooks[i]->args, cwd, hooks[i]->timeout, env,
                                                  stdin, stdin_len, out_fd, err_fd, err);
       if (UNLIKELY (ret != 0))


### PR DESCRIPTION
print the current error and release it.

Closes: https://github.com/containers/crun/issues/1957