### PR TITLE
net_device: correctly handle error

### DIFF
--- a/src/libcrun/net_device.c
+++ b/src/libcrun/net_device.c
@@ -474,7 +474,7 @@ move_network_device (const char *ifname, const char *newifname, int netns_fd, li
     {
       ret = setup_network_device_in_ns_helper (buffer, buffer_size, netns_fd, newifname, ips, err);
       if (UNLIKELY (ret < 0))
-        _safe_exit (-ret);
+        _safe_exit (crun_error_get_errno (err));
 
       _safe_exit (0);
     }
@@ -483,8 +483,9 @@ move_network_device (const char *ifname, const char *newifname, int netns_fd, li
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "waitpid for exec child pid");
 
-  if (wait_status != 0)
-    return -get_process_exit_status (wait_status);
+  ret = get_process_exit_status (wait_status);
+  if (ret > 0)
+    return crun_make_error (err, ret, "set up network device");
 
   return 0;
 }


### PR DESCRIPTION
Use errno as exit value when move_network_device fails.

Add missing crun_make_error.

Closes: https://github.com/containers/crun/issues/2015
Closes: https://github.com/containers/crun/issues/2016