### PR TITLE
fix(utils): use parent directory fd for bind on long Unix socket paths

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -23,6 +23,7 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <string.h>
+#include <libgen.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -1094,21 +1095,35 @@ open_unix_domain_socket (const char *path, int dgram, libcrun_error_t *err)
   struct sockaddr_un addr = {};
   proc_fd_path_t name_buf;
   int ret;
+  cleanup_close int dirfd = -1;
   cleanup_close int fd = socket (AF_UNIX, dgram ? SOCK_DGRAM : SOCK_STREAM, 0);
   if (UNLIKELY (fd < 0))
     return crun_make_error (err, errno, "create UNIX socket");
 
   if (strlen (path) >= sizeof (addr.sun_path))
     {
-      get_proc_self_fd_path (name_buf, fd);
-      path = name_buf;
+      cleanup_free char *dpath = xstrdup (path);
+      cleanup_free char *bpath = xstrdup (path);
+      const char *parent_dir = dirname (dpath);
+      const char *base = basename (bpath);
+      int n;
+
+      dirfd = open (parent_dir, O_PATH | O_DIRECTORY | O_CLOEXEC);
+      if (UNLIKELY (dirfd < 0))
+        return crun_make_error (err, errno, "open directory `%s`", parent_dir);
+
+      get_proc_self_fd_path (name_buf, dirfd);
+
+      n = snprintf (addr.sun_path, sizeof (addr.sun_path), "%s/%s", name_buf, base);
+      if (n < 0 || (size_t) n >= sizeof (addr.sun_path))
+        return crun_make_error (err, ENAMETOOLONG, "socket path too long: `%s`", path);
+    }
+  else
+    {
+      size_t path_len = strlen (path);
+      memcpy (addr.sun_path, path, path_len + 1);
     }
 
-  size_t path_len = strlen (path);
-  if (path_len >= sizeof (addr.sun_path))
-    return crun_make_error (err, ENAMETOOLONG, "socket path too long: `%s`", path);
-
-  memcpy (addr.sun_path, path, path_len + 1);
   addr.sun_family = AF_UNIX;
   ret = bind (fd, (struct sockaddr *) &addr, sizeof (addr));
   if (UNLIKELY (ret < 0))


### PR DESCRIPTION
## Problem

`open_unix_domain_socket()` fails with `EADDRINUSE` (or silently binds to the wrong path) when the socket path exceeds the 108-byte `sun_path` limit of `struct sockaddr_un`.

The current code attempts to work around long paths by using `/proc/self/fd/N` where `N` is the socket file descriptor itself:

```c
if (strlen(path) >= sizeof(addr.sun_path)) {
    get_proc_self_fd_path(name_buf, fd);  // fd = the socket fd
    path = name_buf;
}
```

This is incorrect because `/proc/self/fd/<socket_fd>` points to `socket:[inode]`, not to a filesystem path. The kernel cannot resolve this to a bindable address, so `bind()` fails. This affects the sd-notify socket path which is constructed as `<state_dir>/notify/notify` and can easily exceed 108 bytes with long container IDs or deep `XDG_RUNTIME_DIR` paths.

## Fix

Instead of using the socket's own fd, open the **parent directory** of the target path with `O_PATH | O_DIRECTORY`, then construct the bind address as `/proc/self/fd/<dirfd>/<basename>`. The kernel resolves `/proc/self/fd/<dirfd>` to the actual directory path via procfs, keeping the final `sun_path` well within the 108-byte limit (typically ~30 bytes for the `/proc/self/fd/N/` prefix plus the basename).

The fix:
1. Splits the long path into parent directory + basename using `dirname()`/`strrchr()`
2. Opens the parent directory with `open(parent, O_PATH | O_DIRECTORY | O_CLOEXEC)`
3. Constructs `sun_path` as `/proc/self/fd/<dirfd>/<basename>`
4. Validates the constructed path still fits in `sun_path` before calling `bind()`

Short paths (< 108 bytes) are unaffected and follow the original direct copy path.