### PR TITLE
utils: fix memory leak and missing cache in libcrun_initialize_apparmor()

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -749,22 +749,39 @@ int
 libcrun_initialize_apparmor (libcrun_error_t *err)
 {
   cleanup_close int fd = -1;
+  int ret;
   int size;
   char buf[2];
 
   if (apparmor_enabled >= 0)
     return apparmor_enabled;
 
-  if (crun_dir_p_at (AT_FDCWD, "/sys/kernel/security/apparmor", true, err))
+  ret = crun_dir_p_at (AT_FDCWD, "/sys/kernel/security/apparmor", true, err);
+  if (UNLIKELY (ret < 0))
     {
-      fd = open ("/sys/module/apparmor/parameters/enabled", O_RDONLY | O_CLOEXEC);
-      if (fd == -1)
-        return 0;
-
-      size = TEMP_FAILURE_RETRY (read (fd, &buf, 2));
-
-      apparmor_enabled = size > 0 && buf[0] == 'Y' ? 1 : 0;
+      /* Directory doesn't exist — not an error, just no AppArmor.  */
+      crun_error_release (err);
+      apparmor_enabled = 0;
+      return 0;
     }
+
+  if (ret == 0)
+    {
+      /* Path exists but is not a directory — no AppArmor.  */
+      apparmor_enabled = 0;
+      return 0;
+    }
+
+  fd = open ("/sys/module/apparmor/parameters/enabled", O_RDONLY | O_CLOEXEC);
+  if (fd == -1)
+    {
+      apparmor_enabled = 0;
+      return 0;
+    }
+
+  size = TEMP_FAILURE_RETRY (read (fd, &buf, 2));
+
+  apparmor_enabled = size > 0 && buf[0] == 'Y' ? 1 : 0;
 
   return apparmor_enabled;
 }


### PR DESCRIPTION
Fixes #1936

### Problem

`crun_dir_p_at()` returns three possible values:
- `1` — path exists and is a directory
- `0` — path exists but is not a directory
- negative — `stat()` failed (allocates error into `*err`)

The existing code used the return value directly as a boolean condition:
```c
if (crun_dir_p_at(AT_FDCWD, "/sys/kernel/security/apparmor", true, err))
```

Since negative values are truthy in C, when `/sys/kernel/security/apparmor` doesn't exist:
1. `crun_dir_p_at()` allocates an error object into `*err` and returns a negative value
2. The `if` condition is true (non-zero), entering the block
3. `open()` also fails, returning `-1`
4. The function returns `0` — but `*err` still holds the allocated error (memory leak)

Additionally, `apparmor_enabled` was not cached in the error paths, causing repeated failing `stat()`/`open()` calls on subsequent invocations.

### Fix

- Handle all three return values from `crun_dir_p_at()` explicitly
- On `ret < 0`: release the error with `crun_error_release(err)`, cache `apparmor_enabled = 0`
- On `ret > 0`: proceed with the enabled check, cache result on `open()` failure
- On `ret == 0`: path is not a directory, cache `apparmor_enabled = 0`

This follows the same pattern already used elsewhere in the codebase (e.g., line 234).

Signed-off-by: Jindrich Novy <jnovy@redhat.com>