### PR TITLE
ci: simplify codespell job

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 skip = libocispec,build-aux,contrib,*.1,.git,configure,Makefile,libtool,m4,autom4te.cache,*.m4,*.mk
 count =
-ignore-words-list = trun,ser
+ignore-words-list = ser

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -186,8 +186,8 @@ jobs:
                   sudo docker run --cgroupns=host -e RUN_TIME=300 --privileged --rm -v /sys/fs/cgroup:/sys/fs/cgroup:rw,rslave -v ${PWD}:/crun crun-fuzzing
               ;;
               codespell)
-                  sudo docker build -t crun-codespell tests/codespell
-                  sudo docker run --rm -w /crun -v ${PWD}:/crun crun-codespell codespell -q 0
+                  pip install --break-system-packages codespell==v2.4.1 # Use known version
+                  codespell
               ;;
               wasmedge-build)
                   sudo docker build -t wasmedge tests/wasmedge-build

--- a/tests/codespell/Dockerfile
+++ b/tests/codespell/Dockerfile
@@ -1,3 +1,0 @@
-FROM fedora:latest
-
-RUN dnf install -y awk codespell && yum clean all -y


### PR DESCRIPTION
We don't really need to run Fedora container in order to execute codespell. Inspired by a recent dockerhub reject.

Notes:
 - we use pip so we don't depend on whatever version is installed on the host (Ubuntu);
 - since Ubuntu 24.04, --break-system-packages is required;
 - we use a specified version to avoid unexpected CI failures caused by newer codespell.

While at it, remove an exclusion from .codespellrc -- apparently no longer needed.