### PR TITLE
krun: add support for nested virtualization

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@
   running containers with --read-only.
 - krun: add support for passt-based networking in microVMs via the
   krun.use_passt annotation.
+- krun: add support for nested virtualization in microVMs via the
+  krun.nested_virt annotation.
 - krun: ignore RAM configurations below 128MB.
 
 * crun-1.27

--- a/krun.1.md
+++ b/krun.1.md
@@ -26,6 +26,79 @@ purpose, abstracting most of the complexity from Virtual Machine management.
 
 Because of the additional isolation, sharing content with processes and other
 containers outside of the krun VM is more difficult.
+
+# CONFIGURATION
+
+The microVM can be configured through OCI annotations or a
+**.krun_vm.json** file placed at the root of the container image.
+When both are present, OCI annotations take precedence.
+
+## OCI Annotations
+
+OCI annotations can be passed at container creation time. For
+example, with podman:
+
+    podman run --runtime=krun --annotation krun.nested_virt=1 ...
+
+The following annotations are supported:
+
+**krun.cpus**=*NUM*
+:   Number of vCPUs for the microVM (maximum 16). If not set, defaults
+    to the number of CPUs available via the process CPU affinity.
+
+**krun.ram_mib**=*NUM*
+:   Amount of RAM in MiB for the microVM. Values below 128 MiB are
+    ignored. If not set, defaults to the OCI memory limit if present,
+    otherwise 1024 MiB.
+
+**krun.gpu_flags**=*FLAGS*
+:   Enable virtio-gpu with the specified virgl flags. Requires
+    **/dev/dri** and **/usr/libexec/virgl_render_server** to be
+    available.
+
+**krun.use_passt**=*NUM*
+:   When set to a value greater than 0, enable passt-based networking
+    in the microVM.
+
+**krun.nested_virt**=*NUM*
+:   When set to a value greater than 0, enable nested virtualization
+    in the microVM, exposing hardware virtualization support (VMX on
+    Intel, SVM on AMD) to the guest. This requires nested
+    virtualization to be enabled on the host (e.g.
+    **/sys/module/kvm_intel/parameters/nested** or
+    **/sys/module/kvm_amd/parameters/nested** must report **Y** or
+    **1**). A warning is emitted if the host does not appear to
+    support nested virtualization.
+
+**krun.variant**=*VARIANT*
+:   Select an alternative libkrun variant. Supported values are
+    **sev** (AMD SEV confidential workloads) and **aws-nitro** (AWS
+    Nitro Enclaves).
+
+## VM Configuration File
+
+A **.krun_vm.json** file can be placed at the root of the container
+image to provide default VM settings. The file is a JSON object with
+the following optional fields:
+
+- **cpus** (integer): same as the **krun.cpus** annotation.
+- **ram_mib** (integer): same as the **krun.ram_mib** annotation.
+- **gpu_flags** (integer): same as the **krun.gpu_flags** annotation.
+- **use_passt** (integer): same as the **krun.use_passt** annotation.
+- **nested_virt** (integer): same as the **krun.nested_virt** annotation.
+- **flavor** (string): same as the **krun.variant** annotation.
+- **kernel_path** (string): path to an external kernel.
+- **kernel_format** (integer): kernel format identifier.
+- **initrd_path** (string): path to an initrd image.
+- **kernel_cmdline** (string): kernel command line.
+- **virtiofs_tag** (string): VirtioFS tag (defaults to **/dev/root**).
+- **virtiofs_shm_size** (integer): VirtioFS DAX shared memory size in
+  bytes (defaults to 512 MiB).
+
+Example:
+
+    {"nested_virt": 1, "cpus": 4, "ram_mib": 2048}
+
 # COMMANDS
 
 See crun.1 man page for the commands available to krun

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -248,7 +248,7 @@ libkrun_configure_vm (uint32_t ctx_id, void *handle, struct krun_config *kconf, 
   runtime_spec_schema_config_schema *def = container->container_def;
   int32_t (*krun_set_vm_config) (uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib);
   int32_t (*krun_add_net_unixstream) (uint32_t ctx_id, const char *c_path, int fd, uint8_t *const c_mac, uint32_t features, uint32_t flags);
-  int cpus, ram_mib, gpu_flags, ret;
+  int cpus, ram_mib, gpu_flags, nested_virt, ret;
   cpu_set_t set;
 
   cpus = libkrun_parse_resource_configuration (kconf->config_tree, container, "krun.cpus", "cpus");
@@ -292,6 +292,25 @@ libkrun_configure_vm (uint32_t ctx_id, void *handle, struct krun_config *kconf, 
       ret = libkrun_enable_virtio_gpu (kconf, gpu_flags);
       if (UNLIKELY (ret < 0))
         return crun_make_error (err, -ret, "could not enable virtio gpu");
+    }
+
+  nested_virt = libkrun_parse_resource_configuration (kconf->config_tree, container, "krun.nested_virt", "nested_virt");
+  if (nested_virt > 0)
+    {
+      int32_t (*krun_check_nested_virt) (void);
+      int32_t (*krun_set_nested_virt) (uint32_t ctx_id, bool enabled);
+
+      krun_check_nested_virt = dlsym (handle, "krun_check_nested_virt");
+      if (krun_check_nested_virt != NULL && krun_check_nested_virt () != 1)
+        libcrun_warning ("nested virtualization requested but may not be supported on this host");
+
+      krun_set_nested_virt = dlsym (handle, "krun_set_nested_virt");
+      if (krun_set_nested_virt == NULL)
+        return crun_make_error (err, 0, "could not find symbol `krun_set_nested_virt` in the krun library");
+
+      ret = krun_set_nested_virt (ctx_id, true);
+      if (UNLIKELY (ret < 0))
+        return crun_make_error (err, -ret, "could not enable nested virtualization");
     }
 
   if (kconf->use_passt)


### PR DESCRIPTION
Enable nested virtualization in the microVM by calling krun_set_nested_virt() when requested via the krun.nested_virt OCI annotation or the nested_virt field in .krun_vm.json.

If the host does not support nested virtualization, a warning is emitted but execution continues.

Usage:

  podman run --runtime=krun --annotation krun.nested_virt=1 ...

Or via .krun_vm.json in the container image:

  {"nested_virt": 1}

Related: https://github.com/containers/libkrun/issues/625
Assisted-by: <anthropic/claude-opus-4.6>