### PR TITLE
libcrun: use O_PATH where applicable

### DIFF
--- a/src/libcrun/cgroup-cgroupfs.c
+++ b/src/libcrun/cgroup-cgroupfs.c
@@ -79,7 +79,7 @@ libcrun_precreate_cgroup_cgroupfs (struct libcrun_cgroup_args *args, int *dirfd,
   if (UNLIKELY (ret < 0))
     return ret;
 
-  *dirfd = open (cgroup_path, O_CLOEXEC | O_NOFOLLOW | O_DIRECTORY | O_RDONLY);
+  *dirfd = open (cgroup_path, O_CLOEXEC | O_NOFOLLOW | O_DIRECTORY | O_PATH);
   if (UNLIKELY (*dirfd < 0))
     return crun_make_error (err, errno, "open `%s`", cgroup_path);
 

--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -1370,7 +1370,7 @@ update_cgroup_v2_resources (runtime_spec_schema_config_linux_resources *resource
   if (UNLIKELY (ret < 0))
     return ret;
 
-  cgroup_dirfd = open (cgroup_path, O_DIRECTORY | O_CLOEXEC);
+  cgroup_dirfd = open (cgroup_path, O_DIRECTORY | O_PATH | O_CLOEXEC);
   if (UNLIKELY (cgroup_dirfd < 0))
     return crun_make_error (err, errno, "open `%s`", cgroup_path);
 

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -331,7 +331,7 @@ read_pids_cgroup (int dfd, bool recurse, pid_t **pids, size_t *n_pids, size_t *a
           if (de->d_type != DT_DIR)
             continue;
 
-          nfd = openat (dirfd (dir), de->d_name, O_DIRECTORY | O_CLOEXEC);
+          nfd = openat (dirfd (dir), de->d_name, O_DIRECTORY | O_PATH | O_CLOEXEC);
           if (UNLIKELY (nfd < 0))
             return crun_make_error (err, errno, "open cgroup directory `%s`", de->d_name);
 
@@ -463,7 +463,7 @@ libcrun_cgroup_read_pids_from_path (const char *path, bool recurse, pid_t **pids
       return crun_make_error (err, 0, "invalid cgroup mode `%d`", mode);
     }
 
-  dirfd = open (cgroup_path, O_DIRECTORY | O_CLOEXEC);
+  dirfd = open (cgroup_path, O_DIRECTORY | O_PATH | O_CLOEXEC);
   if (dirfd < 0)
     return crun_make_error (err, errno, "open `%s`", cgroup_path);
 

--- a/src/libcrun/ebpf.c
+++ b/src/libcrun/ebpf.c
@@ -618,7 +618,7 @@ libcrun_ebpf_query_cgroup_progs (const char *cgroup_path, uint32_t **progs_out, 
 #else
   cleanup_close int cgroup_fd = -1;
 
-  cgroup_fd = open (cgroup_path, O_RDONLY | O_CLOEXEC);
+  cgroup_fd = open (cgroup_path, O_PATH | O_CLOEXEC);
   if (UNLIKELY (cgroup_fd < 0))
     return crun_make_error (err, errno, "open cgroup path `%s`", cgroup_path);
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -973,7 +973,7 @@ get_shared_empty_dir_cached (libcrun_container_t *container, char **proc_fd_path
     return ret;
 
   /* Open directory and cache FD (once per container) */
-  fd = open (empty_dir_path, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+  fd = open (empty_dir_path, O_DIRECTORY | O_PATH | O_CLOEXEC);
   if (fd < 0)
     return crun_make_error (err, errno, "open directory `%s`", empty_dir_path);
 
@@ -1466,7 +1466,7 @@ do_mount_cgroup_systemd_v1 (libcrun_container_t *container, const char *source, 
   if (UNLIKELY (ret < 0))
     return ret;
 
-  fd = openat (targetfd, subsystem, O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+  fd = openat (targetfd, subsystem, O_CLOEXEC | O_PATH | O_DIRECTORY | O_NOFOLLOW);
   if (UNLIKELY (fd < 0))
     return crun_make_error (err, errno, "openat `%s`", subsystem_path);
 
@@ -1547,7 +1547,7 @@ do_mount_cgroup_v1 (libcrun_container_t *container, const char *source, int targ
       if (UNLIKELY (ret < 0))
         return crun_make_error (err, errno, "mkdirat `%s`", subsystem_path);
 
-      subsystemfd = openat (targetfd, subsystem, O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+      subsystemfd = openat (targetfd, subsystem, O_CLOEXEC | O_PATH | O_DIRECTORY | O_NOFOLLOW);
       if (UNLIKELY (subsystemfd < 0))
         return crun_make_error (err, errno, "open `%s`", subsystem_path);
 
@@ -1961,7 +1961,7 @@ do_pivot (libcrun_container_t *container, const char *rootfs, libcrun_error_t *e
   if (UNLIKELY (oldrootfd < 0))
     return crun_make_error (err, errno, "open `/`");
 
-  newrootfd = open (rootfs, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+  newrootfd = open (rootfs, O_DIRECTORY | O_PATH | O_CLOEXEC);
   if (UNLIKELY (newrootfd < 0))
     return crun_make_error (err, errno, "open `%s`", rootfs);
 
@@ -4702,7 +4702,7 @@ prepare_and_send_dev_mounts (libcrun_container_t *container, int sync_socket_hos
       goto restore_mountns;
     }
 
-  targetfd = open (devs_path, O_DIRECTORY | O_CLOEXEC);
+  targetfd = open (devs_path, O_DIRECTORY | O_PATH | O_CLOEXEC);
   if (targetfd < 0)
     {
       ret = crun_make_error (err, errno, "open `%s`", devs_path);
@@ -4718,7 +4718,7 @@ prepare_and_send_dev_mounts (libcrun_container_t *container, int sync_socket_hos
 
   close_and_reset (&targetfd);
 
-  targetfd = openat (devs_mountfd, ".", O_DIRECTORY | O_CLOEXEC);
+  targetfd = openat (devs_mountfd, ".", O_DIRECTORY | O_PATH | O_CLOEXEC);
   if (targetfd < 0)
     {
       ret = crun_make_error (err, errno, "open `%s`", devs_path);

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -2873,7 +2873,7 @@ open_proc (libcrun_error_t *err)
     }
 #endif
 
-  fd = open ("/proc", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  fd = open ("/proc", O_PATH | O_DIRECTORY | O_CLOEXEC);
   if (fd < 0)
     return crun_make_error (err, errno, "open `/proc`");
   return fd;


### PR DESCRIPTION
When a file descriptor is only used as a reference (openat base, fchdir, mknodat/fchownat, move_mount with MOVE_MOUNT_T_EMPTY_PATH, mount via /proc/self/fd/N, BPF target_fd, readlinkat), open it with O_PATH so the kernel does not grant read/write access on the inode.