### PR TITLE
man: --regex=REGEX is wrongly documented for crun delete and crun kill commands

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -232,8 +232,8 @@ crun [global options] delete [options] CONTAINER
 Delete the container even if it is still running.
 
 .PP
-\fB--regex\fP=\fIREGEX\fP
-Delete all the containers that satisfy the specified regex.
+\fB--regex\fP
+Treat \fICONTAINER\fP as a regular expression and delete all matching containers.
 
 .SH EXEC OPTIONS
 crun [global options] exec [options] CONTAINER CMD
@@ -311,8 +311,8 @@ crun [global options] kill [options] CONTAINER SIGNAL
 Kill all the processes in the container.
 
 .PP
-\fB--regex\fP=\fIREGEX\fP
-Kill all the containers that satisfy the specified regex.
+\fB--regex\fP
+Treat \fICONTAINER\fP as a regular expression and send the specified signal to all matching containers.
 
 .SH PS OPTIONS
 crun [global options] ps [options]

--- a/crun.1.md
+++ b/crun.1.md
@@ -188,8 +188,8 @@ crun [global options] delete [options] CONTAINER
 **--force**
 Delete the container even if it is still running.
 
-**--regex**=_REGEX_
-Delete all the containers that satisfy the specified regex.
+**--regex**
+Treat _CONTAINER_ as a regular expression and delete all matching containers.
 
 ## EXEC OPTIONS
 
@@ -253,8 +253,8 @@ crun [global options] kill [options] CONTAINER SIGNAL
 **--all**
 Kill all the processes in the container.
 
-**--regex**=_REGEX_
-Kill all the containers that satisfy the specified regex.
+**--regex**
+Treat _CONTAINER_ as a regular expression and send the specified signal to all matching containers.
 
 ## PS OPTIONS
 


### PR DESCRIPTION
The `crun delete` and `crun kill` commands are expecting the CONTAINER as the --regex expression.
It doesn't match the behavior of the CLI, that describes it as `--regex=Regex`.

For details see the issue:
- #2110 

Closes: https://github.com/containers/crun/issues/2110