### PR TITLE
cgroup: preserve errno on errors in rmdir_all_fd

### DIFF
--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -379,7 +379,13 @@ rmdir_all_fd (int dfd)
 
           child_dfd = openat (dfd, name, O_DIRECTORY | O_CLOEXEC);
           if (child_dfd < 0)
-            return child_dfd;
+            {
+              int saved_errno = errno;
+              closedir (dir);
+              dir = NULL;
+              errno = saved_errno;
+              return child_dfd;
+            }
 
           ret = read_pids_cgroup (child_dfd, true, &pids, &n_pids, &allocated, &tmp_err);
           if (UNLIKELY (ret < 0))


### PR DESCRIPTION
Closes: https://github.com/containers/crun/issues/2048