### PR TITLE
status: drop unnecessary strtoll

### DIFF
--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -801,7 +801,7 @@ libcrun_status_write_exec_fifo (const char *state_root, const char *id, libcrun_
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "write to exec.fifo");
 
-  return strtoll (buffer, NULL, 10);
+  return 0;
 }
 
 int


### PR DESCRIPTION
I noticed this when reading the source code.

First I was wondering if the function could return a negative number without creating an error,
but then I realised `strtoll()` is just some old code that can be removed.