### PR TITLE
Replace YAJL with yyjson for JSON parsing and generation

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     - run: |
        sudo apt-get update
-       sudo apt-get install -y make git gcc build-essential pkgconf libtool libsystemd-dev libcap-dev libseccomp-dev libyajl-dev go-md2man libtool autoconf python3 automake libprotobuf-c-dev
+       sudo apt-get install -y make git gcc build-essential pkgconf libtool libsystemd-dev libcap-dev libseccomp-dev go-md2man libtool autoconf python3 automake libprotobuf-c-dev
        ./autogen.sh
        ./configure
        make -j $(nproc)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - run: sudo apt-get update
 
-      - run: sudo apt-get install -y make git gcc build-essential pkgconf libtool libsystemd-dev libcap-dev libseccomp-dev libyajl-dev go-md2man libtool autoconf python3 automake libprotobuf-c-dev
+      - run: sudo apt-get install -y make git gcc build-essential pkgconf libtool libsystemd-dev libcap-dev libseccomp-dev go-md2man libtool autoconf python3 automake libprotobuf-c-dev
 
       - run: |
           set -ex

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
 
           install: |
             apt-get update -y
-            apt-get install -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev libprotobuf-c-dev clang mawk
+            apt-get install -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libprotobuf-c-dev clang mawk
 
           run: |
             find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;
@@ -94,7 +94,7 @@ jobs:
 
           sudo add-apt-repository -y ppa:criu/ppa
           # add-apt-repository runs apt-get update so we don't have to.
-          sudo apt-get install -q -y criu automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget libsystemd-dev gperf clang-format libyajl-dev containerd runc libasan6 libprotobuf-c-dev mawk
+          sudo apt-get install -q -y criu automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget libsystemd-dev gperf clang-format containerd runc libasan6 libprotobuf-c-dev mawk
           # Fedora (used by maintainers as well as for packaging) has newer
           # md2man than in Ubuntu, so we have to install it from source.
           GOBIN=~/.local/bin go install github.com/cpuguy83/go-md2man/v2@latest
@@ -208,7 +208,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get update -q -y
-          sudo apt-get install -q -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libyajl-dev libprotobuf-c-dev mawk
+          sudo apt-get install -q -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libprotobuf-c-dev mawk
       - uses: lumaxis/shellcheck-problem-matchers@v2
       - name: shellcheck
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libocispec"]
 	path = libocispec
-	url = https://github.com/containers/libocispec.git
+	url = https://github.com/giuseppe/libocispec.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,48 +75,48 @@ libcrun_SOURCES = src/libcrun/utils.c \
 		src/libcrun/net_device.c \
 		src/libcrun/terminal.c
 
-if HAVE_EMBEDDED_YAJL
-maybe_libyajl.la = libocispec/yajl/libyajl.la
+if HAVE_EMBEDDED_YYJSON
+maybe_libyyjson =
 else
-maybe_libyajl.la =
+maybe_libyyjson = $(YYJSON_LIBS)
 endif
 
 libocispec/libocispec.la:
 	$(MAKE) $(AM_MAKEFLAGS) -C libocispec libocispec.la
 
 libcrun_la_SOURCES = $(libcrun_SOURCES)
-libcrun_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -fvisibility=hidden
+libcrun_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -fvisibility=hidden
 if ENABLE_COVERAGE
 libcrun_la_CFLAGS += $(COVERAGE_CFLAGS)
 libcrun_la_LDFLAGS = -Wl,--version-script=$(abs_top_srcdir)/libcrun.lds $(COVERAGE_LDFLAGS)
 else
 libcrun_la_LDFLAGS = -Wl,--version-script=$(abs_top_srcdir)/libcrun.lds
 endif
-libcrun_la_LIBADD = libocispec/libocispec.la $(FOUND_LIBS) $(maybe_libyajl.la)
+libcrun_la_LIBADD = libocispec/libocispec.la $(FOUND_LIBS) $(maybe_libyyjson)
 
 # build a version with all the symbols visible for testing
 if BUILD_TESTS
 libcrun_testing_la_SOURCES = $(libcrun_SOURCES)
-libcrun_testing_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -fvisibility=default
+libcrun_testing_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -fvisibility=default
 if ENABLE_COVERAGE
 libcrun_testing_la_CFLAGS += $(COVERAGE_CFLAGS)
 libcrun_testing_la_LDFLAGS = $(COVERAGE_LDFLAGS)
 endif
-libcrun_testing_la_LIBADD = libocispec/libocispec.la $(maybe_libyajl.la)
+libcrun_testing_la_LIBADD = libocispec/libocispec.la $(maybe_libyyjson)
 endif
 
 if PYTHON_BINDINGS
 pyexec_LTLIBRARIES = python_crun.la
 python_crun_la_SOURCES = python/crun_python.c
-python_crun_la_CFLAGS = -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/libocispec/src -I $(abs_top_builddir)/src $(PYTHON_CFLAGS)
+python_crun_la_CFLAGS = -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src $(PYTHON_CFLAGS)
 python_crun_la_LDFLAGS = -avoid-version -module $(PYTHON_LDFLAGS)
-python_crun_la_LIBADD = libcrun.la $(PYTHON_LIBS) $(FOUND_LIBS) $(maybe_libyajl.la)
+python_crun_la_LIBADD = libcrun.la $(PYTHON_LIBS) $(FOUND_LIBS) $(maybe_libyyjson)
 endif
 
 if LUA_BINDINGS
 luaexec_LTLIBRARIES = luacrun.la
 luacrun_la_SOURCES = lua/lua_crun.c
-luacrun_la_CFLAGS = -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/libocispec/src -I $(abs_top_builddir)/src $(LUA_INCLUDE)
+luacrun_la_CFLAGS = -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src $(LUA_INCLUDE)
 luacrun_la_LDFLAGS = -avoid-version -module
 luacrun_la_LIBADD = libcrun.la $(LUA_LIB) $(FOUND_LIBS)
 
@@ -145,7 +145,7 @@ dist-luarock: $(LUACRUN_ROCK)
 
 endif
 
-crun_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -D CRUN_LIBDIR="\"$(CRUN_LIBDIR)\""
+crun_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -D CRUN_LIBDIR="\"$(CRUN_LIBDIR)\""
 if ENABLE_COVERAGE
 crun_CFLAGS += $(COVERAGE_CFLAGS)
 endif
@@ -160,7 +160,7 @@ else
 crun_LDFLAGS = -Wl,--unresolved-symbols=ignore-all $(CRUN_LDFLAGS)
 endif
 else
-crun_LDADD = libcrun.la $(FOUND_LIBS) $(maybe_libyajl.la)
+crun_LDADD = libcrun.la $(FOUND_LIBS) $(maybe_libyyjson)
 if ENABLE_COVERAGE
 crun_LDFLAGS = $(CRUN_LDFLAGS) $(COVERAGE_LDFLAGS)
 else
@@ -203,74 +203,74 @@ endif
 if BUILD_TESTS
 check_PROGRAMS = tests/init $(UNIT_TESTS) tests/tests_libcrun_fuzzer
 
-TESTS_LDADD = libcrun_testing.la $(FOUND_LIBS) $(maybe_libyajl.la)
+TESTS_LDADD = libcrun_testing.la $(FOUND_LIBS) $(maybe_libyyjson)
 
 tests_init_LDADD =
 tests_init_LDFLAGS = -static-libgcc -all-static
 tests_init_CFLAGS = -g -O2
 tests_init_SOURCES = tests/init.c
 
-tests_tests_libcrun_utils_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_utils_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_utils_SOURCES = tests/tests_libcrun_utils.c
 tests_tests_libcrun_utils_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_utils_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_ring_buffer_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_ring_buffer_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_ring_buffer_SOURCES = tests/tests_libcrun_ring_buffer.c
 tests_tests_libcrun_ring_buffer_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_ring_buffer_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_intelrdt_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_intelrdt_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_intelrdt_SOURCES = tests/tests_libcrun_intelrdt.c
 tests_tests_libcrun_intelrdt_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_intelrdt_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_fuzzer_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_fuzzer_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_fuzzer_SOURCES = tests/tests_libcrun_fuzzer.c
-tests_tests_libcrun_fuzzer_LDADD = $(TESTS_LDADD) libocispec/libocispec.la $(maybe_libyajl.la)
+tests_tests_libcrun_fuzzer_LDADD = $(TESTS_LDADD) libocispec/libocispec.la $(maybe_libyyjson)
 tests_tests_libcrun_fuzzer_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_errors_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_errors_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_errors_SOURCES = tests/tests_libcrun_errors.c
 tests_tests_libcrun_errors_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_errors_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_terminal_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_terminal_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_terminal_SOURCES = tests/tests_libcrun_terminal.c
 tests_tests_libcrun_terminal_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_terminal_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_custom_handler_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_custom_handler_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_custom_handler_SOURCES = tests/tests_libcrun_custom_handler.c
 tests_tests_libcrun_custom_handler_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_custom_handler_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_linux_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_linux_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_linux_SOURCES = tests/tests_libcrun_linux.c
 tests_tests_libcrun_linux_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_linux_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_signals_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_signals_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_signals_SOURCES = tests/tests_libcrun_signals.c
 tests_tests_libcrun_signals_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_signals_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_mount_flags_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_mount_flags_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_mount_flags_SOURCES = tests/tests_libcrun_mount_flags.c
 tests_tests_libcrun_mount_flags_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_mount_flags_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_chroot_realpath_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_chroot_realpath_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_chroot_realpath_SOURCES = tests/tests_libcrun_chroot_realpath.c
 tests_tests_libcrun_chroot_realpath_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_chroot_realpath_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_seccomp_notify_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_seccomp_notify_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_seccomp_notify_SOURCES = tests/tests_libcrun_seccomp_notify.c
 tests_tests_libcrun_seccomp_notify_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_seccomp_notify_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_cgroup_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_cgroup_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_srcdir)/libocispec/yyjson/src -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_cgroup_SOURCES = tests/tests_libcrun_cgroup.c
 tests_tests_libcrun_cgroup_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_cgroup_LDFLAGS = $(crun_LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These dependencies are required for the build:
 $ sudo dnf install -y \
     autoconf automake gcc git-core glibc-static go-md2man \
     libcap-devel libseccomp-devel libtool make pkg-config \
-    python python-libmount systemd-devel yajl-devel
+    python python-libmount systemd-devel yyjson-devel
 ```
 
 ### RHEL/CentOS Stream 9
@@ -69,7 +69,7 @@ $ sudo dnf config-manager --set-enabled crb
 $ sudo dnf install -y \
     autoconf automake gcc git-core glibc-static go-md2man \
     libcap-devel libseccomp-devel libtool make pkg-config \
-    python python-libmount systemd-devel yajl-devel
+    python python-libmount systemd-devel yyjson-devel
 ```
 
 ### RHEL/CentOS Stream 10
@@ -82,13 +82,13 @@ $ sudo dnf install -y \
     python python-libmount systemd-devel
 ```
 
-NOTE that you need to add `--enable-embedded-yajl` to `./configure` flags below.
+NOTE that you need to add `--enable-embedded-yyjson` to `./configure` flags below.
 
 ### Ubuntu
 
 ```console
 $ sudo apt-get install -y make git gcc build-essential pkgconf libtool \
-   libsystemd-dev libprotobuf-c-dev libcap-dev libseccomp-dev libyajl-dev \
+   libsystemd-dev libprotobuf-c-dev libcap-dev libseccomp-dev libyyjson-dev \
    go-md2man autoconf python3 automake
 ```
 
@@ -96,14 +96,14 @@ $ sudo apt-get install -y make git gcc build-essential pkgconf libtool \
 
 ```console
 # apk add gcc automake autoconf libtool gettext pkgconf git make musl-dev \
-    python3 libcap-dev libseccomp-dev yajl-dev argp-standalone go-md2man
+    python3 libcap-dev libseccomp-dev yyjson-dev argp-standalone go-md2man
 ```
 
 ### Tumbleweed
 
 ```console
 # zypper install make automake autoconf gettext libtool gcc libcap-devel \
-systemd-devel libyajl-devel libseccomp-devel python3 go-md2man \
+systemd-devel libyyjson-devel libseccomp-devel python3 go-md2man \
 glibc-static;
 ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -67,15 +67,15 @@ esac
 [enable_libcrun=true])
 AM_CONDITIONAL([ENABLE_LIBCRUN], [test "x${enable_libcrun}" = xtrue])
 
-dnl embedded yajl
-AC_ARG_ENABLE(embedded-yajl,
-AS_HELP_STRING([--enable-embedded-yajl], [Statically link a modified yajl version]),
+dnl embedded yyjson
+AC_ARG_ENABLE(embedded-yyjson,
+AS_HELP_STRING([--enable-embedded-yyjson], [Statically link the embedded yyjson version]),
 [
 case "${enableval}" in
-	yes) embedded_yajl=true ;;
-	no)  embedded_yajl=false ;;
-	*) AC_MSG_ERROR(bad value ${enableval} for --enable-embedded-yajl) ;;
-esac],[embedded_yajl=false])
+	yes) embedded_yyjson=true ;;
+	no)  embedded_yyjson=false ;;
+	*) AC_MSG_ERROR(bad value ${enableval} for --enable-embedded-yyjson) ;;
+esac],[embedded_yyjson=auto])
 
 AC_ARG_ENABLE(dynload-libcrun,
 AS_HELP_STRING([--enable-dynload-libcrun], [Dynamically load libcrun]),
@@ -87,11 +87,17 @@ case "${enableval}" in
 esac],[dynload_libcrun=false])
 AM_CONDITIONAL([DYNLOAD_LIBCRUN], [test x"$dynload_libcrun" = xtrue])
 
