### PR TITLE
fix(hooks): log warning when poststop hooks fail

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1798,8 +1798,13 @@ run_poststop_hooks (libcrun_context_t *context, libcrun_container_t *container, 
 
       ret = do_hooks (def, 0, id, true, status->bundle, "stopped", (hook **) def->hooks->poststop,
                       def->hooks->poststop_len, hooks_out_fd, hooks_err_fd, false, err);
-      if (UNLIKELY (ret < 0))
-        crun_error_write_warning_and_release (context->output_handler_arg, &err);
+      if (UNLIKELY (ret != 0))
+        {
+          if (ret < 0)
+            crun_error_write_warning_and_release (context->output_handler_arg, &err);
+          else
+            libcrun_error (0, "poststop hook failed with exit code: %d", ret);
+        }
     }
   return 0;
 }

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -490,6 +490,36 @@ def test_annotation_hook_stdout_stderr():
             os.unlink(stderr_file)
 
 
+def _test_failing_poststop_hooks(hooks):
+    """Helper: verify that failing poststop hooks log a warning but container still succeeds."""
+    conf = base_config()
+    add_all_namespaces(conf)
+    conf['process']['args'] = ['/init', 'true']
+    conf['hooks'] = {"poststop": hooks}
+
+    try:
+        out, _ = run_and_get_output(conf)
+    except Exception as e:
+        logger.error("container failed unexpectedly: %s", e)
+        return -1
+
+    if "poststop hook failed with exit code" not in out:
+        logger.error("expected warning about poststop hook failure, got: %s", out)
+        return -1
+
+    return 0
+
+
+def test_poststop_hook_failure_warning():
+    """Test that a failing poststop hook logs a warning but container still succeeds."""
+    return _test_failing_poststop_hooks([{"path": "/bin/false"}])
+
+
+def test_multiple_poststop_hooks_failure():
+    """Test that multiple failing poststop hooks do not prevent container cleanup."""
+    return _test_failing_poststop_hooks([{"path": "/bin/false"}, {"path": "/bin/false"}])
+
+
 all_tests = {
     "test-fail-prestart" : test_fail_prestart,
     "test-success-prestart" : test_success_prestart,
@@ -507,6 +537,8 @@ all_tests = {
     "test-hook-receives-state": test_hook_receives_state,
     "test-multiple-hooks": test_multiple_hooks,
     "test-annotation-hook-stdout-stderr": test_annotation_hook_stdout_stderr,
+    "test-poststop-hook-failure-warning": test_poststop_hook_failure_warning,
+    "test-multiple-poststop-hooks-failure": test_multiple_poststop_hooks_failure,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
Poststop hook errors were silently ignored when the hook returned a positive exit code. The error check only caught negative return values, missing the case where hooks fail with a non-zero exit status.

Change the condition from ret < 0 to ret != 0 and create a proper error message for positive exit codes so crun_error_write_warning_and_release has something to print.  Note that do_hooks() also logs via libcrun_warning() but that is suppressed at default verbosity, so the explicit crun_error_write_warning_and_release call ensures the warning is always visible.

Fixes: https://github.com/containers/crun/issues/1946