### PR TITLE
linux: fix copy_from_fd ownership

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -2250,6 +2250,7 @@ copy_recursive_fd_to_fd (int srcdirfd, int dfd, const char *srcname, const char 
             return ret;
 #endif
 
+          // copy_recursive_fd_to_fd closes srcfd and destfd
           ret = copy_recursive_fd_to_fd (srcfd, destfd, de->d_name, de->d_name, err);
           srcfd = destfd = -1;
           if (UNLIKELY (ret < 0))


### PR DESCRIPTION
Fix some issues regarding file descriptor ownership.

Initial investigation in https://github.com/containers/crun/issues/2002
(I found these when reading the source code)