### PR TITLE
ci: fix test (check) flake caused by older md2man

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,7 +128,7 @@ jobs:
                   unshare -r make check ASAN_OPTIONS=detect_leaks=false || (cat test-suite.log; exit 1)
 
                   git status
-                  git diff
+                  git diff --exit-code
 
                   # check that the working dir is clean
                   git describe --broken --dirty --all | grep -qv dirty


### PR DESCRIPTION
Sometimes (but not always) make wants to re-generate the man pages
in CI while the sources haven't changed in fact. Sometimes the man
pages are actually changed, so CI needs to check if the generated
man pages is updated accordingly.
    
Either way, it fails because Ubuntu has an older version of go-md2man.
    
This is not easy to fix in a decent manner but the not-so-decent is
to install the latest md2man from source, this is what this patch does.

(the decent way would be to run man page generation in a fedora container, I guess, but it seems like too much)
