### PR TITLE
utils: refactor set_home_env

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1186,7 +1186,7 @@ setup_environment (runtime_spec_schema_config_schema *def, uid_t container_uid, 
   if (getenv ("HOME") == NULL)
     {
       ret = set_home_env (container_uid);
-      if (UNLIKELY (ret < 0 && errno != ENOTSUP))
+      if (UNLIKELY (ret < 0))
         {
           setenv ("HOME", "/", 1);
           libcrun_warning ("cannot detect HOME environment variable, setting default");
@@ -3689,7 +3689,7 @@ exec_process_entrypoint (libcrun_context_t *context,
   if (getenv ("HOME") == NULL)
     {
       ret = set_home_env (container_uid);
-      if (UNLIKELY (ret < 0 && errno != ENOTSUP))
+      if (UNLIKELY (ret < 0))
         {
           setenv ("HOME", "/", 1);
           libcrun_warning ("cannot detect HOME environment variable, setting default");


### PR DESCRIPTION
Use the return value from fgetpwent_r as error value. Reference:
https://man7.org/linux/man-pages/man3/fgetpwent_r.3.html#RETURN_VALUE

Closes: https://github.com/containers/crun/issues/2010