### PR TITLE
Fix: skip cgroup filesystem type check when cgroups are disabled

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -2789,12 +2789,15 @@ libcrun_container_run_internal (libcrun_container_t *container, libcrun_context_
   const char *seccomp_bpf_data = find_annotation (container, "run.oci.seccomp_bpf_data");
   int cgroup_mode;
 
-  cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (UNLIKELY (cgroup_mode < 0))
-    return cgroup_mode;
+  if (! context->force_no_cgroup)
+    {
+      cgroup_mode = libcrun_get_cgroup_mode (err);
+      if (UNLIKELY (cgroup_mode < 0))
+        return cgroup_mode;
 
-  if (cgroup_mode != CGROUP_MODE_UNIFIED)
-    libcrun_warning ("cgroup v1 is deprecated and will be removed in a future release.  Use cgroup v2");
+      if (cgroup_mode != CGROUP_MODE_UNIFIED)
+        libcrun_warning ("cgroup v1 is deprecated and will be removed in a future release.  Use cgroup v2");
+    }
 
   ret = setup_container_hooks_output (container, def, &container_args, &hooks_out_fd, &hooks_err_fd, err);
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2848,20 +2848,23 @@ libcrun_set_mounts (struct container_entrypoint_s *entrypoint_args, libcrun_cont
       get_private_data (container)->remounts = r;
     }
 
-  cgroup_mode = libcrun_get_cgroup_mode (err);
-  if (UNLIKELY (cgroup_mode < 0))
-    return cgroup_mode;
-
-  if (cgroup_mode == CGROUP_MODE_UNIFIED)
+  if (! container->context->force_no_cgroup)
     {
-      char *unified_cgroup_path = NULL;
+      cgroup_mode = libcrun_get_cgroup_mode (err);
+      if (UNLIKELY (cgroup_mode < 0))
+        return cgroup_mode;
 
-      /* Read the cgroup path before we enter the cgroupns.  */
-      ret = libcrun_get_cgroup_process (0, &unified_cgroup_path, true, err);
-      if (UNLIKELY (ret < 0))
-        return ret;
+      if (cgroup_mode == CGROUP_MODE_UNIFIED)
+        {
+          char *unified_cgroup_path = NULL;
 
-      get_private_data (container)->unified_cgroup_path = unified_cgroup_path;
+          /* Read the cgroup path before we enter the cgroupns.  */
+          ret = libcrun_get_cgroup_process (0, &unified_cgroup_path, true, err);
+          if (UNLIKELY (ret < 0))
+            return ret;
+
+          get_private_data (container)->unified_cgroup_path = unified_cgroup_path;
+        }
     }
 
   ret = libcrun_container_enter_cgroup_ns (container, err);

--- a/tests/test_cgroup_setup.py
+++ b/tests/test_cgroup_setup.py
@@ -1369,7 +1369,80 @@ def test_cgroup_v2_mount_options():
 
     return 0
 
+def _cgroup_disabled_config():
+    """Return a config suitable for --cgroup-manager=disabled: no cgroup mount,
+    no resources, no cgroupsPath, no cgroup namespace."""
+    conf = base_config()
+    add_all_namespaces(conf, cgroupns=False)
+    conf['mounts'] = [m for m in conf.get('mounts', [])
+                      if m.get('destination') != '/sys/fs/cgroup']
+    if 'resources' in conf.get('linux', {}):
+        del conf['linux']['resources']
+    if 'cgroupsPath' in conf.get('linux', {}):
+        del conf['linux']['cgroupsPath']
+    return conf
+
+
+def _run_cgroup_disabled(detach):
+    """Run a container with --cgroup-manager=disabled in foreground or detached
+    mode.  Returns 0 on success, (77, reason) for environment skips, -1 on
+    failure.
+
+    Regression test for https://github.com/containers/crun/issues/1413.
+    When cgroups are disabled, crun must not call statfs on /sys/fs/cgroup,
+    which would fail on systems where it is not mounted as tmpfs or cgroup2.
+    """
+    conf = _cgroup_disabled_config()
+    conf['process']['args'] = ['/init', 'pause'] if detach else ['/init', 'true']
+
+    cid = None
+    try:
+        if detach:
+            _, cid = run_and_get_output(conf, hide_stderr=False, command='run',
+                                        detach=True, cgroup_manager='disabled')
+            state = json.loads(run_crun_command(['state', cid]))
+            if state['status'] not in ('running', 'created'):
+                logger.info("container not running: %s", state['status'])
+                return -1
+        else:
+            run_and_get_output(conf, hide_stderr=False, cgroup_manager='disabled')
+        return 0
+    except subprocess.CalledProcessError as e:
+        output = e.output.decode('utf-8', errors='ignore') if e.output else ''
+        if "invalid file system type" in output:
+            logger.info("test failed: cgroup filesystem type checked despite --cgroups=disabled")
+            return -1
+        if any(kw in output.lower() for kw in ["mount", "proc", "rootfs"]):
+            return (77, "environment issue, not related to cgroup disabled")
+        logger.info("test failed: %s (output: %s)", e, output)
+        return -1
+    except Exception as e:
+        logger.info("test failed: %s", e)
+        return -1
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+
+
+def test_cgroup_disabled():
+    """Test --cgroup-manager=disabled skips cgroup filesystem type verification (foreground).
+
+    Regression test for https://github.com/containers/crun/issues/1413.
+    """
+    return _run_cgroup_disabled(detach=False)
+
+
+def test_cgroup_disabled_detach():
+    """Test --cgroup-manager=disabled works with run --detach.
+
+    Regression test for https://github.com/containers/crun/issues/1413.
+    """
+    return _run_cgroup_disabled(detach=True)
+
+
 all_tests = {
+    "cgroup-disabled": test_cgroup_disabled,
+    "cgroup-disabled-detach": test_cgroup_disabled_detach,
     "cgroup-creation": test_cgroup_creation,
     "cgroup-cleanup": test_cgroup_cleanup,
     "cgroup-with-resources": test_cgroup_with_resources,


### PR DESCRIPTION
Fixes #1413

## Problem

When `--cgroup-manager=disabled` is used (or `--cgroups=disabled` via podman), crun still unconditionally calls `libcrun_get_cgroup_mode()` early in the container startup path. This function does `statfs("/sys/fs/cgroup")` and returns an error if the filesystem type is neither `CGROUP2_SUPER_MAGIC` nor `TMPFS_MAGIC`.

On systems where `/sys/fs/cgroup` is not a standard cgroup mount — such as Android with Linux Deploy where it is mounted as `sysfs` — this causes container creation to fail with:

```
OCI runtime error: crun: invalid file system type on `/sys/fs/cgroup`
```

This defeats the purpose of `--cgroups=disabled`, which exists precisely for environments where cgroups are not properly available.

## Root Cause

In `libcrun_container_run_internal()` (container.c), `libcrun_get_cgroup_mode()` is called **before** `setup_cgroup_manager()`, which is where `context->force_no_cgroup` is evaluated. The same pattern exists in `libcrun_set_mounts()` (linux.c), where the cgroup mode is queried unconditionally to determine the unified cgroup path.

## Fix

Guard the `libcrun_get_cgroup_mode()` calls and related cgroup logic with checks for `context->force_no_cgroup`:

- **`src/libcrun/container.c`**: Skip the cgroup mode detection and the cgroup v1 deprecation warning when `force_no_cgroup` is set.
- **`src/libcrun/linux.c`**: Skip the cgroup mode detection and unified cgroup path reading in `libcrun_set_mounts()` when `force_no_cgroup` is set.

## Testing

Added two regression tests in `tests/test_cgroup_setup.py`:

- `test_cgroup_disabled()` — verifies that a foreground container with `--cgroup-manager=disabled` runs successfully without triggering cgroup filesystem validation.
- `test_cgroup_disabled_detach()` — verifies the same for the create+start (detached) code path.

All existing tests continue to pass.

## Reproduction

```shell
# On a system where /sys/fs/cgroup is not tmpfs or cgroup2 (e.g., Android/Linux Deploy):
sudo podman run -dt --runtime crun --cgroups=disabled --network=host docker.io/library/httpd
# Before fix: OCI runtime error: crun: invalid file system type on `/sys/fs/cgroup`
# After fix: container starts successfully
```

Signed-off-by: Jindrich Novy <jnovy@redhat.com>