### PR TITLE
.clang-format: fixup for v22.1.4

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -94,6 +94,7 @@ SpaceAfterCStyleCast: true
 SpaceAfterLogicalNot: true
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
 SpaceBeforeParens: Always
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false


### PR DESCRIPTION
Fedora 44 comes with clang-format v22.1.4, which wants to reformat the code like this:

```diff
-    ((struct bpf_insn) {
+    ((struct bpf_insn){
```
in a few places (see e.g. https://github.com/containers/crun/actions/runs/25196200197/job/73877239346?pr=2082)

Add an option to config to retain the old behavior.