-AM_CONDITIONAL([HAVE_EMBEDDED_YAJL], [test x"$embedded_yajl" = xtrue])
-AM_COND_IF([HAVE_EMBEDDED_YAJL], [], [
-AC_SEARCH_LIBS(yajl_tree_get, [yajl], [AC_DEFINE([HAVE_YAJL], 1, [Define if libyajl is available])], [AC_MSG_ERROR([*** libyajl headers not found])])
-PKG_CHECK_MODULES([YAJL], [yajl >= 2.0.0])
+if test x"$embedded_yyjson" != xtrue; then
+PKG_CHECK_MODULES([YYJSON], [yyjson >= 0.8.0], [embedded_yyjson=false], [
+  if test x"$embedded_yyjson" = xauto; then
+    AC_MSG_NOTICE([yyjson not found on the system, using the embedded version])
+    embedded_yyjson=true
+  else
+    AC_MSG_ERROR([yyjson >= 0.8.0 not found and embedded yyjson is disabled])
+  fi
 ])
+fi
+AM_CONDITIONAL([HAVE_EMBEDDED_YYJSON], [test x"$embedded_yyjson" = xtrue])
 
 dnl libcap
 AC_ARG_ENABLE([caps],

--- a/contrib/honggfuzz.sh
+++ b/contrib/honggfuzz.sh
@@ -4,7 +4,7 @@
 
 test -e rootfs || mkdir rootfs
 
-./configure --enable-embedded-yajl CC=hfuzz-clang  CPPFLAGS='-D FUZZER' CFLAGS="-ggdb3"
+./configure --enable-embedded-yyjson CC=hfuzz-clang  CPPFLAGS='-D FUZZER' CFLAGS="-ggdb3"
 
 make
 

--- a/flake.nix
+++ b/flake.nix
@@ -72,9 +72,6 @@
             '';
           });
           staticLibseccomp = static pkgs.libseccomp;
-          staticYajl = pkgs.yajl.overrideAttrs (x: {
-            cmakeFlags = (x.cmakeFlags or []) ++ [ "-DBUILD_SHARED_LIBS=OFF" ];
-          });
           staticSystemd = (static pkgs.systemdMinimal).overrideAttrs (x: {
             outputs = [ "out" "dev" ];
             mesonFlags = x.mesonFlags ++ [
@@ -116,7 +113,7 @@
             inherit enableCriu enableSystemd;
             libcap = staticLibcap;
             libseccomp = staticLibseccomp;
-            yajl = staticYajl;
+            yyjson = pkgs.yyjson;
             libsystemd = staticSystemd;
             criu = staticCriu;
           };

--- a/lua/lua_crun.c
+++ b/lua/lua_crun.c
@@ -652,20 +652,23 @@ luacrun_ctx_update_container (lua_State *S)
   const char *content = luaL_checkstring (S, 3);
   luaL_checkstack (S, 2, NULL);
 
-  char errbuf[1024] = {};
-  yajl_val parsed_json = yajl_tree_parse (content, errbuf, sizeof (errbuf));
-  if (parsed_json == NULL)
+  struct parser_context parser_ctx = { .options = 0, .errfile = stderr };
+  libcrun_error_t crun_parse_err = NULL;
+  yyjson_doc *doc = NULL;
+  int parse_ret = parse_json_file (&doc, content, &parser_ctx, &crun_parse_err);
+  if (parse_ret < 0)
     {
       lua_pushboolean (S, false);
-      lua_pushfstring (S, "cannot parse the data: \"%s\"", errbuf);
+      lua_pushfstring (S, "cannot parse the data: \"%s\"", crun_parse_err ? crun_parse_err->msg : "unknown error");
+      if (crun_parse_err)
+        libcrun_error_release (&crun_parse_err);
       return 2;
     }
 
-  struct parser_context parser_ctx = { .options = 0, .errfile = stderr };
   runtime_spec_schema_config_schema_process *rt_spec_process;
   parser_error p_err = NULL;
-  rt_spec_process = make_runtime_spec_schema_config_schema_process (parsed_json, &parser_ctx, &p_err);
-  yajl_tree_free (parsed_json);
+  rt_spec_process = make_runtime_spec_schema_config_schema_process (yyjson_doc_get_root (doc), &parser_ctx, &p_err);
+  yyjson_doc_free (doc);
   if (rt_spec_process == NULL)
     {
       lua_pushboolean (S, false);

--- a/lua/luacrun.rockspec
+++ b/lua/luacrun.rockspec
@@ -24,8 +24,7 @@ dependencies = {"lua >= 5.4"}
 build = {
     type = "command",
     build_command = [[
-        rm -rf libocispec/yajl/src/api && ln -s ./headers/yajl libocispec/yajl/src/api &&
-        ./configure --prefix=$(PREFIX) --libdir=$(LIBDIR) --disable-lua-path-guessing --disable-crun --disable-libcrun --enable-shared --with-lua-bindings --enable-embedded-yajl LUA=$(LUA) LUA_INCLUDE=-I$(LUA_INCDIR) &&
+        ./configure --prefix=$(PREFIX) --libdir=$(LIBDIR) --disable-lua-path-guessing --disable-crun --disable-libcrun --enable-shared --with-lua-bindings --enable-embedded-yyjson LUA=$(LUA) LUA_INCLUDE=-I$(LUA_INCDIR) &&
         make -j]],
     install_command = "make install",
 }

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -5,7 +5,7 @@
 , libcap
 , libseccomp
 , libsystemd
-, yajl
+, yyjson
 , criu
 }:
 with pkgs; stdenv.mkDerivation {
@@ -34,7 +34,7 @@ with pkgs; stdenv.mkDerivation {
       libcap
       libseccomp
       libsystemd
-      yajl
+      yyjson
     ] ++ lib.optionals enableCriu [ criu ];
   configureFlags = [ "--enable-static" ] ++ lib.optional (!enableSystemd) [ "--disable-systemd" ];
   prePatch = let
@@ -48,7 +48,7 @@ with pkgs; stdenv.mkDerivation {
         "${lib.getLib libseccomp}/lib/libseccomp.a"
       ]
       ++ lib.optional enableSystemd "${lib.getLib libsystemd}/lib/libsystemd.a"
-      ++ [ "${yajl}/lib/libyajl.a" ];
+      ++ [ "${yyjson}/lib/libyyjson.a" ];
   in ''
     export CFLAGS='-static -pthread -DSTATIC'
     export LDFLAGS='-s -w -static-libgcc -static'

--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -360,20 +360,6 @@ container_status (PyObject *self arg_unused, PyObject *args)
   return PyUnicode_FromString (buffer);
 }
 
-static int
-load_json_file (yajl_val *out, const char *jsondata, struct parser_context *ctx arg_unused, libcrun_error_t *err)
-{
-    char errbuf[1024];
-
-    *err = NULL;
-
-    *out = yajl_tree_parse (jsondata, errbuf, sizeof (errbuf));
-    if (*out == NULL)
-      return libcrun_make_error (err, 0, "cannot parse the data: `%s`", errbuf);
-
-    return 0;
-}
-
 static PyObject *
 container_update (PyObject *self arg_unused, PyObject *args)
 {
@@ -382,7 +368,7 @@ container_update (PyObject *self arg_unused, PyObject *args)
   libcrun_context_t *ctx;
   char *id = NULL;
   char *content = NULL;
-  yajl_val tree = NULL;
+  yyjson_doc *doc = NULL;
   int ret;
   parser_error parser_err = NULL;
   struct parser_context parser_ctx = { 0, stderr };
@@ -395,12 +381,12 @@ container_update (PyObject *self arg_unused, PyObject *args)
   if (ctx == NULL)
     return NULL;
 
-  ret = load_json_file (&tree, content, &parser_ctx, &err);
+  ret = parse_json_file (&doc, content, &parser_ctx, &err);
   if (UNLIKELY (ret < 0))
     return set_error (&err);
 
-  process = make_runtime_spec_schema_config_schema_process (tree, &parser_ctx, &parser_err);
-  yajl_tree_free (tree);
+  process = make_runtime_spec_schema_config_schema_process (yyjson_doc_get_root (doc), &parser_ctx, &parser_err);
+  yyjson_doc_free (doc);
   if (process == NULL)
     {
       cleanup_free char *msg = NULL;

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -9,8 +9,7 @@ endif
 # rpm build deps
 srpm-dep:
 	$(SUDO_CMD) dnf -y install autoconf automake git git-archive-all \
-		libcap-devel libseccomp-devel libtool m4 rpm-build systemd-devel \
-		yajl-devel
+		libcap-devel libseccomp-devel libtool m4 rpm-build systemd-devel
 
 .ONESHELL:
 tarball-prep: srpm-dep
@@ -19,11 +18,11 @@ tarball-prep: srpm-dep
 	git config --global --add safe.directory /crun/libocispec
 	git config --global --add safe.directory /crun/libocispec/image-spec
 	git config --global --add safe.directory /crun/libocispec/runtime-spec
-	git config --global --add safe.directory /crun/libocispec/yajl
+	git config --global --add safe.directory /crun/libocispec/yyjson
 	git config --global --add safe.directory $(shell pwd)/libocispec
 	git config --global --add safe.directory $(shell pwd)/libocispec/image-spec
 	git config --global --add safe.directory $(shell pwd)/libocispec/runtime-spec
-	git config --global --add safe.directory $(shell pwd)/libocispec/yajl
+	git config --global --add safe.directory $(shell pwd)/libocispec/yyjson
 	git-archive-all --prefix=crun-HEAD/ --force-submodules crun-HEAD.tar.gz
 
 # Configure options intentionally don't match the ones used in crun.spec.in to

--- a/rpm/crun.spec
+++ b/rpm/crun.spec
@@ -1,6 +1,5 @@
 %global krun_opts %{nil}
 %global wasmedge_opts %{nil}
-%global yajl_opts %{nil}
 
 %if %{defined copr_username}
 %define copr_build 1
@@ -22,10 +21,8 @@
 
 %endif
 
-%if %{defined fedora} || (%{defined rhel} && 0%{?rhel} < 10)
-%global system_yajl 1
-%else
-%global yajl_opts --enable-embedded-yajl
+%if 0%{?fedora} && !0%{?eln}
+%global system_yyjson 1
 %endif
 
 Summary: OCI runtime written in C
@@ -59,8 +56,8 @@ BuildRequires: libcap-devel
 BuildRequires: libkrun-devel
 %endif
 BuildRequires: systemd-devel
-%if %{defined system_yajl}
-BuildRequires: yajl-devel
+%if %{defined system_yyjson}
+BuildRequires: yyjson-devel
 %endif
 BuildRequires: libseccomp-devel
 BuildRequires: python3-libmount
@@ -110,7 +107,7 @@ Recommends: wasmedge
 
 %build
 ./autogen.sh
-./configure --disable-silent-rules %{krun_opts} %{wasmedge_opts} %{yajl_opts}
+./configure --disable-silent-rules %{krun_opts} %{wasmedge_opts}
 %make_build
 
 %install

--- a/src/crun.c
+++ b/src/crun.c
@@ -278,7 +278,7 @@ print_version (FILE *stream, struct argp_state *state arg_unused)
 
   libcrun_handler_manager_print_feature_tags (libcrun_get_handler_manager (), stream);
 
-  fprintf (stream, "+YAJL\n");
+  fprintf (stream, "+YYJSON\n");
 }
 
 static error_t

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -63,10 +63,8 @@
 #  include <systemd/sd-daemon.h>
 #endif
 
-#include <yajl/yajl_tree.h>
-#include <yajl/yajl_gen.h>
-
-#define YAJL_STR(x) ((const unsigned char *) (x))
+#include <yyjson.h>
+#include <ocispec/json_common.h>
 
 enum
 {
@@ -699,7 +697,7 @@ do_hooks (runtime_spec_schema_config_schema *def, pid_t pid, const char *id, boo
   char *stdin = NULL;
   cleanup_free char *cwd_allocated = NULL;
   const char *rootfs = def->root ? def->root->path : "";
-  yajl_gen gen = NULL;
+  json_gen_ctx *gen = NULL;
 
   if (cwd == NULL)
     {
@@ -708,97 +706,96 @@ do_hooks (runtime_spec_schema_config_schema *def, pid_t pid, const char *id, boo
         OOM ();
     }
 
-  gen = yajl_gen_alloc (NULL);
-  if (gen == NULL)
-    return crun_make_error (err, 0, "yajl_gen_alloc failed");
+  if (! json_gen_init (&gen, NULL))
+    return crun_make_error (err, 0, "json_gen_init failed");
 
-  r = yajl_gen_map_open (gen);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_map_open (gen);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("ociVersion"), strlen ("ociVersion"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "ociVersion", strlen ("ociVersion"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("1.0"), strlen ("1.0"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "1.0", strlen ("1.0"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("id"), strlen ("id"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "id", strlen ("id"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR (id), strlen (id));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, id, strlen (id));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("pid"), strlen ("pid"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "pid", strlen ("pid"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_integer (gen, pid);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = map_int (gen, pid);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("root"), strlen ("root"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "root", strlen ("root"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR (rootfs), strlen (rootfs));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, rootfs, strlen (rootfs));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("bundle"), strlen ("bundle"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "bundle", strlen ("bundle"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR (cwd), strlen (cwd));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, cwd, strlen (cwd));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("status"), strlen ("status"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "status", strlen ("status"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR (status), strlen (status));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, status, strlen (status));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
   if (def && def->annotations && def->annotations->len)
     {
-      r = yajl_gen_string (gen, YAJL_STR ("annotations"), strlen ("annotations"));
-      if (UNLIKELY (r != yajl_gen_status_ok))
-        goto yajl_error;
+      r = json_gen_string (gen, "annotations", strlen ("annotations"));
+      if (UNLIKELY (r != json_gen_status_ok))
+        goto gen_error;
 
-      r = yajl_gen_map_open (gen);
-      if (UNLIKELY (r != yajl_gen_status_ok))
-        goto yajl_error;
+      r = json_gen_map_open (gen);
+      if (UNLIKELY (r != json_gen_status_ok))
+        goto gen_error;
 
       for (i = 0; i < def->annotations->len; i++)
         {
           const char *key = def->annotations->keys[i];
           const char *val = def->annotations->values[i];
 
-          r = yajl_gen_string (gen, YAJL_STR (key), strlen (key));
-          if (UNLIKELY (r != yajl_gen_status_ok))
-            goto yajl_error;
+          r = json_gen_string (gen, key, strlen (key));
+          if (UNLIKELY (r != json_gen_status_ok))
+            goto gen_error;
 
-          r = yajl_gen_string (gen, YAJL_STR (val), strlen (val));
-          if (UNLIKELY (r != yajl_gen_status_ok))
-            goto yajl_error;
+          r = json_gen_string (gen, val, strlen (val));
+          if (UNLIKELY (r != json_gen_status_ok))
+            goto gen_error;
         }
-      r = yajl_gen_map_close (gen);
-      if (UNLIKELY (r != yajl_gen_status_ok))
-        goto yajl_error;
+      r = json_gen_map_close (gen);
+      if (UNLIKELY (r != json_gen_status_ok))
+        goto gen_error;
     }
 
-  r = yajl_gen_map_close (gen);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_map_close (gen);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_get_buf (gen, (const unsigned char **) &stdin, &stdin_len);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_get_buf (gen, (const char **) &stdin, &stdin_len);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
   ret = 0;
 
@@ -835,25 +832,25 @@ do_hooks (runtime_spec_schema_config_schema *def, pid_t pid, const char *id, boo
     }
 
   if (gen)
-    yajl_gen_free (gen);
+    json_gen_free (gen);
 
   return ret;
 
-yajl_error:
+gen_error:
   if (gen)
-    yajl_gen_free (gen);
-  return yajl_error_to_crun_error (r, err);
+    json_gen_free (gen);
+  return json_gen_error_to_crun_error (r, err);
 }
 
 static int
-get_yajl_result (yajl_gen gen, char **out, size_t *out_len)
+get_json_gen_result (json_gen_ctx *gen, char **out, size_t *out_len)
 {
-  const unsigned char *buf = NULL;
+  const char *buf = NULL;
   size_t buf_len = 0;
   int r;
 
-  r = yajl_gen_get_buf (gen, &buf, &buf_len);
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_get_buf (gen, &buf, &buf_len);
+  if (UNLIKELY (r != json_gen_status_ok))
     return r;
 
   *out_len = buf_len;
@@ -862,7 +859,7 @@ get_yajl_result (yajl_gen gen, char **out, size_t *out_len)
   memcpy (*out, buf, buf_len);
   (*out)[buf_len] = '\0';
 
-  return yajl_gen_status_ok;
+  return json_gen_status_ok;
 }
 
 static int
@@ -870,51 +867,49 @@ get_seccomp_receiver_fd_payload (libcrun_container_t *container, const char *sta
                                  char **seccomp_fd_payload, size_t *seccomp_fd_payload_len, libcrun_error_t *err)
 {
   int r;
-  yajl_gen gen = NULL;
+  json_gen_ctx *gen = NULL;
   runtime_spec_schema_config_schema *def = container->container_def;
   const char *const OCI_VERSION = "0.2.0";
 
-  gen = yajl_gen_alloc (NULL);
-  if (gen == NULL)
-    return crun_make_error (err, 0, "yajl_gen_alloc failed");
+  if (! json_gen_init (&gen, NULL))
+    return crun_make_error (err, 0, "json_gen_init failed");
 
-  yajl_gen_config (gen, yajl_gen_beautify, 1);
-  yajl_gen_config (gen, yajl_gen_validate_utf8, 1);
+  json_gen_config (gen, json_gen_beautify, 1);
 
-  r = yajl_gen_map_open (gen);
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_map_open (gen);
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_string (gen, YAJL_STR ("ociVersion"), strlen ("ociVersion"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, "ociVersion", strlen ("ociVersion"));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_string (gen, YAJL_STR (OCI_VERSION), strlen (OCI_VERSION));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, OCI_VERSION, strlen (OCI_VERSION));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_string (gen, YAJL_STR ("fds"), strlen ("fds"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, "fds", strlen ("fds"));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_array_open (gen);
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_array_open (gen);
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_string (gen, YAJL_STR ("seccompFd"), strlen ("seccompFd"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, "seccompFd", strlen ("seccompFd"));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_array_close (gen);
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_array_close (gen);
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_string (gen, YAJL_STR ("pid"), strlen ("pid"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, "pid", strlen ("pid"));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_integer (gen, own_pid);
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = map_int (gen, own_pid);
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
   if (def && def->linux && def->linux->seccomp)
@@ -923,68 +918,68 @@ get_seccomp_receiver_fd_payload (libcrun_container_t *container, const char *sta
 
       if (metadata)
         {
-          r = yajl_gen_string (gen, YAJL_STR ("metadata"), strlen ("metadata"));
-          if (UNLIKELY (r != yajl_gen_status_ok))
+          r = json_gen_string (gen, "metadata", strlen ("metadata"));
+          if (UNLIKELY (r != json_gen_status_ok))
             goto exit;
 
-          r = yajl_gen_string (gen, YAJL_STR (metadata), strlen (metadata));
-          if (UNLIKELY (r != yajl_gen_status_ok))
+          r = json_gen_string (gen, metadata, strlen (metadata));
+          if (UNLIKELY (r != json_gen_status_ok))
             goto exit;
         }
     }
 
   /* State.  */
-  r = yajl_gen_string (gen, YAJL_STR ("state"), strlen ("state"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, "state", strlen ("state"));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_map_open (gen);
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_map_open (gen);
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_string (gen, YAJL_STR ("ociVersion"), strlen ("ociVersion"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, "ociVersion", strlen ("ociVersion"));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_string (gen, YAJL_STR (OCI_VERSION), strlen (OCI_VERSION));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, OCI_VERSION, strlen (OCI_VERSION));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
   if (container->context && container->context->id)
     {
-      r = yajl_gen_string (gen, YAJL_STR ("id"), strlen ("id"));
-      if (UNLIKELY (r != yajl_gen_status_ok))
+      r = json_gen_string (gen, "id", strlen ("id"));
+      if (UNLIKELY (r != json_gen_status_ok))
         goto exit;
 
-      r = yajl_gen_string (gen, YAJL_STR (container->context->id), strlen (container->context->id));
-      if (UNLIKELY (r != yajl_gen_status_ok))
+      r = json_gen_string (gen, container->context->id, strlen (container->context->id));
+      if (UNLIKELY (r != json_gen_status_ok))
         goto exit;
     }
 
-  r = yajl_gen_string (gen, YAJL_STR ("status"), strlen ("status"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, "status", strlen ("status"));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_string (gen, YAJL_STR (status), strlen (status));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, status, strlen (status));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_string (gen, YAJL_STR ("pid"), strlen ("pid"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_string (gen, "pid", strlen ("pid"));
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = yajl_gen_integer (gen, own_pid);
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = map_int (gen, own_pid);
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
   if (container->context && container->context->bundle)
     {
-      r = yajl_gen_string (gen, YAJL_STR ("bundle"), strlen ("bundle"));
-      if (UNLIKELY (r != yajl_gen_status_ok))
+      r = json_gen_string (gen, "bundle", strlen ("bundle"));
+      if (UNLIKELY (r != json_gen_status_ok))
         goto exit;
 
-      r = yajl_gen_string (gen, YAJL_STR (container->context->bundle), strlen (container->context->bundle));
-      if (UNLIKELY (r != yajl_gen_status_ok))
+      r = json_gen_string (gen, container->context->bundle, strlen (container->context->bundle));
+      if (UNLIKELY (r != json_gen_status_ok))
         goto exit;
     }
 
@@ -992,12 +987,12 @@ get_seccomp_receiver_fd_payload (libcrun_container_t *container, const char *sta
     {
       size_t i;
 
-      r = yajl_gen_string (gen, YAJL_STR ("annotations"), strlen ("annotations"));
-      if (UNLIKELY (r != yajl_gen_status_ok))
+      r = json_gen_string (gen, "annotations", strlen ("annotations"));
+      if (UNLIKELY (r != json_gen_status_ok))
         goto exit;
 
-      r = yajl_gen_map_open (gen);
-      if (UNLIKELY (r != yajl_gen_status_ok))
+      r = json_gen_map_open (gen);
+      if (UNLIKELY (r != json_gen_status_ok))
         goto exit;
 
       for (i = 0; i < def->annotations->len; i++)
@@ -1005,34 +1000,34 @@ get_seccomp_receiver_fd_payload (libcrun_container_t *container, const char *sta
           const char *key = def->annotations->keys[i];
           const char *val = def->annotations->values[i];
 
-          r = yajl_gen_string (gen, YAJL_STR (key), strlen (key));
-          if (UNLIKELY (r != yajl_gen_status_ok))
+          r = json_gen_string (gen, key, strlen (key));
+          if (UNLIKELY (r != json_gen_status_ok))
             goto exit;
 
-          r = yajl_gen_string (gen, YAJL_STR (val), strlen (val));
-          if (UNLIKELY (r != yajl_gen_status_ok))
+          r = json_gen_string (gen, val, strlen (val));
+          if (UNLIKELY (r != json_gen_status_ok))
             goto exit;
         }
-      r = yajl_gen_map_close (gen);
-      if (UNLIKELY (r != yajl_gen_status_ok))
+      r = json_gen_map_close (gen);
+      if (UNLIKELY (r != json_gen_status_ok))
         goto exit;
     }
 
-  r = yajl_gen_map_close (gen);
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_map_close (gen);
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
   /* End state.  */
 
-  r = yajl_gen_map_close (gen);
-  if (UNLIKELY (r != yajl_gen_status_ok))
+  r = json_gen_map_close (gen);
+  if (UNLIKELY (r != json_gen_status_ok))
     goto exit;
 
-  r = get_yajl_result (gen, seccomp_fd_payload, seccomp_fd_payload_len);
+  r = get_json_gen_result (gen, seccomp_fd_payload, seccomp_fd_payload_len);
 
 exit:
-  yajl_gen_free (gen);
+  json_gen_free (gen);
 
-  return yajl_error_to_crun_error (r, err);
+  return json_gen_error_to_crun_error (r, err);
 }
 
 static int
@@ -3507,8 +3502,8 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
   libcrun_container_status_t status = {};
   const char *state_root = context->state_root;
   const char *container_status = NULL;
-  yajl_gen gen = NULL;
-  const unsigned char *buf;
+  json_gen_ctx *gen = NULL;
+  const char *buf;
   int ret = 0;
   int running;
   size_t len;
@@ -3522,45 +3517,43 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
     goto exit;
 
   ret = 0;
-  gen = yajl_gen_alloc (NULL);
-  if (gen == NULL)
-    return crun_make_error (err, 0, "yajl_gen_alloc failed");
+  if (! json_gen_init (&gen, NULL))
+    return crun_make_error (err, 0, "json_gen_init failed");
 
-  yajl_gen_config (gen, yajl_gen_beautify, 1);
-  yajl_gen_config (gen, yajl_gen_validate_utf8, 1);
+  json_gen_config (gen, json_gen_beautify, 1);
 
-  yajl_gen_map_open (gen);
-  yajl_gen_string (gen, YAJL_STR ("ociVersion"), strlen ("ociVersion"));
-  yajl_gen_string (gen, YAJL_STR (OCI_CONFIG_VERSION), strlen (OCI_CONFIG_VERSION));
+  json_gen_map_open (gen);
+  json_gen_string (gen, "ociVersion", strlen ("ociVersion"));
+  json_gen_string (gen, OCI_CONFIG_VERSION, strlen (OCI_CONFIG_VERSION));
 
-  yajl_gen_string (gen, YAJL_STR ("id"), strlen ("id"));
-  yajl_gen_string (gen, YAJL_STR (id), strlen (id));
+  json_gen_string (gen, "id", strlen ("id"));
+  json_gen_string (gen, id, strlen (id));
 
-  yajl_gen_string (gen, YAJL_STR ("pid"), strlen ("pid"));
-  yajl_gen_integer (gen, running ? status.pid : 0);
+  json_gen_string (gen, "pid", strlen ("pid"));
+  map_int (gen, running ? status.pid : 0);
 
-  yajl_gen_string (gen, YAJL_STR ("status"), strlen ("status"));
-  yajl_gen_string (gen, YAJL_STR (container_status), strlen (container_status));
+  json_gen_string (gen, "status", strlen ("status"));
+  json_gen_string (gen, container_status, strlen (container_status));
 
-  yajl_gen_string (gen, YAJL_STR ("bundle"), strlen ("bundle"));
-  yajl_gen_string (gen, YAJL_STR (status.bundle), strlen (status.bundle));
+  json_gen_string (gen, "bundle", strlen ("bundle"));
+  json_gen_string (gen, status.bundle, strlen (status.bundle));
 
-  yajl_gen_string (gen, YAJL_STR ("rootfs"), strlen ("rootfs"));
-  yajl_gen_string (gen, YAJL_STR (status.rootfs), strlen (status.rootfs));
+  json_gen_string (gen, "rootfs", strlen ("rootfs"));
+  json_gen_string (gen, status.rootfs, strlen (status.rootfs));
 
-  yajl_gen_string (gen, YAJL_STR ("created"), strlen ("created"));
-  yajl_gen_string (gen, YAJL_STR (status.created), strlen (status.created));
+  json_gen_string (gen, "created", strlen ("created"));
+  json_gen_string (gen, status.created, strlen (status.created));
 
   if (status.scope)
     {
-      yajl_gen_string (gen, YAJL_STR ("systemd-scope"), strlen ("systemd-scope"));
-      yajl_gen_string (gen, YAJL_STR (status.scope), strlen (status.scope));
+      json_gen_string (gen, "systemd-scope", strlen ("systemd-scope"));
+      json_gen_string (gen, status.scope, strlen (status.scope));
     }
 
   if (status.owner)
     {
-      yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));
-      yajl_gen_string (gen, YAJL_STR (status.owner), strlen (status.owner));
+      json_gen_string (gen, "owner", strlen ("owner"));
+      json_gen_string (gen, status.owner, strlen (status.owner));
     }
 
   {
@@ -3586,22 +3579,22 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
 
     if (container->container_def->annotations && container->container_def->annotations->len)
       {
-        yajl_gen_string (gen, YAJL_STR ("annotations"), strlen ("annotations"));
-        yajl_gen_map_open (gen);
+        json_gen_string (gen, "annotations", strlen ("annotations"));
+        json_gen_map_open (gen);
         for (i = 0; i < container->container_def->annotations->len; i++)
           {
             const char *key = container->container_def->annotations->keys[i];
             const char *val = container->container_def->annotations->values[i];
-            yajl_gen_string (gen, YAJL_STR (key), strlen (key));
-            yajl_gen_string (gen, YAJL_STR (val), strlen (val));
+            json_gen_string (gen, key, strlen (key));
+            json_gen_string (gen, val, strlen (val));
           }
-        yajl_gen_map_close (gen);
+        json_gen_map_close (gen);
       }
   }
 
-  yajl_gen_map_close (gen);
+  json_gen_map_close (gen);
 
-  if (yajl_gen_get_buf (gen, &buf, &len) != yajl_gen_status_ok)
+  if (json_gen_get_buf (gen, &buf, &len) != json_gen_status_ok)
     {
       ret = crun_make_error (err, 0, "error generating JSON");
       goto exit;
@@ -3611,7 +3604,7 @@ libcrun_container_state (libcrun_context_t *context, const char *id, FILE *out, 
 
 exit:
   if (gen)
-    yajl_gen_free (gen);
+    json_gen_free (gen);
   libcrun_free_container_status (&status);
   return ret;
 }
@@ -3976,7 +3969,8 @@ libcrun_container_exec_with_options (libcrun_context_t *context, const char *id,
       struct parser_context ctx = { 0, stderr };
       cleanup_free char *content = NULL;
       parser_error parser_err = NULL;
-      yajl_val tree = NULL;
+      yyjson_doc *doc = NULL;
+      yyjson_val *tree = NULL;
       size_t len;
 
       if (process)
@@ -3986,23 +3980,25 @@ libcrun_container_exec_with_options (libcrun_context_t *context, const char *id,
       if (UNLIKELY (ret < 0))
         return ret;
 
-      ret = parse_json_file (&tree, content, &ctx, err);
+      ret = parse_json_file (&doc, content, &ctx, err);
       if (UNLIKELY (ret < 0))
         return ret;
+
+      tree = yyjson_doc_get_root (doc);
 
       process = make_runtime_spec_schema_config_schema_process (tree, &ctx, &parser_err);
       if (UNLIKELY (process == NULL))
         {
           ret = crun_make_error (err, 0, "cannot parse process file: `%s`", parser_err);
           free (parser_err);
-          if (tree)
-            yajl_tree_free (tree);
+          if (doc)
+            yyjson_doc_free (doc);
           return ret;
         }
 
       free (parser_err);
-      if (tree)
-        yajl_tree_free (tree);
+      if (doc)
+        yyjson_doc_free (doc);
 
       process_cleanup = process;
     }
@@ -4176,7 +4172,8 @@ libcrun_container_update (libcrun_context_t *context, const char *id, const char
   struct parser_context ctx = { 0, stderr };
   libcrun_container_status_t status = {};
   parser_error parser_err = NULL;
-  yajl_val tree = NULL;
+  yyjson_doc *doc = NULL;
+  yyjson_val *tree = NULL;
   int ret;
 
   ret = libcrun_read_container_status (&status, state_root, id, err);
@@ -4195,9 +4192,11 @@ libcrun_container_update (libcrun_context_t *context, const char *id, const char
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = parse_json_file (&tree, content, &ctx, err);
+  ret = parse_json_file (&doc, content, &ctx, err);
   if (UNLIKELY (ret < 0))
     return ret;
+
+  tree = yyjson_doc_get_root (doc);
 
   resources = make_runtime_spec_schema_config_linux_resources (tree, &ctx, &parser_err);
   if (UNLIKELY (resources == NULL))
@@ -4226,8 +4225,8 @@ libcrun_container_update (libcrun_context_t *context, const char *id, const char
   ret = libcrun_linux_container_update (&status, state_root, resources, err);
 
 cleanup:
-  if (tree)
-    yajl_tree_free (tree);
+  if (doc)
+    yyjson_doc_free (doc);
   free (parser_err);
   if (resources)
     free_runtime_spec_schema_config_linux_resources (resources);
@@ -4268,15 +4267,14 @@ libcrun_container_update_from_values (libcrun_context_t *context, const char *id
                                       libcrun_error_t *err)
 {
   const char *current_section = NULL;
-  const unsigned char *buf;
-  yajl_gen gen = NULL;
+  const char *buf;
+  json_gen_ctx *gen = NULL;
   size_t i, buf_len;
   int ret;
 
-  gen = yajl_gen_alloc (NULL);
-  if (gen == NULL)
-    return crun_make_error (err, 0, "yajl_gen_alloc failed");
-  yajl_gen_map_open (gen);
+  if (! json_gen_init (&gen, NULL))
+    return crun_make_error (err, 0, "json_gen_init failed");
+  json_gen_map_open (gen);
 
   qsort (values, len, sizeof (struct libcrun_update_value_s), compare_update_values);
 
@@ -4285,30 +4283,30 @@ libcrun_container_update_from_values (libcrun_context_t *context, const char *id
       if (current_section == NULL || strcmp (values[i].section, current_section))
         {
           if (i > 0)
-            yajl_gen_map_close (gen);
+            json_gen_map_close (gen);
 
           current_section = values[i].section;
-          yajl_gen_string (gen, YAJL_STR (current_section), strlen (current_section));
-          yajl_gen_map_open (gen);
+          json_gen_string (gen, current_section, strlen (current_section));
+          json_gen_map_open (gen);
         }
 
-      yajl_gen_string (gen, (const unsigned char *) values[i].name, strlen (values[i].name));
+      json_gen_string (gen, values[i].name, strlen (values[i].name));
 
       if (values[i].numeric)
-        yajl_gen_number (gen, (const char *) values[i].value, strlen (values[i].value));
+        json_gen_number (gen, values[i].value, strlen (values[i].value));
       else
-        yajl_gen_string (gen, (const unsigned char *) values[i].value, strlen (values[i].value));
+        json_gen_string (gen, values[i].value, strlen (values[i].value));
     }
   if (len)
-    yajl_gen_map_close (gen);
+    json_gen_map_close (gen);
 
-  yajl_gen_map_close (gen);
+  json_gen_map_close (gen);
 
-  yajl_gen_get_buf (gen, &buf, &buf_len);
+  json_gen_get_buf (gen, &buf, &buf_len);
 
-  ret = libcrun_container_update (context, id, (const char *) buf, buf_len, err);
+  ret = libcrun_container_update (context, id, buf, buf_len, err);
 
-  yajl_gen_free (gen);
+  json_gen_free (gen);
 
   return ret;
 }
@@ -4879,8 +4877,8 @@ int
 libcrun_write_json_containers_list (libcrun_context_t *context, FILE *out, libcrun_error_t *err)
 {
   libcrun_container_list_t *list = NULL, *it;
-  const unsigned char *content = NULL;
-  yajl_gen gen = NULL;
+  const char *content = NULL;
+  json_gen_ctx *gen = NULL;
   size_t len;
   int ret;
 
@@ -4888,16 +4886,14 @@ libcrun_write_json_containers_list (libcrun_context_t *context, FILE *out, libcr
   if (UNLIKELY (ret < 0))
     return ret;
 
-  gen = yajl_gen_alloc (NULL);
-  if (gen == NULL)
+  if (! json_gen_init (&gen, NULL))
     {
       ret = crun_make_error (err, 0, "cannot allocate json generator");
       goto exit;
     }
 
-  yajl_gen_config (gen, yajl_gen_beautify, 1);
-  yajl_gen_config (gen, yajl_gen_validate_utf8, 1);
-  yajl_gen_array_open (gen);
+  json_gen_config (gen, json_gen_beautify, 1);
+  json_gen_array_open (gen);
 
   for (it = list; it; it = it->next)
     {
@@ -4923,26 +4919,26 @@ libcrun_write_json_containers_list (libcrun_context_t *context, FILE *out, libcr
       if (! running)
         pid = 0;
 
-      yajl_gen_map_open (gen);
-      yajl_gen_string (gen, YAJL_STR ("id"), strlen ("id"));
-      yajl_gen_string (gen, YAJL_STR (it->name), strlen (it->name));
-      yajl_gen_string (gen, YAJL_STR ("pid"), strlen ("pid"));
-      yajl_gen_integer (gen, pid);
-      yajl_gen_string (gen, YAJL_STR ("status"), strlen ("status"));
-      yajl_gen_string (gen, YAJL_STR (container_status), strlen (container_status));
-      yajl_gen_string (gen, YAJL_STR ("bundle"), strlen ("bundle"));
-      yajl_gen_string (gen, YAJL_STR (status.bundle), strlen (status.bundle));
-      yajl_gen_string (gen, YAJL_STR ("created"), strlen ("created"));
-      yajl_gen_string (gen, YAJL_STR (status.created), strlen (status.created));
-      yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));
-      yajl_gen_string (gen, YAJL_STR (status.owner), strlen (status.owner));
-      yajl_gen_map_close (gen);
+      json_gen_map_open (gen);
+      json_gen_string (gen, "id", strlen ("id"));
+      json_gen_string (gen, it->name, strlen (it->name));
+      json_gen_string (gen, "pid", strlen ("pid"));
+      map_int (gen, pid);
+      json_gen_string (gen, "status", strlen ("status"));
+      json_gen_string (gen, container_status, strlen (container_status));
+      json_gen_string (gen, "bundle", strlen ("bundle"));
+      json_gen_string (gen, status.bundle, strlen (status.bundle));
+      json_gen_string (gen, "created", strlen ("created"));
+      json_gen_string (gen, status.created, strlen (status.created));
+      json_gen_string (gen, "owner", strlen ("owner"));
+      json_gen_string (gen, status.owner, strlen (status.owner));
+      json_gen_map_close (gen);
 
       libcrun_free_container_status (&status);
     }
 
-  yajl_gen_array_close (gen);
-  if (yajl_gen_get_buf (gen, &content, &len) != yajl_gen_status_ok)
+  json_gen_array_close (gen);
+  if (json_gen_get_buf (gen, &content, &len) != json_gen_status_ok)
     {
       ret = libcrun_make_error (err, 0, "cannot generate json list");
       goto exit;
@@ -4966,7 +4962,7 @@ exit:
   if (list)
     libcrun_free_containers_list (list);
   if (gen)
-    yajl_gen_free (gen);
+    json_gen_free (gen);
 
   return ret;
 }
@@ -5005,9 +5001,9 @@ libcrun_container_add_or_remove_mounts_from_file (libcrun_context_t *context, co
   struct parser_context pctx = { 0, stderr };
   libcrun_container_status_t status = {};
   cleanup_free char *content = NULL;
-  yajl_val tree = NULL;
+  yyjson_doc *doc = NULL;
+  yyjson_val *tree = NULL;
   size_t n_mounts = 0, len, i;
-  yajl_val *values;
   int ret = 1;
 
   ret = read_all_file (file, &content, &len, err);
@@ -5022,24 +5018,25 @@ libcrun_container_add_or_remove_mounts_from_file (libcrun_context_t *context, co
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = parse_json_file (&tree, content, &pctx, err);
+  ret = parse_json_file (&doc, content, &pctx, err);
   if (UNLIKELY (ret < 0))
     return ret;
 
-  if (! YAJL_IS_ARRAY (tree))
+  tree = yyjson_doc_get_root (doc);
+
+  if (! yyjson_is_arr (tree))
     {
       ret = crun_make_error (err, 0, "mounts must be an array");
       goto cleanup;
     }
   else
     {
-      values = YAJL_GET_ARRAY (tree)->values;
-      n_mounts = YAJL_GET_ARRAY (tree)->len;
+      n_mounts = yyjson_arr_size (tree);
 
       mounts = xmalloc0 ((n_mounts + 1) * sizeof (*mounts));
       for (i = 0; i < n_mounts; i++)
         {
-          mounts[i] = make_runtime_spec_schema_defs_mount (values[i], &pctx, &parser_err);
+          mounts[i] = make_runtime_spec_schema_defs_mount (yyjson_arr_get (tree, i), &pctx, &parser_err);
           if (mounts[i] == NULL)
             {
               ret = crun_make_error (err, 0, "cannot parse mount: %s", parser_err);
@@ -5054,8 +5051,8 @@ libcrun_container_add_or_remove_mounts_from_file (libcrun_context_t *context, co
     ret = libcrun_destroy_runtime_mounts (container, &status, mounts, n_mounts, err);
 
 cleanup:
-  if (tree)
-    yajl_tree_free (tree);
+  if (doc)
+    yyjson_doc_free (doc);
   if (mounts)
     for (i = 0; i < n_mounts; i++)
       free_runtime_spec_schema_defs_mount (mounts[i]);

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -979,8 +979,8 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
   {
     cleanup_free char *descriptors_path = NULL;
     cleanup_free char *buffer = NULL;
-    char err_buffer[256];
-    yajl_val tree;
+    yyjson_doc *doc = NULL;
+    yyjson_val *tree;
 
     ret = append_paths (&descriptors_path, err, cr_options->image_path, DESCRIPTORS_FILENAME, NULL);
     if (UNLIKELY (ret < 0))
@@ -996,28 +996,29 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
      * a pipe 'pipe:' we tell CRIU to reconnect that pipe
      * to the corresponding FD to have (especially) stdout
      * and stderr being correctly redirected. */
-    tree = yajl_tree_parse (buffer, err_buffer, sizeof (err_buffer));
-    if (UNLIKELY (tree == NULL))
+    doc = yyjson_read (buffer, strlen (buffer), 0);
+    if (UNLIKELY (doc == NULL))
       return crun_make_error (err, 0, "cannot parse descriptors file `%s`", DESCRIPTORS_FILENAME);
 
-    if (tree && YAJL_IS_ARRAY (tree))
+    tree = yyjson_doc_get_root (doc);
+    if (tree && yyjson_is_arr (tree))
       {
-        size_t i, len = tree->u.array.len;
+        size_t i, len = yyjson_arr_size (tree);
 
         /* len will probably always be 3 as crun is currently only
          * recording the destination of FD 0, 1 and 2. */
         for (i = 0; i < len; ++i)
           {
-            yajl_val s = tree->u.array.values[i];
-            if (s && YAJL_IS_STRING (s))
+            yyjson_val *s = yyjson_arr_get (tree, i);
+            if (s && yyjson_is_str (s))
               {
-                char *str = YAJL_GET_STRING (s);
+                const char *str = yyjson_get_str (s);
                 if (has_prefix (str, "pipe:"))
                   libcriu_wrapper->criu_add_inherit_fd (i, str);
               }
           }
       }
-    yajl_tree_free (tree);
+    yyjson_doc_free (doc);
   }
 
   /* work_dir is the place CRIU will put its logfiles. If not explicitly set,

--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -26,14 +26,12 @@
 #include <stdio.h>
 #include "utils.h"
 
-#include <yajl/yajl_tree.h>
-#include <yajl/yajl_gen.h>
+#include <yyjson.h>
+#include <ocispec/json_common.h>
 
 #ifdef HAVE_SYSTEMD
 #  include <systemd/sd-journal.h>
 #endif
-
-#define YAJL_STR(x) ((const unsigned char *) (x))
 
 enum
 {
@@ -385,46 +383,45 @@ make_json_error (const char *msg, int errno_, int verbosity)
       level = "error";
       break;
     }
-  const unsigned char *buf = NULL;
-  yajl_gen gen = NULL;
+  const char *buf = NULL;
+  json_gen_ctx *gen = NULL;
   char *ret = NULL;
   size_t buf_len;
   timestamp_t timestamp = {
     0,
   };
 
-  gen = yajl_gen_alloc (NULL);
-  if (gen == NULL)
+  if (! json_gen_init (&gen, NULL))
     return NULL;
 
   get_timestamp (&timestamp, "");
 
-  yajl_gen_map_open (gen);
+  json_gen_map_open (gen);
 
-  yajl_gen_string (gen, YAJL_STR ("msg"), strlen ("msg"));
+  json_gen_string (gen, "msg", strlen ("msg"));
   if (errno_ == 0)
-    yajl_gen_string (gen, YAJL_STR (msg), strlen (msg));
+    json_gen_string (gen, msg, strlen (msg));
   else
     {
       cleanup_free char *tmp = NULL;
 
       xasprintf (&tmp, "%s: %s", msg, strerror (errno_));
-      yajl_gen_string (gen, YAJL_STR (tmp), strlen (tmp));
+      json_gen_string (gen, tmp, strlen (tmp));
     }
 
-  yajl_gen_string (gen, YAJL_STR ("level"), strlen ("level"));
-  yajl_gen_string (gen, YAJL_STR (level), strlen (level));
+  json_gen_string (gen, "level", strlen ("level"));
+  json_gen_string (gen, level, strlen (level));
 
-  yajl_gen_string (gen, YAJL_STR ("time"), strlen ("time"));
-  yajl_gen_string (gen, YAJL_STR (timestamp), strlen (timestamp));
+  json_gen_string (gen, "time", strlen ("time"));
+  json_gen_string (gen, timestamp, strlen (timestamp));
 
-  yajl_gen_map_close (gen);
+  json_gen_map_close (gen);
 
-  yajl_gen_get_buf (gen, &buf, &buf_len);
+  json_gen_get_buf (gen, &buf, &buf_len);
   if (buf)
-    ret = strdup ((const char *) buf);
+    ret = strdup (buf);
 
-  yajl_gen_free (gen);
+  json_gen_free (gen);
 
   return ret;
 }
@@ -514,35 +511,14 @@ libcrun_set_log_format (const char *format, libcrun_error_t *err)
 }
 
 int
-yajl_error_to_crun_error (int yajl_status, libcrun_error_t *err)
+json_gen_error_to_crun_error (int status, libcrun_error_t *err)
 {
-  switch (yajl_status)
+  switch (status)
     {
-    case yajl_gen_status_ok:
+    case json_gen_status_ok:
       return 0;
 
-    case yajl_gen_keys_must_be_strings:
-      return crun_make_error (err, 0, "generate JSON document: gen keys must be strings");
-
-    case yajl_max_depth_exceeded:
-      return crun_make_error (err, 0, "generate JSON document: max depth exceeded");
-
-    case yajl_gen_in_error_state:
-      return crun_make_error (err, 0, "generate JSON document: complete JSON document generated");
-
-    case yajl_gen_generation_complete:
-      return crun_make_error (err, 0, "generate JSON document: called while in error state");
-
-    case yajl_gen_invalid_number:
-      return crun_make_error (err, 0, "generate JSON document: invalid number");
-
-    case yajl_gen_no_buf:
-      return crun_make_error (err, 0, "generate JSON document: no buffer provided");
-
-    case yajl_gen_invalid_string:
-      return crun_make_error (err, 0, "generate JSON document: invalid string");
-
     default:
-      return crun_make_error (err, 0, "generate JSON document");
+      return crun_make_error (err, 0, "generate JSON document: error");
     }
 }

--- a/src/libcrun/error.h
+++ b/src/libcrun/error.h
@@ -112,7 +112,7 @@ LIBCRUN_PUBLIC int libcrun_init_logging (crun_output_handler *output_handler, vo
 
 LIBCRUN_PUBLIC int libcrun_error_release (libcrun_error_t *err);
 
-int yajl_error_to_crun_error (int yajl_status, libcrun_error_t *err);
+int json_gen_error_to_crun_error (int gen_status, libcrun_error_t *err);
 
 enum
 {

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -85,7 +85,8 @@ struct krun_config
   bool has_kvm;
   bool has_awsnitro;
   int passt_fds[2];
-  yajl_val config_tree;
+  yyjson_doc *config_doc;
+  yyjson_val *config_tree;
   bool use_passt;
 };
 
@@ -109,47 +110,43 @@ libkrun_create_context (void *handle, libcrun_error_t *err)
 }
 
 static int
-libkrun_configure_kernel (uint32_t ctx_id, void *handle, yajl_val *config_tree, libcrun_error_t *err)
+libkrun_configure_kernel (uint32_t ctx_id, void *handle, yyjson_val *config_tree, libcrun_error_t *err)
 {
   int32_t (*krun_set_kernel) (uint32_t ctx_id, const char *kernel_path,
                               uint32_t kernel_format, const char *initrd_path, const char *kernel_cmdline);
-  const char *path_kernel_path[] = { "kernel_path", (const char *) 0 };
-  const char *path_kernel_format[] = { "kernel_format", (const char *) 0 };
-  const char *path_initrd_path[] = { "initrd_path", (const char *) 0 };
-  const char *path_kernel_cmdline[] = { "kernel_cmdline", (const char *) 0 };
-  yajl_val kernel_path = NULL;
-  yajl_val kernel_format = NULL;
-  yajl_val val_initrd_path = NULL;
-  yajl_val val_kernel_cmdline = NULL;
-  char *initrd_path = NULL;
-  char *kernel_cmdline = NULL;
+  yyjson_val *kernel_path = NULL;
+  yyjson_val *kernel_format = NULL;
+  yyjson_val *val_initrd_path = NULL;
+  yyjson_val *val_kernel_cmdline = NULL;
+  const char *initrd_path = NULL;
+  const char *kernel_cmdline = NULL;
   int ret;
 
   /* kernel_path and kernel_format must be present */
-  kernel_path = yajl_tree_get (*config_tree, path_kernel_path, yajl_t_string);
-  if (kernel_path == NULL || ! YAJL_IS_STRING (kernel_path))
+  kernel_path = yyjson_obj_get (config_tree, "kernel_path");
+  if (kernel_path == NULL || ! yyjson_is_str (kernel_path))
     return 0;
 
-  kernel_format = yajl_tree_get (*config_tree, path_kernel_format, yajl_t_number);
-  if (kernel_format == NULL || ! YAJL_IS_INTEGER (kernel_format))
+  kernel_format = yyjson_obj_get (config_tree, "kernel_format");
+  if (kernel_format == NULL || ! yyjson_is_int (kernel_format))
     return 0;
 
   /* initrd and kernel_cmdline are optional */
-  val_initrd_path = yajl_tree_get (*config_tree, path_initrd_path, yajl_t_string);
-  if (val_initrd_path != NULL && YAJL_IS_STRING (val_initrd_path))
-    initrd_path = YAJL_GET_STRING (val_initrd_path);
+  val_initrd_path = yyjson_obj_get (config_tree, "initrd_path");
+  if (val_initrd_path != NULL && yyjson_is_str (val_initrd_path))
+    initrd_path = yyjson_get_str (val_initrd_path);
 
-  val_kernel_cmdline = yajl_tree_get (*config_tree, path_kernel_cmdline, yajl_t_string);
-  if (val_kernel_cmdline != NULL && YAJL_IS_STRING (val_kernel_cmdline))
-    kernel_cmdline = YAJL_GET_STRING (val_kernel_cmdline);
+  val_kernel_cmdline = yyjson_obj_get (config_tree, "kernel_cmdline");
+  if (val_kernel_cmdline != NULL && yyjson_is_str (val_kernel_cmdline))
+    kernel_cmdline = yyjson_get_str (val_kernel_cmdline);
 
   krun_set_kernel = dlsym (handle, "krun_set_kernel");
   if (krun_set_kernel == NULL)
     return crun_make_error (err, 0, "could not find symbol in krun library");
 
   ret = krun_set_kernel (ctx_id,
-                         YAJL_GET_STRING (kernel_path),
-                         YAJL_GET_INTEGER (kernel_format),
+                         yyjson_get_str (kernel_path),
+                         (uint32_t) yyjson_get_sint (kernel_format),
                          initrd_path, kernel_cmdline);
 
   if (UNLIKELY (ret < 0))
@@ -177,7 +174,6 @@ libkrun_read_vm_config (struct krun_config *kconf, int rootfsfd, const char *roo
   int ret;
   cleanup_free char *config = NULL;
   cleanup_close int fd = -1;
-  struct parser_context ctx = { 0, stderr };
 
   fd = safe_openat (rootfsfd, rootfs, KRUN_VM_FILE, O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0, err);
   if (fd < 0)
@@ -195,10 +191,11 @@ libkrun_read_vm_config (struct krun_config *kconf, int rootfsfd, const char *roo
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = parse_json_file (&kconf->config_tree, config, &ctx, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
+  kconf->config_doc = yyjson_read (config, strlen (config), 0);
+  if (kconf->config_doc == NULL)
+    return crun_make_error (err, 0, "cannot parse `%s`", KRUN_VM_FILE);
 
+  kconf->config_tree = yyjson_doc_get_root (kconf->config_doc);
   return 0;
 }
 
@@ -211,11 +208,11 @@ libkrun_read_vm_config (struct krun_config *kconf, int rootfsfd, const char *roo
  * OCI annotations -> krun_vm.json.
  */
 static int
-libkrun_parse_resource_configuration (yajl_val *config_tree, libcrun_container_t *container, const char *annotation, const char *path[])
+libkrun_parse_resource_configuration (yyjson_val *config_tree, libcrun_container_t *container, const char *annotation, const char *key)
 {
   char *val_str, *endptr;
   int val = -1;
-  yajl_val val_json = NULL;
+  yyjson_val *val_json = NULL;
 
   val_str = (char *) find_annotation (container, annotation);
   if (val_str != NULL)
@@ -231,14 +228,15 @@ libkrun_parse_resource_configuration (yajl_val *config_tree, libcrun_container_t
 
       return val;
     }
-  else if (*config_tree != NULL)
+  else if (config_tree != NULL)
     {
-      val_json = yajl_tree_get (*config_tree, path, yajl_t_number);
+      val_json = yyjson_obj_get (config_tree, key);
       if (val_json == NULL)
         return val;
-      if (! YAJL_IS_INTEGER (val_json))
-        error (EXIT_FAILURE, 0, "krun krun_vm.json %s value is not an integer", path[0]);
-      val = (int) YAJL_GET_INTEGER (val_json);
+      if (! yyjson_is_int (val_json))
+        error (EXIT_FAILURE, 0, "krun krun_vm.json %s value is not an integer", key);
+
+      val = (int) yyjson_get_sint (val_json);
     }
 
   return val;
@@ -252,11 +250,8 @@ libkrun_configure_vm (uint32_t ctx_id, void *handle, struct krun_config *kconf, 
   int32_t (*krun_add_net_unixstream) (uint32_t ctx_id, const char *c_path, int fd, uint8_t *const c_mac, uint32_t features, uint32_t flags);
   int cpus, ram_mib, gpu_flags, ret;
   cpu_set_t set;
-  const char *path_cpus[] = { "cpus", (const char *) 0 };
-  const char *path_ram_mib[] = { "ram_mib", (const char *) 0 };
-  const char *path_gpu_flags[] = { "gpu_flags", (const char *) 0 };
 
-  cpus = libkrun_parse_resource_configuration (&kconf->config_tree, container, "krun.cpus", path_cpus);
+  cpus = libkrun_parse_resource_configuration (kconf->config_tree, container, "krun.cpus", "cpus");
   if (cpus <= 0)
     {
       CPU_ZERO (&set);
@@ -266,7 +261,7 @@ libkrun_configure_vm (uint32_t ctx_id, void *handle, struct krun_config *kconf, 
         cpus = 1;
     }
 
-  ram_mib = libkrun_parse_resource_configuration (&kconf->config_tree, container, "krun.ram_mib", path_ram_mib);
+  ram_mib = libkrun_parse_resource_configuration (kconf->config_tree, container, "krun.ram_mib", "ram_mib");
   if (ram_mib <= LIBKRUN_MINIMUM_RAM_MIB)
     {
       if (def && def->linux && def->linux->resources && def->linux->resources->memory
@@ -285,7 +280,7 @@ libkrun_configure_vm (uint32_t ctx_id, void *handle, struct krun_config *kconf, 
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, -ret, "could not set krun vm configuration");
 
-  gpu_flags = libkrun_parse_resource_configuration (&kconf->config_tree, container, "krun.gpu_flags", path_gpu_flags);
+  gpu_flags = libkrun_parse_resource_configuration (kconf->config_tree, container, "krun.gpu_flags", "gpu_flags");
   if (gpu_flags > 0)
     {
       if (access ("/dev/dri", F_OK) != 0)
@@ -315,7 +310,7 @@ libkrun_configure_vm (uint32_t ctx_id, void *handle, struct krun_config *kconf, 
        * specify a kernel, libkrun automatically fall back to using libkrunfw,
        * if the library is present and was loaded while creating the context.
        */
-      ret = libkrun_configure_kernel (ctx_id, handle, &kconf->config_tree, err);
+      ret = libkrun_configure_kernel (ctx_id, handle, kconf->config_tree, err);
       if (UNLIKELY (ret))
         return ret;
     }
@@ -324,12 +319,11 @@ libkrun_configure_vm (uint32_t ctx_id, void *handle, struct krun_config *kconf, 
 }
 
 static int
-libkrun_configure_flavor (void *cookie, yajl_val *config_tree, libcrun_container_t *container, libcrun_error_t *err)
+libkrun_configure_flavor (void *cookie, yyjson_val *config_tree, libcrun_container_t *container, libcrun_error_t *err)
 {
   int ret, sev_indicated = 0, awsnitro_indicated = 0;
-  const char *path_flavor[] = { "flavor", (const char *) 0 };
   struct krun_config *kconf = (struct krun_config *) cookie;
-  yajl_val val_flavor = NULL;
+  yyjson_val *val_flavor = NULL;
   const char *flavor = NULL;
   void *close_handles[2];
 
@@ -338,12 +332,12 @@ libkrun_configure_flavor (void *cookie, yajl_val *config_tree, libcrun_container
 
   // Check if the user provided the krun variant through OCI annotations.
   flavor = find_annotation (container, "krun.variant");
-  if (flavor == NULL && *config_tree != NULL)
+  if (flavor == NULL && config_tree != NULL)
     {
       // If the user doesn't specify a variant via OCI annotations, check the krun VM config to see if the "flavor" field was populated.
-      val_flavor = yajl_tree_get (*config_tree, path_flavor, yajl_t_string);
-      if (val_flavor != NULL && YAJL_IS_STRING (val_flavor))
-        flavor = YAJL_GET_STRING (val_flavor);
+      val_flavor = yyjson_obj_get (config_tree, "flavor");
+      if (val_flavor != NULL && yyjson_is_str (val_flavor))
+        flavor = yyjson_get_str (val_flavor);
     }
 
   if (flavor != NULL)
@@ -420,7 +414,7 @@ libkrun_exec (void *cookie, libcrun_container_t *container, const char *pathname
   int32_t ctx_id, ret;
   libcrun_error_t err;
 
-  ret = libkrun_configure_flavor (cookie, &kconf->config_tree, container, &err);
+  ret = libkrun_configure_flavor (cookie, kconf->config_tree, container, &err);
   if (UNLIKELY (ret < 0))
     {
       int errcode = crun_error_get_errno (&err);
@@ -471,23 +465,21 @@ libkrun_exec (void *cookie, libcrun_container_t *container, const char *pathname
     }
   else
     {
-      const char *path_virtiofs_tag[] = { "virtiofs_tag", (const char *) 0 };
-      const char *path_virtiofs_shm_size[] = { "virtiofs_shm_size", (const char *) 0 };
-      yajl_val val_virtiofs_tag = NULL;
-      yajl_val val_virtiofs_shm_size = NULL;
+      yyjson_val *val_virtiofs_tag = NULL;
+      yyjson_val *val_virtiofs_shm_size = NULL;
       const char *virtiofs_tag = NULL;
       // Default to a conservative DAX size of 512MB, just like krun_set_root() does.
       uint64_t virtiofs_shm_size = 512 * 1024 * 1024ULL;
 
       if (kconf->config_tree != NULL)
         {
-          val_virtiofs_tag = yajl_tree_get (kconf->config_tree, path_virtiofs_tag, yajl_t_string);
-          if (val_virtiofs_tag != NULL && YAJL_IS_STRING (val_virtiofs_tag))
-            virtiofs_tag = YAJL_GET_STRING (val_virtiofs_tag);
+          val_virtiofs_tag = yyjson_obj_get (kconf->config_tree, "virtiofs_tag");
+          if (val_virtiofs_tag != NULL && yyjson_is_str (val_virtiofs_tag))
+            virtiofs_tag = yyjson_get_str (val_virtiofs_tag);
 
-          val_virtiofs_shm_size = yajl_tree_get (kconf->config_tree, path_virtiofs_shm_size, yajl_t_number);
-          if (val_virtiofs_shm_size != NULL && YAJL_IS_INTEGER (val_virtiofs_shm_size))
-            virtiofs_shm_size = (uint64_t) YAJL_GET_INTEGER (val_virtiofs_shm_size);
+          val_virtiofs_shm_size = yyjson_obj_get (kconf->config_tree, "virtiofs_shm_size");
+          if (val_virtiofs_shm_size != NULL && yyjson_is_int (val_virtiofs_shm_size))
+            virtiofs_shm_size = (uint64_t) yyjson_get_sint (val_virtiofs_shm_size);
         }
 
       if (virtiofs_tag == NULL)
@@ -530,7 +522,7 @@ libkrun_exec (void *cookie, libcrun_container_t *container, const char *pathname
       error (EXIT_FAILURE, errcode, "could not configure krun vm");
     }
 
-  yajl_tree_free (kconf->config_tree);
+  yyjson_doc_free (kconf->config_doc);
 
   ret = krun_start_enter (ctx_id);
   if (UNLIKELY (ret < 0))
@@ -543,7 +535,6 @@ static int
 libkrun_start_passt (void *cookie, libcrun_container_t *container)
 {
   struct krun_config *kconf = (struct krun_config *) cookie;
-  const char *path_use_passt[] = { "use_passt", (const char *) 0 };
   pid_t pid;
   char *passt_argv[9];
   char fd_as_str[16];
@@ -553,7 +544,7 @@ libkrun_start_passt (void *cookie, libcrun_container_t *container)
   int null;
   int ret;
 
-  use_passt = libkrun_parse_resource_configuration (&kconf->config_tree, container, "krun.use_passt", path_use_passt);
+  use_passt = libkrun_parse_resource_configuration (kconf->config_tree, container, "krun.use_passt", "use_passt");
   if (use_passt > 0)
     kconf->use_passt = 1;
   else

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -70,13 +70,11 @@
 #include <linux/sched.h>
 #include <linux/magic.h>
 
-#include <yajl/yajl_tree.h>
-#include <yajl/yajl_gen.h>
+#include <yyjson.h>
+#include <ocispec/json_common.h>
 
 #include "mount_flags.h"
 #include "syscalls.h"
-
-#define YAJL_STR(x) ((const unsigned char *) (x))
 
 #ifndef RLIMIT_RTTIME
 #  define RLIMIT_RTTIME 15
@@ -3837,19 +3835,18 @@ libcrun_get_external_descriptors (libcrun_container_t *container)
 int
 libcrun_save_external_descriptors (libcrun_container_t *container, pid_t pid, libcrun_error_t *err)
 {
-  const unsigned char *buf = NULL;
-  yajl_gen gen = NULL;
+  const char *buf = NULL;
+  json_gen_ctx *gen = NULL;
   size_t buf_len;
   int ret;
   int i;
 
-  gen = yajl_gen_alloc (NULL);
-  if (gen == NULL)
-    return crun_make_error (err, 0, "yajl_gen_alloc");
+  if (! json_gen_init (&gen, NULL))
+    return crun_make_error (err, errno, "json_gen_init");
 
-  ret = yajl_gen_array_open (gen);
-  if (UNLIKELY (ret != yajl_gen_status_ok))
-    goto yajl_error;
+  ret = json_gen_array_open (gen);
+  if (UNLIKELY (ret != json_gen_status_ok))
+    goto json_error;
 
   /* Remember original stdin, stdout, stderr for container restore.  */
   for (i = 0; i < 3; i++)
@@ -3870,24 +3867,24 @@ libcrun_save_external_descriptors (libcrun_container_t *container, pid_t pid, li
             }
           else
             {
-              yajl_gen_free (gen);
+              json_gen_free (gen);
               return crun_make_error (err, errno, "readlink `%s`", fd_path);
             }
         }
       link_path[ret] = 0;
 
-      ret = yajl_gen_string (gen, YAJL_STR (link_path), ret);
-      if (UNLIKELY (ret != yajl_gen_status_ok))
-        goto yajl_error;
+      ret = json_gen_string (gen, link_path, ret);
+      if (UNLIKELY (ret != json_gen_status_ok))
+        goto json_error;
     }
 
-  ret = yajl_gen_array_close (gen);
-  if (UNLIKELY (ret != yajl_gen_status_ok))
-    goto yajl_error;
+  ret = json_gen_array_close (gen);
+  if (UNLIKELY (ret != json_gen_status_ok))
+    goto json_error;
 
-  ret = yajl_gen_get_buf (gen, &buf, &buf_len);
-  if (UNLIKELY (ret != yajl_gen_status_ok))
-    goto yajl_error;
+  ret = json_gen_get_buf (gen, &buf, &buf_len);
+  if (UNLIKELY (ret != json_gen_status_ok))
+    goto json_error;
 
   if (buf)
     {
@@ -3897,14 +3894,14 @@ libcrun_save_external_descriptors (libcrun_container_t *container, pid_t pid, li
       get_private_data (container)->external_descriptors = b;
     }
 
-  yajl_gen_free (gen);
+  json_gen_free (gen);
 
   return 0;
 
-yajl_error:
+json_error:
   if (gen)
-    yajl_gen_free (gen);
-  return yajl_error_to_crun_error (ret, err);
+    json_gen_free (gen);
+  return json_gen_error_to_crun_error (ret, err);
 }
 
 int

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -23,14 +23,13 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <yajl/yajl_tree.h>
+#include <yyjson.h>
+#include <ocispec/json_common.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <dirent.h>
 #include <signal.h>
-
-#define YAJL_STR(x) ((const unsigned char *) (x))
 
 #define STEAL_POINTER(x, y) \
   do                        \
@@ -229,10 +228,10 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   cleanup_free char *file = NULL;
   size_t len;
   cleanup_close int fd_write = -1;
-  const unsigned char *buf = NULL;
+  const char *buf = NULL;
   struct pid_stat st;
   const char *tmp;
-  yajl_gen gen = NULL;
+  json_gen_ctx *gen = NULL;
 
   ret = get_state_directory_status_file (&file, state_root, id, err);
   if (UNLIKELY (ret < 0))
@@ -249,117 +248,115 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   if (UNLIKELY (fd_write < 0))
     return crun_make_error (err, errno, "cannot open status file");
 
-  gen = yajl_gen_alloc (NULL);
-  if (gen == NULL)
-    return crun_make_error (err, 0, "yajl_gen_alloc failed");
+  if (! json_gen_init (&gen, NULL))
+    return crun_make_error (err, 0, "json_gen_init failed");
 
-  yajl_gen_config (gen, yajl_gen_beautify, 1);
-  yajl_gen_config (gen, yajl_gen_validate_utf8, 1);
+  json_gen_config (gen, json_gen_beautify, 1);
 
-  r = yajl_gen_map_open (gen);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_map_open (gen);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("pid"), strlen ("pid"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "pid", strlen ("pid"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_integer (gen, status->pid);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = map_int (gen, status->pid);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("process-start-time"), strlen ("process-start-time"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "process-start-time", strlen ("process-start-time"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_integer (gen, status->process_start_time);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = map_int (gen, status->process_start_time);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("cgroup-path"), strlen ("cgroup-path"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "cgroup-path", strlen ("cgroup-path"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
   tmp = status->cgroup_path ? status->cgroup_path : "";
-  r = yajl_gen_string (gen, YAJL_STR (tmp), strlen (tmp));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, tmp, strlen (tmp));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("scope"), strlen ("scope"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "scope", strlen ("scope"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
   tmp = status->scope ? status->scope : "";
-  r = yajl_gen_string (gen, YAJL_STR (tmp), strlen (tmp));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, tmp, strlen (tmp));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("rootfs"), strlen ("rootfs"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "rootfs", strlen ("rootfs"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR (status->rootfs), strlen (status->rootfs));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, status->rootfs, strlen (status->rootfs));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("systemd-cgroup"), strlen ("systemd-cgroup"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "systemd-cgroup", strlen ("systemd-cgroup"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_bool (gen, status->systemd_cgroup);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_bool (gen, status->systemd_cgroup);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("bundle"), strlen ("bundle"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "bundle", strlen ("bundle"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR (status->bundle), strlen (status->bundle));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, status->bundle, strlen (status->bundle));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("created"), strlen ("created"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "created", strlen ("created"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR (status->created), strlen (status->created));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, status->created, strlen (status->created));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
   if (status->owner)
     {
-      r = yajl_gen_string (gen, YAJL_STR ("owner"), strlen ("owner"));
-      if (UNLIKELY (r != yajl_gen_status_ok))
-        goto yajl_error;
+      r = json_gen_string (gen, "owner", strlen ("owner"));
+      if (UNLIKELY (r != json_gen_status_ok))
+        goto gen_error;
 
-      r = yajl_gen_string (gen, YAJL_STR (status->owner), strlen (status->owner));
-      if (UNLIKELY (r != yajl_gen_status_ok))
-        goto yajl_error;
+      r = json_gen_string (gen, status->owner, strlen (status->owner));
+      if (UNLIKELY (r != json_gen_status_ok))
+        goto gen_error;
     }
 
-  r = yajl_gen_string (gen, YAJL_STR ("detached"), strlen ("detached"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "detached", strlen ("detached"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_bool (gen, status->detached);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_bool (gen, status->detached);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR ("external_descriptors"), strlen ("external_descriptors"));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, "external_descriptors", strlen ("external_descriptors"));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_string (gen, YAJL_STR (status->external_descriptors), strlen (status->external_descriptors));
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_string (gen, status->external_descriptors, strlen (status->external_descriptors));
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_map_close (gen);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_map_close (gen);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
-  r = yajl_gen_get_buf (gen, &buf, &len);
-  if (UNLIKELY (r != yajl_gen_status_ok))
-    goto yajl_error;
+  r = json_gen_get_buf (gen, &buf, &len);
+  if (UNLIKELY (r != json_gen_status_ok))
+    goto gen_error;
 
   ret = safe_write (fd_write, "status file", buf, len, err);
   if (UNLIKELY (ret < 0))
@@ -375,15 +372,15 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
 
 exit:
   if (gen)
-    yajl_gen_free (gen);
+    json_gen_free (gen);
 
   return ret;
 
-yajl_error:
+gen_error:
   if (gen)
-    yajl_gen_free (gen);
+    json_gen_free (gen);
 
-  return yajl_error_to_crun_error (r, err);
+  return json_gen_error_to_crun_error (r, err);
 }
 
 int
@@ -391,10 +388,11 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
                                libcrun_error_t *err)
 {
   cleanup_free char *buffer = NULL;
-  char err_buffer[256];
   int ret;
   cleanup_free char *file = NULL;
-  yajl_val tree, tmp;
+  yyjson_doc *doc = NULL;
+  yyjson_val *tree, *tmp;
+  const char *val;
 
   ret = get_state_directory_status_file (&file, state_root, id, err);
   if (UNLIKELY (ret < 0))
@@ -425,77 +423,79 @@ libcrun_read_container_status (libcrun_container_status_t *status, const char *s
       return ret;
     }
 
-  tree = yajl_tree_parse (buffer, err_buffer, sizeof (err_buffer));
-  if (UNLIKELY (tree == NULL))
-    return crun_make_error (err, 0, "cannot parse status file: `%s`", err_buffer);
+  doc = yyjson_read (buffer, strlen (buffer), 0);
+  if (UNLIKELY (doc == NULL))
+    return crun_make_error (err, 0, "cannot parse status file");
+  tree = yyjson_doc_get_root (doc);
 
   {
-    const char *pid_path[] = { "pid", NULL };
-    tmp = yajl_tree_get (tree, pid_path, yajl_t_number);
+    tmp = yyjson_obj_get (tree, "pid");
     if (UNLIKELY (tmp == NULL))
       return crun_make_error (err, 0, "`pid` missing in `%s`", file);
-    status->pid = strtoull (YAJL_GET_NUMBER (tmp), NULL, 10);
+    status->pid = (pid_t) yyjson_get_int (tmp);
   }
   {
-    const char *process_start_time_path[] = { "process-start-time", NULL };
-    tmp = yajl_tree_get (tree, process_start_time_path, yajl_t_number);
+    tmp = yyjson_obj_get (tree, "process-start-time");
     if (UNLIKELY (tmp == NULL))
       status->process_start_time = 0; /* backwards compatibility */
     else
-      status->process_start_time = strtoull (YAJL_GET_NUMBER (tmp), NULL, 10);
+      status->process_start_time = yyjson_get_uint (tmp);
   }
   {
-    const char *cgroup_path[] = { "cgroup-path", NULL };
-    tmp = yajl_tree_get (tree, cgroup_path, yajl_t_string);
+    tmp = yyjson_obj_get (tree, "cgroup-path");
     if (UNLIKELY (tmp == NULL))
       return crun_make_error (err, 0, "`cgroup-path` missing in `%s`", file);
-    status->cgroup_path = xstrdup (YAJL_GET_STRING (tmp));
+    val = yyjson_get_str (tmp);
+    if (UNLIKELY (val == NULL))
+      return crun_make_error (err, 0, "`cgroup-path` is not a string in `%s`", file);
+    status->cgroup_path = xstrdup (val);
   }
   {
-    const char *scope[] = { "scope", NULL };
-    tmp = yajl_tree_get (tree, scope, yajl_t_string);
-    status->scope = tmp ? xstrdup (YAJL_GET_STRING (tmp)) : NULL;
+    tmp = yyjson_obj_get (tree, "scope");
+    status->scope = tmp ? xstrdup (yyjson_get_str (tmp)) : NULL;
   }
   {
-    const char *rootfs[] = { "rootfs", NULL };
-    tmp = yajl_tree_get (tree, rootfs, yajl_t_string);
+    tmp = yyjson_obj_get (tree, "rootfs");
     if (UNLIKELY (tmp == NULL))
       return crun_make_error (err, 0, "`rootfs` missing in `%s`", file);
-    status->rootfs = xstrdup (YAJL_GET_STRING (tmp));
+    val = yyjson_get_str (tmp);
+    if (UNLIKELY (val == NULL))
+      return crun_make_error (err, 0, "`rootfs` is not a string in `%s`", file);
+    status->rootfs = xstrdup (val);
   }
   {
-    const char *systemd_cgroup[] = { "systemd-cgroup", NULL };
-    status->systemd_cgroup = YAJL_IS_TRUE (yajl_tree_get (tree, systemd_cgroup, yajl_t_true));
+    status->systemd_cgroup = yyjson_is_true (yyjson_obj_get (tree, "systemd-cgroup"));
   }
   {
-    const char *bundle[] = { "bundle", NULL };
-    tmp = yajl_tree_get (tree, bundle, yajl_t_string);
+    tmp = yyjson_obj_get (tree, "bundle");
     if (UNLIKELY (tmp == NULL))
       return crun_make_error (err, 0, "`bundle` missing in `%s`", file);
-    status->bundle = xstrdup (YAJL_GET_STRING (tmp));
+    val = yyjson_get_str (tmp);
+    if (UNLIKELY (val == NULL))
+      return crun_make_error (err, 0, "`bundle` is not a string in `%s`", file);
+    status->bundle = xstrdup (val);
   }
   {
-    const char *created[] = { "created", NULL };
-    tmp = yajl_tree_get (tree, created, yajl_t_string);
+    tmp = yyjson_obj_get (tree, "created");
     if (UNLIKELY (tmp == NULL))
       return crun_make_error (err, 0, "`created` missing in `%s`", file);
-    status->created = xstrdup (YAJL_GET_STRING (tmp));
+    val = yyjson_get_str (tmp);
+    if (UNLIKELY (val == NULL))
+      return crun_make_error (err, 0, "`created` is not a string in `%s`", file);
+    status->created = xstrdup (val);
   }
   {
-    const char *owner[] = { "owner", NULL };
-    tmp = yajl_tree_get (tree, owner, yajl_t_string);
-    status->owner = tmp ? xstrdup (YAJL_GET_STRING (tmp)) : NULL;
+    tmp = yyjson_obj_get (tree, "owner");
+    status->owner = tmp ? xstrdup (yyjson_get_str (tmp)) : NULL;
   }
   {
-    const char *detached[] = { "detached", NULL };
-    status->detached = YAJL_IS_TRUE (yajl_tree_get (tree, detached, yajl_t_true));
+    status->detached = yyjson_is_true (yyjson_obj_get (tree, "detached"));
   }
   {
-    const char *external_descriptors[] = { "external_descriptors", NULL };
-    tmp = yajl_tree_get (tree, external_descriptors, yajl_t_string);
-    status->external_descriptors = tmp ? xstrdup (YAJL_GET_STRING (tmp)) : NULL;
+    tmp = yyjson_obj_get (tree, "external_descriptors");
+    status->external_descriptors = tmp ? xstrdup (yyjson_get_str (tmp)) : NULL;
   }
-  yajl_tree_free (tree);
+  yyjson_doc_free (doc);
   return 0;
 }
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1915,15 +1915,16 @@ set_blocking_fd (int fd, bool blocking, libcrun_error_t *err)
 }
 
 int
-parse_json_file (yajl_val *out, const char *jsondata, struct parser_context *ctx arg_unused, libcrun_error_t *err)
+parse_json_file (yyjson_doc **out, const char *jsondata, struct parser_context *ctx arg_unused, libcrun_error_t *err)
 {
-  char errbuf[1024];
-
   *err = NULL;
 
-  *out = yajl_tree_parse (jsondata, errbuf, sizeof (errbuf));
+  if (UNLIKELY (jsondata == NULL))
+    return crun_make_error (err, 0, "JSON data is NULL");
+
+  *out = yyjson_read (jsondata, strlen (jsondata), YYJSON_READ_NUMBER_AS_RAW);
   if (*out == NULL)
-    return crun_make_error (err, 0, "cannot parse the data: `%s`", errbuf);
+    return crun_make_error (err, 0, "cannot parse the data");
 
   return 0;
 }

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -352,7 +352,7 @@ void get_current_timestamp (char *out, size_t len);
 
 int set_blocking_fd (int fd, bool blocking, libcrun_error_t *err);
 
-int parse_json_file (yajl_val *out, const char *jsondata, struct parser_context *ctx, libcrun_error_t *err);
+int parse_json_file (yyjson_doc **out, const char *jsondata, struct parser_context *ctx, libcrun_error_t *err);
 
 static inline int
 has_prefix (const char *str, const char *prefix)

--- a/src/oci_features.c
+++ b/src/oci_features.c
@@ -23,8 +23,8 @@
 #include <unistd.h>
 #include <errno.h>
 
-#include <yajl/yajl_tree.h>
-#include <yajl/yajl_gen.h>
+#include <yyjson.h>
+#include <ocispec/json_common.h>
 
 #include "crun.h"
 #include "libcrun/container.h"
@@ -36,7 +36,7 @@ static struct argp_option options[] = { { 0 } };
 
 static char args_doc[] = "features";
 
-const unsigned char *json_string;
+const char *json_string;
 
 size_t json_length;
 
@@ -54,21 +54,21 @@ parse_opt (int key, char *arg arg_unused, struct argp_state *state arg_unused)
 static struct argp run_argp = { options, parse_opt, args_doc, doc, NULL, NULL, NULL };
 
 void
-add_string_to_json (yajl_gen json_gen, const char *key, char *value)
+add_string_to_json (json_gen_ctx *json_gen, const char *key, char *value)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) key, strlen (key));
-  yajl_gen_string (json_gen, (const unsigned char *) value, strlen (value));
+  json_gen_string (json_gen, key, strlen (key));
+  json_gen_string (json_gen, value, strlen (value));
 }
 
 void
-add_bool_to_json (yajl_gen json_gen, const char *key, int value)
+add_bool_to_json (json_gen_ctx *json_gen, const char *key, int value)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) key, strlen (key));
-  yajl_gen_bool (json_gen, value);
+  json_gen_string (json_gen, key, strlen (key));
+  json_gen_bool (json_gen, value);
 }
 
 void
-add_bool_str_to_json (yajl_gen json_gen, const char *key, int value)
+add_bool_str_to_json (json_gen_ctx *json_gen, const char *key, int value)
 {
   char *val = "";
   if (value)
@@ -80,66 +80,66 @@ add_bool_str_to_json (yajl_gen json_gen, const char *key, int value)
       val = "false";
     }
 
-  yajl_gen_string (json_gen, (const unsigned char *) key, strlen (key));
-  yajl_gen_string (json_gen, (const unsigned char *) val, strlen (val));
+  json_gen_string (json_gen, key, strlen (key));
+  json_gen_string (json_gen, val, strlen (val));
 }
 
 void
-add_array_to_json (yajl_gen json_gen, const char *key, char **array)
+add_array_to_json (json_gen_ctx *json_gen, const char *key, char **array)
 {
   size_t i;
-  yajl_gen_string (json_gen, (const unsigned char *) key, strlen (key));
-  yajl_gen_array_open (json_gen);
+  json_gen_string (json_gen, key, strlen (key));
+  json_gen_array_open (json_gen);
 
   for (i = 0; array[i] != NULL; i++)
-    yajl_gen_string (json_gen, (const unsigned char *) array[i], strlen (array[i]));
+    json_gen_string (json_gen, array[i], strlen (array[i]));
 
-  yajl_gen_array_close (json_gen);
+  json_gen_array_close (json_gen);
 }
 
 void
-crun_features_add_hooks (yajl_gen json_gen, char **hooks)
+crun_features_add_hooks (json_gen_ctx *json_gen, char **hooks)
 {
   add_array_to_json (json_gen, "hooks", hooks);
 }
 
 void
-crun_features_add_mount_options (yajl_gen json_gen, char **mount_options)
+crun_features_add_mount_options (json_gen_ctx *json_gen, char **mount_options)
 {
   add_array_to_json (json_gen, "mountOptions", mount_options);
 }
 
 void
-crun_features_add_namespaces (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_namespaces (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
   add_array_to_json (json_gen, "namespaces", linux->namespaces);
 }
 
 void
-crun_features_add_capabilities (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_capabilities (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
   add_array_to_json (json_gen, "capabilities", linux->capabilities);
 }
 
 void
-crun_features_add_cgroup_info (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_cgroup_info (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) "cgroup", strlen ("cgroup"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "cgroup", strlen ("cgroup"));
+  json_gen_map_open (json_gen);
 
   add_bool_to_json (json_gen, "v1", linux->cgroup.v1);
   add_bool_to_json (json_gen, "v2", linux->cgroup.v2);
   add_bool_to_json (json_gen, "systemd", linux->cgroup.systemd);
   add_bool_to_json (json_gen, "systemdUser", linux->cgroup.systemd_user);
 
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 }
 
 void
-crun_features_add_seccomp_info (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_seccomp_info (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) "seccomp", strlen ("seccomp"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "seccomp", strlen ("seccomp"));
+  json_gen_map_open (json_gen);
 
   add_bool_to_json (json_gen, "enabled", linux->seccomp.enabled);
   if (linux->seccomp.actions)
@@ -147,14 +147,14 @@ crun_features_add_seccomp_info (yajl_gen json_gen, const struct linux_info_s *li
   if (linux->seccomp.operators)
     add_array_to_json (json_gen, "operators", linux->seccomp.operators);
 
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 }
 
 void
-crun_features_add_mempolicy_info (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_mempolicy_info (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) "memoryPolicy", strlen ("memoryPolicy"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "memoryPolicy", strlen ("memoryPolicy"));
+  json_gen_map_open (json_gen);
 
   if (linux->memory_policy.mode)
     add_array_to_json (json_gen, "modes", linux->memory_policy.mode);
@@ -162,68 +162,68 @@ crun_features_add_mempolicy_info (yajl_gen json_gen, const struct linux_info_s *
   if (linux->memory_policy.flags)
     add_array_to_json (json_gen, "flags", linux->memory_policy.flags);
 
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 }
 
 void
-crun_features_add_apparmor_info (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_apparmor_info (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) "apparmor", strlen ("apparmor"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "apparmor", strlen ("apparmor"));
+  json_gen_map_open (json_gen);
 
   add_bool_to_json (json_gen, "enabled", linux->apparmor.enabled);
 
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 }
 
 void
-crun_features_add_selinux_info (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_selinux_info (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) "selinux", strlen ("selinux"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "selinux", strlen ("selinux"));
+  json_gen_map_open (json_gen);
 
   add_bool_to_json (json_gen, "enabled", linux->selinux.enabled);
 
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 }
 
 void
-crun_features_add_mount_ext_info (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_mount_ext_info (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) "mountExtensions", strlen ("mountExtensions"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "mountExtensions", strlen ("mountExtensions"));
+  json_gen_map_open (json_gen);
 
-  yajl_gen_string (json_gen, (const unsigned char *) "idmap", strlen ("idmap"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "idmap", strlen ("idmap"));
+  json_gen_map_open (json_gen);
   add_bool_to_json (json_gen, "enabled", linux->mount_ext.idmap.enabled);
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 }
 
 void
-crun_features_add_intel_rdt (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_intel_rdt (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) "intelRdt", strlen ("intelRdt"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "intelRdt", strlen ("intelRdt"));
+  json_gen_map_open (json_gen);
   add_bool_to_json (json_gen, "enabled", linux->intel_rdt.enabled);
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 }
 
 void
-crun_features_add_net_devices (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_net_devices (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) "netDevices", strlen ("netDevices"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "netDevices", strlen ("netDevices"));
+  json_gen_map_open (json_gen);
   add_bool_to_json (json_gen, "enabled", linux->net_devices.enabled);
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 }
 
 void
-crun_features_add_linux_info (yajl_gen json_gen, const struct linux_info_s *linux)
+crun_features_add_linux_info (json_gen_ctx *json_gen, const struct linux_info_s *linux)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) "linux", strlen ("linux"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "linux", strlen ("linux"));
+  json_gen_map_open (json_gen);
 
   crun_features_add_namespaces (json_gen, linux);
   crun_features_add_capabilities (json_gen, linux);
@@ -236,14 +236,14 @@ crun_features_add_linux_info (yajl_gen json_gen, const struct linux_info_s *linu
   crun_features_add_net_devices (json_gen, linux);
   crun_features_add_mempolicy_info (json_gen, linux);
 
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 }
 
 void
-crun_features_add_annotations_info (yajl_gen json_gen, const struct annotations_info_s *annotation)
+crun_features_add_annotations_info (json_gen_ctx *json_gen, const struct annotations_info_s *annotation)
 {
-  yajl_gen_string (json_gen, (const unsigned char *) "annotations", strlen ("annotations"));
-  yajl_gen_map_open (json_gen);
+  json_gen_string (json_gen, "annotations", strlen ("annotations"));
+  json_gen_map_open (json_gen);
 
   if (! is_empty_string (annotation->io_github_seccomp_libseccomp_version))
     add_string_to_json (json_gen, "io.github.seccomp.libseccomp.version", annotation->io_github_seccomp_libseccomp_version);
@@ -256,11 +256,11 @@ crun_features_add_annotations_info (yajl_gen json_gen, const struct annotations_
 
   add_bool_str_to_json (json_gen, "run.oci.crun.wasm", annotation->run_oci_crun_wasm);
 
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 }
 
 void
-crun_features_add_potentially_unsafe_config_annotations_info (yajl_gen json_gen, char **annotations)
+crun_features_add_potentially_unsafe_config_annotations_info (json_gen_ctx *json_gen, char **annotations)
 {
   add_array_to_json (json_gen, "potentiallyUnsafeConfigAnnotations", annotations);
 }
@@ -273,7 +273,7 @@ crun_command_features (struct crun_global_arguments *global_args, int argc, char
   libcrun_context_t crun_context = {
     0,
   };
-  yajl_gen json_gen;
+  json_gen_ctx *json_gen;
 
   argp_parse (&run_argp, argc, argv, 0, 0, &options);
 
@@ -287,14 +287,13 @@ crun_command_features (struct crun_global_arguments *global_args, int argc, char
     return ret;
 
   // Prepare the JSON output
-  json_gen = yajl_gen_alloc (NULL);
-  if (json_gen == NULL)
+  if (! json_gen_init (&json_gen, NULL))
     return libcrun_make_error (err, 0, "Failed to initialize json structure");
 
-  yajl_gen_config (json_gen, yajl_gen_beautify, 1); // Optional: Enable pretty formatting
+  json_gen_config (json_gen, json_gen_beautify, 1); // Optional: Enable pretty formatting
 
   // Start building the JSON
-  yajl_gen_map_open (json_gen);
+  json_gen_map_open (json_gen);
 
   // Add ociVersionMin field
   add_string_to_json (json_gen, "ociVersionMin", info->oci_version_min);
@@ -318,13 +317,13 @@ crun_command_features (struct crun_global_arguments *global_args, int argc, char
   crun_features_add_potentially_unsafe_config_annotations_info (json_gen, info->potentially_unsafe_annotations);
 
   // End building the JSON
-  yajl_gen_map_close (json_gen);
+  json_gen_map_close (json_gen);
 
-  yajl_gen_get_buf (json_gen, &json_string, &json_length);
+  json_gen_get_buf (json_gen, &json_string, &json_length);
 
-  printf ("%s", (const char *) json_string);
+  printf ("%s", json_string);
 
-  yajl_gen_free (json_gen);
+  json_gen_free (json_gen);
 
   return 0;
 }

--- a/tests/alpine-build/Dockerfile
+++ b/tests/alpine-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 RUN apk add gcc automake autoconf libtool gettext pkgconf git make musl-dev \
-    python3 libcap-dev libseccomp-dev yajl-dev argp-standalone go-md2man gperf
+    python3 libcap-dev libseccomp-dev argp-standalone go-md2man gperf
 
 COPY run-tests.sh /usr/local/bin
 

--- a/tests/centos10-build/run-tests.sh
+++ b/tests/centos10-build/run-tests.sh
@@ -7,14 +7,14 @@ git config --global --add safe.directory /crun
 
 git clean -fdx
 ./autogen.sh
-./configure --enable-embedded-yajl CFLAGS='-Wall -Wextra -Werror'
+./configure --enable-embedded-yyjson CFLAGS='-Wall -Wextra -Werror'
 make -j "$(nproc)"
 
-make -j "$(nproc)" distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-embedded-yajl"
+make -j "$(nproc)" distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-embedded-yyjson"
 
 git clean -fdx
 ./autogen.sh
-./configure --enable-embedded-yajl CFLAGS='-Wall -Wextra -Werror' --disable-systemd
+./configure --enable-embedded-yyjson CFLAGS='-Wall -Wextra -Werror' --disable-systemd
 make -j "$(nproc)"
 
-make -j "$(nproc)" distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-embedded-yajl"
+make -j "$(nproc)" distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-embedded-yyjson"

--- a/tests/centos8-build/Dockerfile
+++ b/tests/centos8-build/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream8
 
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
     yum --enablerepo='powertools' install -y make automake autoconf gettext \
-    criu-devel libtool gcc libcap-devel systemd-devel yajl-devel \
+    criu-devel libtool gcc libcap-devel systemd-devel \
     libseccomp-devel python36 libtool git glibc-static
 
 COPY run-tests.sh /usr/local/bin

--- a/tests/centos9-build/Dockerfile
+++ b/tests/centos9-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream9
 
 RUN yum  --enablerepo='appstream'  --enablerepo='baseos' --enablerepo='crb' install -y make \
-    automake autoconf gettext criu-devel libtool gcc libcap-devel systemd-devel yajl-devel \
+    automake autoconf gettext criu-devel libtool gcc libcap-devel systemd-devel \
     libseccomp-devel python3 libtool git protobuf-c protobuf-c-devel glibc-static
 
 COPY run-tests.sh /usr/local/bin

--- a/tests/clang-check/Dockerfile
+++ b/tests/clang-check/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/fedora/fedora:latest
 
-RUN dnf install -y awk git protobuf-c protobuf-c-devel make clang-analyzer clang-tools-extra clang python3-pip glibc-static 'dnf-command(builddep)' && \
+RUN dnf install -y awk git protobuf-c protobuf-c-devel make clang-analyzer clang-tools-extra clang python3-pip glibc-static yyjson-devel 'dnf-command(builddep)' && \
         dnf builddep -y crun && pip install scan-build
 
 COPY run-tests.sh /usr/local/bin

--- a/tests/clang-format/Dockerfile
+++ b/tests/clang-format/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/fedora/fedora:latest
 
-RUN dnf install -y awk git make clang-tools-extra glibc-static 'dnf-command(builddep)' && dnf builddep -y crun
+RUN dnf install -y awk git make clang-tools-extra glibc-static yyjson-devel 'dnf-command(builddep)' && dnf builddep -y crun
 
 COPY run-tests.sh /usr/local/bin
 ENTRYPOINT /usr/local/bin/run-tests.sh

--- a/tests/containerd/Dockerfile
+++ b/tests/containerd/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
             protobuf-c-compiler libcap-dev libaio-dev \
             curl libprotobuf-c-dev libprotobuf-dev socat libseccomp-dev \
             pigz lsof make git gcc build-essential pkgconf libtool \
-            libsystemd-dev libcap-dev libyajl-dev \
+            libsystemd-dev libcap-dev \
             go-md2man libtool autoconf python3 automake sudo \
     && update-alternatives --install /usr/bin/go go /usr/lib/go-1.22/bin/go 0 \
     && mkdir -p /root/go/src/github.com/containerd \

--- a/tests/cri-o/Dockerfile
+++ b/tests/cri-o/Dockerfile
@@ -4,7 +4,7 @@ ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
 RUN dnf install -y awk python git gcc automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel go-md2man conntrack-tools which \
+    systemd-devel yyjson-devel libseccomp-devel go-md2man conntrack-tools which \
     glibc-static python3-libmount libtool make podman xz nmap-ncat jq bats \
     iproute openssl iputils socat criu-libs irqbalance && \
     dnf install -y awk 'dnf-command(builddep)' && dnf builddep -y podman && \

--- a/tests/fuzzing/Dockerfile
+++ b/tests/fuzzing/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/fedora/fedora:latest
 
 RUN dnf install -y awk golang python git automake autoconf libcap-devel \
-     systemd-devel yajl-devel libseccomp-devel go-md2man \
+     systemd-devel yyjson-devel libseccomp-devel go-md2man \
     glibc-static python3-libmount libtool make git libunwind-devel binutils-devel xz-devel \
     libatomic clang
 

--- a/tests/fuzzing/run-tests.sh
+++ b/tests/fuzzing/run-tests.sh
@@ -15,7 +15,7 @@ CORPUS=${CORPUS:=/testcases}
 git config --global --add safe.directory /crun
 git clean -fdx
 ./autogen.sh
-./configure --enable-embedded-yajl HFUZZ_CC_UBSAN=1 HFUZZ_CC_ASAN=1 CC=hfuzz-clang CPPFLAGS="-D FUZZER" CFLAGS="-ggdb3 -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-div,indirect-calls"
+./configure --enable-embedded-yyjson HFUZZ_CC_UBSAN=1 HFUZZ_CC_ASAN=1 CC=hfuzz-clang CPPFLAGS="-D FUZZER" CFLAGS="-ggdb3 -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-div,indirect-calls"
 make -j "$(nproc)"
 make -j "$(nproc)" tests/tests_libcrun_fuzzer
 

--- a/tests/oci-validation/Dockerfile
+++ b/tests/oci-validation/Dockerfile
@@ -4,7 +4,7 @@ ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
 RUN dnf install -y awk golang python git gcc automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel libselinux-devel \
+    systemd-devel yyjson-devel libseccomp-devel libselinux-devel \
     glibc-static python3-libmount libtool make go-md2man perl-Test2-Harness
 
 COPY run-tests.sh /usr/local/bin

--- a/tests/podman/Dockerfile
+++ b/tests/podman/Dockerfile
@@ -4,7 +4,7 @@ ENV GOPATH=/root/go
 ENV PATH=/usr/bin:/usr/sbin:/root/go/bin:/usr/local/bin::/usr/local/sbin
 
 RUN dnf install -y awk golang python git gcc automake autoconf libcap-devel \
-    systemd-devel yajl-devel libseccomp-devel go-md2man catatonit \
+    systemd-devel yyjson-devel libseccomp-devel go-md2man catatonit \
     glibc-static python3-libmount libtool make podman xz nmap-ncat procps-ng slirp4netns \
     device-mapper-devel containernetworking-plugins 'dnf-command(builddep)' && \
     dnf builddep -y podman && \

--- a/tests/wasmedge-build/Dockerfile
+++ b/tests/wasmedge-build/Dockerfile
@@ -4,8 +4,7 @@ ARG WASM_EDGE_VERSION="0.14.0"
 
 # Install the deps for building crun
 RUN dnf update -y && dnf install -y awk make python git gcc automake autoconf libcap-devel \
-		systemd-devel yajl-devel libseccomp-devel pkg-config diffutils \
-		systemd-devel yajl-devel libseccomp-devel pkg-config \
+		systemd-devel yyjson-devel libseccomp-devel pkg-config diffutils \
 		go-md2man glibc-static python3-libmount libtool buildah podman which
 
 # Install WasmEdge


### PR DESCRIPTION
Switch from the unmaintained YAJL library to yyjson for all JSON operations.  Update the build system (configure.ac, Makefile.am) to use yyjson, and update the libocispec submodule to the version with yyjson support.

gitmodules is pointing to my git repo for now.

Needs: https://github.com/containers/libocispec/pull/171