### PR TITLE
linux: drop unnecessary code

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -629,7 +629,6 @@ libcrun_create_keyring (libcrun_container_t *container, const char *name, const 
             return labelfd;
 
           crun_error_release (err);
-          labelfd = -1;
         }
 
       if (labelfd >= 0)


### PR DESCRIPTION
Any negative number will do. There is no need to explicitly set `labelfd` to `-1`.

cleanup_close only closes when the number is non-negative.

https://github.com/containers/crun/blob/d0c1224f0d4d3525b8a3414efe3dbc5f3177637f/src/libcrun/utils.h#L103-L109