### PR TITLE
man: align --no-pivot documentation with command parser behavior

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -134,11 +134,6 @@ Define the log level.  It can either be \fBdebug\fP, \fBwarning\fP or \fBerror\f
 The default is \fBerror\fP\&.
 
 .PP
-\fB--no-pivot\fP
-Use \fBchroot(2)\fR instead of \fBpivot_root(2)\fR when creating the container.
-This option is not safe, and should be avoided.
-
-.PP
 \fB--root\fP=\fIDIR\fP
 Defines where to store the state for crun containers.
 
@@ -185,6 +180,11 @@ the container.
 Keep the same session key
 
 .PP
+\fB--no-pivot\fP
+Use \fBchroot(2)\fR instead of \fBpivot_root(2)\fR when creating the container.
+This option is not safe, and should be avoided.
+
+.PP
 \fB--preserve-fds\fP=\fIN\fP
 Additional number of FDs to pass into the container.
 
@@ -211,6 +211,11 @@ the container.
 .PP
 \fB--no-new-keyring\fP
 Keep the same session key.
+
+.PP
+\fB--no-pivot\fP
+Use \fBchroot(2)\fR instead of \fBpivot_root(2)\fR when creating the container.
+This option is not safe, and should be avoided.
 
 .PP
 \fB--preserve-fds\fP=\fIN\fP

--- a/crun.1.md
+++ b/crun.1.md
@@ -108,10 +108,6 @@ Define the format of the log messages.  It can either be **text**, or
 Define the log level.  It can either be **debug**, **warning** or **error**.
 The default is **error**.
 
-**--no-pivot**
-Use `chroot(2)` instead of `pivot_root(2)` when creating the container.
-This option is not safe, and should be avoided.
-
 **--root**=_DIR_
 Defines where to store the state for crun containers.
 
@@ -149,6 +145,10 @@ the container.
 **--no-new-keyring**
 Keep the same session key
 
+**--no-pivot**
+Use `chroot(2)` instead of `pivot_root(2)` when creating the container.
+This option is not safe, and should be avoided.
+
 **--preserve-fds**=_N_
 Additional number of FDs to pass into the container.
 
@@ -171,6 +171,10 @@ the container.
 
 **--no-new-keyring**
 Keep the same session key.
+
+**--no-pivot**
+Use `chroot(2)` instead of `pivot_root(2)` when creating the container.
+This option is not safe, and should be avoided.
 
 **--preserve-fds**=_N_
 Additional number of FDs to pass into the container.


### PR DESCRIPTION
Align the documentation to match the source code and consequently CLI of the tool.

For details see the issue:
- #2107 

Closes: #2107