### PR TITLE
fix(utils): retry fgetpwent_r() on EINTR

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1465,6 +1465,9 @@ set_home_env (uid_t id)
       int ret = fgetpwent_r (stream, &pwd, buf, buf_size, &ret_pw);
       if (UNLIKELY (ret != 0))
         {
+          if (ret == EINTR)
+            continue;
+
           if (ret != ERANGE)
             {
               /* Let callers handle the error if the user was not found. */


### PR DESCRIPTION
The passwd entry lookup could fail spuriously when interrupted by a signal during iteration. The call is now retried when interrupted, consistent with standard practice for handling interruptible system calls.

Fixes: https://github.com/containers/crun/issues/2009