### PR TITLE
Fix centos-stream-9 tmt tests

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -18,6 +18,14 @@ prepare:
         fi
         dnf -y upgrade --allowerasing
       order: 20
+
+    # TODO: Remove once https://issues.redhat.com/browse/RHEL-153064 is fixed.
+    - when: distro == centos-stream-9
+      how: install
+      package:
+        - iptables-legacy
+      order: 30
+
     - how: install
       package:
         - bats


### PR DESCRIPTION
... by installing iptables-legacy. Otherwise podman checkpoint tests fail.

See also: https://issues.redhat.com/browse/RHEL-153064