### PR TITLE
krun: passt - don't map the gateway address

### DIFF
--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -567,7 +567,7 @@ libkrun_start_passt (void *cookie, libcrun_container_t *container)
 {
   struct krun_config *kconf = (struct krun_config *) cookie;
   pid_t pid;
-  char *passt_argv[9];
+  char *passt_argv[10];
   char fd_as_str[16];
   int use_passt;
   int argv_idx;
@@ -597,6 +597,12 @@ libkrun_start_passt (void *cookie, libcrun_container_t *container)
       passt_argv[argv_idx++] = (char *) "all";
       passt_argv[argv_idx++] = (char *) "--no-dhcp-dns";
     }
+
+  /* Set --no-map-gw. If the gateway for the network is also the DNS server
+   * we won't be able to query the DNS server without --no-map-gw.
+   * See discussion in https://github.com/containers/crun/pull/2099
+   */
+  passt_argv[argv_idx++] = (char *) "--no-map-gw";
 
   passt_argv[argv_idx++] = (char *) "--fd";
   passt_argv[argv_idx++] = fd_as_str;


### PR DESCRIPTION
EDIT:

If the gateway for the network is also the DNS server
we won't be able to query the DNS server without --no-map-gw.

See discussion in https://github.com/containers/crun/pull/2099


--- 
Old:

~~The commits in this PR try to get some default networking into the krun VM started with `podman run --runtime=krun --annotation krun.use_passt=1`. First we pass in `NET_FLAG_DHCP_CLIENT` to `krun_add_net_unixstream` and then pass in `--dns 169.254.1.1` to workaround a problem where if the DNS server is on the local network it won't hit NAT and won't be forwarded (thus unreachable from inside the krun VM).~~

~~The hardcoding here of `169.254.1.1` isn't great. It's the default used by podman rootless (so that target is available inside the rootless container namespace, but not the krun VM). I'm interested to know the experts thoughts here and if there is a better alternative.~~