### PR TITLE
container, seccomp, seccomp_notify: tighten crun_make_error input

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1723,7 +1723,7 @@ container_init (void *args, char *notify_socket, int sync_socket, libcrun_error_
                                                                exec_path,
                                                                def->process->args);
       if (ret != 0)
-        return crun_make_error (err, ret, "exec container process failed with handler as `%s`", entrypoint_args->custom_handler->vtable->name);
+        return crun_make_error (err, 0, "exec container process failed with handler as `%s`", entrypoint_args->custom_handler->vtable->name);
 
       return ret;
     }

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -346,7 +346,7 @@ libcrun_apply_seccomp (int infd, int listener_receiver_fd, const char *receiver_
 
       ret = get_process_exit_status (status);
       if (ret != 0)
-        return crun_make_error (err, ret, "send listener fd `%d` to receiver", listener_fd);
+        return crun_make_error (err, 0, "send listener fd `%d` to receiver", listener_fd);
     }
 
   return 0;

--- a/src/libcrun/seccomp_notify.c
+++ b/src/libcrun/seccomp_notify.c
@@ -143,7 +143,7 @@ libcrun_load_seccomp_notify_plugins (struct seccomp_notify_context_s **out, cons
 
           ret = start_cb (&opq, conf, sizeof (*conf));
           if (UNLIKELY (ret != 0))
-            return crun_make_error (err, -ret, "error loading `%s`", it);
+            return crun_make_error (err, 0, "error loading `%s`", it);
         }
       ctx->plugins[s].opaque = opq;
     }
@@ -189,7 +189,7 @@ libcrun_seccomp_notify_plugins (struct seccomp_notify_context_s *ctx, int seccom
           ret = ctx->plugins[i].handle_request_cb (ctx->plugins[i].opaque, &ctx->sizes, ctx->sreq, ctx->sresp,
                                                    seccomp_fd, &handled);
           if (UNLIKELY (ret != 0))
-            return crun_make_error (err, -ret, "error handling seccomp notify request");
+            return crun_make_error (err, 0, "error handling seccomp notify request");
 
           switch (handled)
             {


### PR DESCRIPTION
The second argument to `crun_make_error()` should be non-negative.
I don't see this happening but let's enforce this.

I didn't fix the ones in _src/libcrun/criu.c_ as those should probably be fixed
by checking for `ret < 0` instead of `ret != 0`. 
