### PR TITLE
libcrun: standardize error code after `yajl_gen_alloc()` failure

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -4242,7 +4242,7 @@ libcrun_container_update_from_values (libcrun_context_t *context, const char *id
 
   gen = yajl_gen_alloc (NULL);
   if (gen == NULL)
-    return crun_make_error (err, errno, "yajl_gen_create failed");
+    return crun_make_error (err, 0, "yajl_gen_alloc failed");
   yajl_gen_map_open (gen);
 
   qsort (values, len, sizeof (struct libcrun_update_value_s), compare_update_values);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3738,7 +3738,7 @@ libcrun_save_external_descriptors (libcrun_container_t *container, pid_t pid, li
 
   gen = yajl_gen_alloc (NULL);
   if (gen == NULL)
-    return crun_make_error (err, errno, "yajl_gen_alloc");
+    return crun_make_error (err, 0, "yajl_gen_alloc");
 
   ret = yajl_gen_array_open (gen);
   if (UNLIKELY (ret != yajl_gen_status_ok))


### PR DESCRIPTION
The libcrun source code sometimes use `0` and sometimes `errno` as error code after `yajl_gen_alloc()` failures. 
Use `0` everywhere.