### PR TITLE
chroot_realpath: fix potential buffer overflows in destination buffer

### DIFF
--- a/src/libcrun/chroot_realpath.c
+++ b/src/libcrun/chroot_realpath.c
@@ -63,6 +63,10 @@ char *chroot_realpath(const char *chroot, const char *path, char resolved_path[]
 	/* Trivial case. */
 	if (chroot == NULL || *chroot == '\0' ||
 	    (*chroot == '/' && chroot[1] == '\0')) {
+		if (strlen(path) >= PATH_MAX) {
+			__set_errno(ENAMETOOLONG);
+			return NULL;
+		}
 		strcpy(resolved_path, path);
 		return resolved_path;
 	}
@@ -114,7 +118,7 @@ char *chroot_realpath(const char *chroot, const char *path, char resolved_path[]
 		}
 		/* Safely copy the next pathname component. */
 		while (*path != '\0' && *path != '/') {
-			if (path > max_path) {
+			if (path > max_path || new_path >= got_path + PATH_MAX - 1) {
 				__set_errno(ENAMETOOLONG);
 				return NULL;
 			}
@@ -167,8 +171,13 @@ char *chroot_realpath(const char *chroot, const char *path, char resolved_path[]
 			path = copy_path;
 		}
 #endif							/* S_IFLNK */
-		if (!last_component)
+		if (!last_component) {
+			if (new_path >= got_path + PATH_MAX - 1) {
+				__set_errno(ENAMETOOLONG);
+				return NULL;
+			}
 			*new_path++ = '/';
+		}
 	}
 	/* Delete trailing slash but don't whomp a lone slash. */
 	if (new_path != got_path + 1 && new_path[-1] == '/')


### PR DESCRIPTION
## Problem

`chroot_realpath()` builds a resolved path component-by-component into a stack buffer `got_path[PATH_MAX]`. The existing bounds check only limits the **source** pointer (`path > max_path`), not the **destination** pointer (`new_path`). When symlinks are resolved, `copy_path` is refilled and `path` resets — but `new_path` keeps advancing. Crafted symlink chains that expand the resolved path can write past the end of `got_path`.

The trivial-case code path also does an unbounded `strcpy` into `resolved_path`.

## Fix

Three bounds checks added:

1. **Trivial case:** validate `strlen(path) < PATH_MAX` before `strcpy`.
2. **Component copy loop:** add `new_path >= got_path + PATH_MAX - 1` alongside the existing source-pointer check.
3. **Slash separator:** check before appending `'/'` between components.

All return `NULL` with `errno = ENAMETOOLONG`, matching existing conventions. No behavioral change for valid paths.
