### PR TITLE
libcrun: fall back to bind mount for /dev/console on read-only file systems

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3951,7 +3951,18 @@ libcrun_set_terminal (libcrun_container_t *container, libcrun_error_t *err)
     {
       ret = unlink ("/dev/console");
       if (UNLIKELY (ret < 0 && errno != ENOENT))
-        return crun_make_error (err, errno, "unlink `/dev/console`");
+        {
+          if (errno == EROFS)
+            {
+              /* If the file system is read-only, fall back to a bind mount.  */
+              ret = do_mount (container, pty, -1, "/dev/console", NULL, MS_BIND, NULL, LABEL_MOUNT, err);
+              if (UNLIKELY (ret < 0))
+                return ret;
+
+              return get_and_reset (&fd);
+            }
+          return crun_make_error (err, errno, "unlink `/dev/console`");
+        }
 
       ret = symlink (pty, "/dev/console");
       if (UNLIKELY (ret < 0))

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -379,6 +379,32 @@ def test_terminal_zero_size():
         return -1
 
 
+def test_terminal_readonly_rootfs_no_dev_tmpfs():
+    """Test terminal with readonly rootfs and no /dev tmpfs (issue #1745)."""
+    if os.isatty(1) == False:
+        return (77, "requires TTY")
+
+    conf = base_config()
+    add_all_namespaces(conf, userns=True)
+    conf['process']['terminal'] = True
+    conf['process']['args'] = ['/init', 'true']
+    conf['root']['readonly'] = True
+
+    # Remove the /dev tmpfs mount so /dev/console lives on the read-only rootfs.
+    # Keep /dev/pts which is needed for terminal allocation.
+    conf['mounts'] = [m for m in conf['mounts']
+                      if m['destination'] != '/dev'
+                      and m['destination'] != '/dev/shm'
+                      and m['destination'] != '/dev/mqueue']
+
+    try:
+        out, _ = run_and_get_output(conf, hide_stderr=True)
+        return 0
+    except Exception as e:
+        logger.info("test failed: %s", e)
+        return -1
+
+
 all_tests = {
     "terminal-allocation": test_terminal_allocation,
     "terminal-size": test_terminal_size,
@@ -392,6 +418,7 @@ all_tests = {
     "terminal-exec": test_terminal_exec,
     "terminal-exec-no-tty": test_terminal_exec_no_tty,
     "terminal-env-term": test_terminal_env_term,
+    "terminal-readonly-rootfs-no-dev-tmpfs": test_terminal_readonly_rootfs_no_dev_tmpfs,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
Commit 405d2a2c changed /dev/console setup to use unlink+symlink instead
of a bind mount when mount_dev_from_host is false.  When the rootfs is
read-only and /dev is not a separate tmpfs mount, unlink fails with EROFS.

Fall back to the original bind mount approach when unlink returns EROFS.

Closes #1745