### PR TITLE
pass cgroup2 mount options to the kernel

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1310,7 +1310,7 @@ container_has_cgroupns (libcrun_container_t *container)
 
 static int
 do_mount_cgroup_v2 (libcrun_container_t *container, int targetfd, const char *target,
-                    unsigned long mountflags, libcrun_error_t *err)
+                    unsigned long mountflags, const char *data, libcrun_error_t *err)
 {
   int ret;
   int cgroup_mode;
@@ -1319,7 +1319,7 @@ do_mount_cgroup_v2 (libcrun_container_t *container, int targetfd, const char *ta
   if (UNLIKELY (cgroup_mode < 0))
     return cgroup_mode;
 
-  ret = do_mount (container, "cgroup2", targetfd, target, "cgroup2", mountflags, NULL, LABEL_NONE, err);
+  ret = do_mount (container, "cgroup2", targetfd, target, "cgroup2", mountflags, data, LABEL_NONE, err);
   if (UNLIKELY (ret < 0))
     {
       errno = crun_error_get_errno (err);
@@ -1338,7 +1338,7 @@ do_mount_cgroup_v2 (libcrun_container_t *container, int targetfd, const char *ta
               ret = do_mount (container, "tmpfs", targetfd, target, "tmpfs", MS_PRIVATE, "nr_blocks=1,nr_inodes=1", LABEL_NONE, err);
               if (LIKELY (ret == 0))
                 {
-                  ret = do_mount (container, "cgroup2", targetfd, target, "cgroup2", mountflags, NULL, LABEL_NONE, err);
+                  ret = do_mount (container, "cgroup2", targetfd, target, "cgroup2", mountflags, data, LABEL_NONE, err);
                   if (LIKELY (ret == 0))
                     return ret;
 
@@ -1530,7 +1530,7 @@ do_mount_cgroup_v1 (libcrun_container_t *container, const char *source, int targ
 
 static int
 do_mount_cgroup (libcrun_container_t *container, const char *source, int targetfd, const char *target,
-                 unsigned long mountflags, libcrun_error_t *err)
+                 unsigned long mountflags, const char *data, libcrun_error_t *err)
 {
   int cgroup_mode;
 
@@ -1541,7 +1541,7 @@ do_mount_cgroup (libcrun_container_t *container, const char *source, int targetf
   switch (cgroup_mode)
     {
     case CGROUP_MODE_UNIFIED:
-      return do_mount_cgroup_v2 (container, targetfd, target, mountflags, err);
+      return do_mount_cgroup_v2 (container, targetfd, target, mountflags, data, err);
     case CGROUP_MODE_LEGACY:
     case CGROUP_MODE_HYBRID:
       return do_mount_cgroup_v1 (container, source, targetfd, target, mountflags, err);
@@ -2317,7 +2317,7 @@ process_single_mount (libcrun_container_t *container, const char *rootfs,
         }
       else if (strcmp (type, "cgroup") == 0)
         {
-          ret = do_mount_cgroup (container, source, targetfd, target, flags, err);
+          ret = do_mount_cgroup (container, source, targetfd, target, flags, data, err);
           if (UNLIKELY (ret < 0))
             return ret;
         }

--- a/tests/test_cgroup_setup.py
+++ b/tests/test_cgroup_setup.py
@@ -1337,6 +1337,37 @@ def test_annotation_systemd_force_cgroup_v1():
         logger.info("test failed: %s", e)
         return -1
 
+def test_cgroup_v2_mount_options():
+    """Test that cgroup v2 mount options are passed to the kernel."""
+
+    if not is_cgroup_v2_unified():
+        return (77, "requires cgroup v2")
+
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'true']
+    add_all_namespaces(conf, cgroupns=True)
+
+    # Test this by intentionally providing an invalid mount option.
+    # If the options are ignored, the mount will succeed.
+    # If they are correctly passed to the kernel, the mount will fail.
+    for mount in conf['mounts']:
+        if mount.get('destination') == '/sys/fs/cgroup':
+            if 'options' not in mount:
+                mount['options'] = []
+            mount['options'].append("invalid_cgroup_option")
+            break
+
+    try:
+        run_and_get_output(conf, hide_stderr=False)
+        logger.info("expected mount failure due to invalid mount option, but it succeeded")
+        return -1
+    except subprocess.CalledProcessError as e:
+        output = e.output.decode('utf-8', errors='ignore') if e.output else ""
+        if "Invalid argument" not in output:
+            logger.info("failed, but did not find expected 'Invalid argument' error message. Output: %s", output)
+            return -1
+
+    return 0
 
 all_tests = {
     "cgroup-creation": test_cgroup_creation,
@@ -1377,6 +1408,7 @@ all_tests = {
     "annotation-systemd-subgroup": test_annotation_systemd_subgroup,
     "annotation-delegate-cgroup": test_annotation_delegate_cgroup,
     "annotation-systemd-force-cgroup-v1": test_annotation_systemd_force_cgroup_v1,
+    "cgroup-v2-mount-options": test_cgroup_v2_mount_options,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
When mounting the cgroup v2 filesystem, VFS options such as "nsdelegate" were previously ignored because the mount data argument was hardcoded to `NULL` in `do_mount_cgroup_v2()`.

This commit updates `do_mount_cgroup()` and `do_mount_cgroup_v2()` to accept and pass the `data` parameter from `process_single_mount()`, ensuring that custom cgroup mount options are successfully propagated to the kernel.

A new test case has been added to verify this behavior by intentionally passing an invalid mount option and checking for the expected mount failure.

Assisted-by: gemini-cli

@samuelkarp @Divya063