### PR TITLE
cgroup: fix memory issue when resizing array of strings

### DIFF
--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -671,7 +671,7 @@ append_systemd_annotation (sd_bus_message *m, const char *name, size_t name_len,
           if (n_parts == parts_size - 1)
             {
               parts_size += 32;
-              parts = xrealloc (parts, parts_size);
+              parts = xrealloc (parts, sizeof (char *) * parts_size);
             }
           parts[n_parts] = NULL;
           if (next == NULL)


### PR DESCRIPTION
The function `append_systemd_annotation()` initializes the array of strings pointers `char **` using the correct byte size, but when it is resized, the code uses a hard-coded element count instead of the actual number of bytes required:

For details see the issue:
- #2106

Closes: #2106
