### PR TITLE
cgroup: fix recursive cgroup cleanup consuming caller's fd

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -114,7 +114,8 @@ static void
 get_systemd_scope_and_slice (const char *id, bool user_slice, const char *cgroup_path,
                              char **scope, char **slice)
 {
-  char *n;
+  const char *n;
+  char *p;
 
   if (cgroup_path == NULL || cgroup_path[0] == '\0')
     {
@@ -128,16 +129,16 @@ get_systemd_scope_and_slice (const char *id, bool user_slice, const char *cgroup
   else
     {
       xasprintf (scope, "%s.scope", n + 1);
-      n = strchr (*scope, ':');
-      if (n)
-        *n = '-';
+      p = strchr (*scope, ':');
+      if (p)
+        *p = '-';
     }
   if (slice)
     {
       *slice = xstrdup (cgroup_path);
-      n = strchr (*slice, ':');
-      if (n)
-        *n = '\0';
+      p = strchr (*slice, ':');
+      if (p)
+        *p = '\0';
 
       /* Ref: https://github.com/opencontainers/runc/blob/main/docs/systemd.md#systemd-unit-name-and-placement */
       if (is_empty_string (*slice))
@@ -638,7 +639,7 @@ append_systemd_annotation (sd_bus_message *m, const char *name, size_t name_len,
 
       it = v_start = xstrdup (value);
 
-      end = strchr (it + 1, '\'');
+      end = strchr (v_start + 1, '\'');
       if (end == NULL)
         return crun_make_error (err, 0, "invalid variant `%s`", value);
       *end = '\0';

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -308,14 +308,18 @@ read_pids_cgroup (int dfd, bool recurse, pid_t **pids, size_t *n_pids, size_t *a
 
   if (recurse)
     {
+      cleanup_close int dfd_clone = openat (dfd, ".", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
       cleanup_dir DIR *dir = NULL;
       struct dirent *de;
 
-      dir = fdopendir (dfd);
+      if (UNLIKELY (dfd_clone < 0))
+        return crun_make_error (err, errno, "open cgroup sub-directory");
+
+      dir = fdopendir (dfd_clone);
       if (UNLIKELY (dir == NULL))
         return crun_make_error (err, errno, "open cgroup sub-directory");
-      /* Now dir owns the dfd descriptor.  */
-      dfd = -1;
+      /* fdopendir takes ownership of dfd_clone.  */
+      dfd_clone = -1;
 
       for (de = readdir (dir); de; de = readdir (dir))
         {
@@ -330,6 +334,7 @@ read_pids_cgroup (int dfd, bool recurse, pid_t **pids, size_t *n_pids, size_t *a
           nfd = openat (dirfd (dir), de->d_name, O_DIRECTORY | O_CLOEXEC);
           if (UNLIKELY (nfd < 0))
             return crun_make_error (err, errno, "open cgroup directory `%s`", de->d_name);
+
           ret = read_pids_cgroup (nfd, recurse, pids, n_pids, allocated, err);
           if (UNLIKELY (ret < 0))
             return ret;
@@ -375,7 +380,6 @@ rmdir_all_fd (int dfd)
           libcrun_error_t tmp_err = NULL;
           size_t i, n_pids = 0, allocated = 0;
           cleanup_close int child_dfd = -1;
-          int tmp;
 
           child_dfd = openat (dfd, name, O_DIRECTORY | O_CLOEXEC);
           if (child_dfd < 0)
@@ -397,9 +401,13 @@ rmdir_all_fd (int dfd)
           for (i = 0; i < n_pids; i++)
             kill (pids[i], SIGKILL);
 
-          tmp = child_dfd;
+          ret = rmdir_all_fd (child_dfd);
           child_dfd = -1;
-          return rmdir_all_fd (tmp);
+          if (ret < 0)
+            return ret;
+
+          /* Retry removing the directory now that its children are gone.  */
+          unlinkat (dfd, name, AT_REMOVEDIR);
         }
     }
   return 0;

--- a/src/libcrun/error.c
+++ b/src/libcrun/error.c
@@ -191,7 +191,7 @@ enum
 static int
 get_log_type (const char *log, const char **data)
 {
-  char *sep = strchr (log, ':');
+  const char *sep = strchr (log, ':');
   if (sep == NULL)
     {
       *data = log;

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -454,7 +454,7 @@ crun_safe_ensure_at (bool do_open, bool dir, int dirfd, const char *dirpath,
   cleanup_free char *npath = NULL;
   bool last_component = false;
   size_t depth = 0;
-  const char *cur;
+  char *cur;
   char *it;
   int cwd;
   int ret;

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -233,13 +233,13 @@ xstrdup (const char *str)
 
 void consume_trailing_slashes (char *path);
 
-static inline const char *
-consume_slashes (const char *t)
-{
-  while (*t == '/')
-    t++;
-  return t;
-}
+#define consume_slashes(t) \
+  ({                       \
+    typeof (t) _s = (t);   \
+    while (*_s == '/')     \
+      _s++;                \
+    _s;                    \
+  })
 
 static inline bool
 path_is_slash_dev (const char *path)

--- a/tests/init.c
+++ b/tests/init.c
@@ -770,15 +770,21 @@ main (int argc, char **argv)
       char path[PATH_MAX];
       int ret;
       int fd;
+      int i;
 
       if (argc < 3)
         error (EXIT_FAILURE, 0, "'create-sub-cgroup-and-wait' requires an argument");
 
-      snprintf (path, sizeof (path), "/sys/fs/cgroup/%s", argv[2]);
-      ret = mkdir (path, 0700);
-      if (ret < 0)
-        error (EXIT_FAILURE, errno, "mkdir");
+      /* Create all requested subcgroups.  */
+      for (i = 2; i < argc; i++)
+        {
+          snprintf (path, sizeof (path), "/sys/fs/cgroup/%s", argv[i]);
+          ret = mkdir (path, 0700);
+          if (ret < 0)
+            error (EXIT_FAILURE, errno, "mkdir `%s`", path);
+        }
 
+      /* Move into the first subcgroup.  */
       snprintf (path, sizeof (path), "/sys/fs/cgroup/%s/cgroup.procs", argv[2]);
 
       fd = open (path, O_WRONLY);
@@ -786,7 +792,7 @@ main (int argc, char **argv)
         error (EXIT_FAILURE, errno, "open `%s`", path);
       ret = write (fd, "1", 1);
       if (ret < 0)
-        error (EXIT_FAILURE, errno, "open `%s`", path);
+        error (EXIT_FAILURE, errno, "write `%s`", path);
       close (fd);
 
       do_pause ();

--- a/tests/test_cgroup_setup.py
+++ b/tests/test_cgroup_setup.py
@@ -1440,6 +1440,70 @@ def test_cgroup_disabled_detach():
     return _run_cgroup_disabled(detach=True)
 
 
+def test_cgroup_subcgroup_cleanup():
+    """Test that subcgroups are cleaned up on container delete.
+
+    Regression test for a bug where read_pids_cgroup() consumed the
+    caller's fd via fdopendir(), causing rmdir_all_fd() to fail with
+    EBADF when cleaning up nested cgroup directories.
+    """
+    if not is_cgroup_v2_unified():
+        return (77, "requires cgroup v2")
+    if is_rootless():
+        return (77, "requires root for cgroup manipulation")
+    if get_cgroup_manager() == 'systemd':
+        return (77, "test uses cgroupfs-style paths")
+
+    conf = base_config()
+    add_all_namespaces(conf, cgroupns=True)
+    conf['process']['args'] = ['/init', 'create-sub-cgroup-and-wait',
+                               'sub1', 'sub1/nested', 'sub2']
+
+    cgroup_path = f'/test-subcgroup-cleanup-{os.getpid()}'
+    conf['linux']['cgroupsPath'] = cgroup_path
+
+    host_cgroup_dir = f'/sys/fs/cgroup{cgroup_path}'
+
+    cid = None
+    try:
+        _, cid = run_and_get_output(conf, hide_stderr=False, command='run', detach=True)
+
+        # Verify the cgroup directory exists
+        if not os.path.isdir(host_cgroup_dir):
+            logger.info("cgroup directory %s does not exist", host_cgroup_dir)
+            return -1
+
+        # Delete the container -- crun must clean up all subcgroups
+        run_crun_command(['delete', '-f', cid])
+        cid = None
+
+        # Give a moment for cleanup
+        time.sleep(0.5)
+
+        # Verify cgroup directory is fully removed
+        if os.path.exists(host_cgroup_dir):
+            logger.info("cgroup directory %s still exists after delete", host_cgroup_dir)
+            return -1
+
+        return 0
+
+    except subprocess.CalledProcessError as e:
+        output = e.output.decode('utf-8', errors='ignore') if e.output else ''
+        if "Bad file descriptor" in output:
+            logger.info("EBADF during cgroup cleanup (known regression): %s", output)
+            return -1
+        if any(kw in output.lower() for kw in ["mount", "proc", "rootfs"]):
+            return (77, "environment issue")
+        logger.info("test failed: %s", e)
+        return -1
+    except Exception as e:
+        logger.info("test failed: %s", e)
+        return -1
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+
+
 all_tests = {
     "cgroup-disabled": test_cgroup_disabled,
     "cgroup-disabled-detach": test_cgroup_disabled_detach,
@@ -1482,6 +1546,7 @@ all_tests = {
     "annotation-delegate-cgroup": test_annotation_delegate_cgroup,
     "annotation-systemd-force-cgroup-v1": test_annotation_systemd_force_cgroup_v1,
     "cgroup-v2-mount-options": test_cgroup_v2_mount_options,
+    "cgroup-subcgroup-cleanup": test_cgroup_subcgroup_cleanup,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
 Commit 1492e83c ("cgroup: fix read_pids_cgroup skipping child cgroups") changed read_pids_cgroup() to always recurse into subdirectories.  The recursion calls fdopendir(dfd) which consumes the caller's file descriptor.  When rmdir_all_fd() called read_pids_cgroup() on a child cgroup and then tried to recurse into it, the fd was already closed causing EBADF.