### PR TITLE
Make CI green again (exclude --tls-details podman tests)

### DIFF
--- a/tests/podman/run-tests.sh
+++ b/tests/podman/run-tests.sh
@@ -97,6 +97,9 @@ SKIP_TESTS=(
 
 	# Does not work inside container as upperdir is overlayfs (issue 1999).
 	'podman build and remove basic alpine with TMPDIR as relative'
+
+	# Not related to runtime.
+	'--tls-details'
 )
 SKIP_REGEX=$(IFS='|'; echo "${SKIP_TESTS[*]}")
 


### PR DESCRIPTION
* tests/podman: exclude --tls-details tests
    
    Those were recently added in [podman PR 28208](https://github.com/containers/podman/pull/28208) and are failing here.
    As most probably they have nothing to do with OCI runtime, and are
    failing, let's skip them.

This PR also includes some cleanup of `tests/podman/run-tests.sh` which
I forgot to submit earlier, so I'm shoving it here.