### PR TITLE
linux: fix missing output and SELinux warnings with OPEN_TREE_NAMESPACE

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3600,6 +3600,42 @@ setup_mount_namespace (libcrun_container_t *container, bool no_pivot, char **roo
         return ret;
     }
 
+  /* Pre-open needed device fds and the notify socket while the host
+     file system is still reachable.  After setns(OPEN_TREE_NAMESPACE)
+     the host /dev is no longer accessible.  When tree_fd < 0 (no
+     OPEN_TREE_NAMESPACE), this is retried after unshare(CLONE_NEWNS)
+     below since open_tree needs CAP_SYS_ADMIN in the user namespace
+     that owns the mount namespace.  */
+  if (tree_fd >= 0)
+    {
+      if (get_private_data (container)->needed_devs_fds)
+        {
+          struct libcrun_fd_map *dev_fds = get_private_data (container)->needed_devs_fds;
+
+          for (i = 0; needed_devs[i].path; i++)
+            {
+              if (i < dev_fds->nfds && dev_fds->fds[i] >= 0)
+                continue;
+
+              int fd = syscall_open_tree (AT_FDCWD, needed_devs[i].path,
+                                          OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC);
+              if (fd >= 0 && i < dev_fds->nfds)
+                dev_fds->fds[i] = fd;
+              else if (fd >= 0)
+                close (fd);
+            }
+        }
+
+      if (get_private_data (container)->notify_socket_tree_fd < 0
+          && get_private_data (container)->host_notify_socket_path)
+        {
+          int fd = syscall_open_tree (AT_FDCWD, get_private_data (container)->host_notify_socket_path,
+                                      OPEN_TREE_CLONE | AT_RECURSIVE | OPEN_TREE_CLOEXEC);
+          if (fd >= 0)
+            get_private_data (container)->notify_socket_tree_fd = fd;
+        }
+    }
+
   if (tree_fd >= 0)
     {
       ret = setns (tree_fd, CLONE_NEWNS);
@@ -3690,34 +3726,34 @@ setup_mount_namespace (libcrun_container_t *container, bool no_pivot, char **roo
   close_and_reset (&get_private_data (container)->rootfsfd);
   get_private_data (container)->rootfs = NULL;
 
-  /* Pre-open needed device fds for rootless containers.
-     The parent skips open_tree for rootless (EPERM), but the child
-     has CAP_SYS_ADMIN in its user namespace.  */
-  if (get_private_data (container)->needed_devs_fds)
+  if (tree_fd < 0)
     {
-      struct libcrun_fd_map *dev_fds = get_private_data (container)->needed_devs_fds;
-
-      for (i = 0; needed_devs[i].path; i++)
+      if (get_private_data (container)->needed_devs_fds)
         {
-          if (i < dev_fds->nfds && dev_fds->fds[i] >= 0)
-            continue;
+          struct libcrun_fd_map *dev_fds = get_private_data (container)->needed_devs_fds;
 
-          int fd = syscall_open_tree (AT_FDCWD, needed_devs[i].path,
-                                      OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC);
-          if (fd >= 0 && i < dev_fds->nfds)
-            dev_fds->fds[i] = fd;
-          else if (fd >= 0)
-            close (fd);
+          for (i = 0; needed_devs[i].path; i++)
+            {
+              if (i < dev_fds->nfds && dev_fds->fds[i] >= 0)
+                continue;
+
+              int fd = syscall_open_tree (AT_FDCWD, needed_devs[i].path,
+                                          OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC);
+              if (fd >= 0 && i < dev_fds->nfds)
+                dev_fds->fds[i] = fd;
+              else if (fd >= 0)
+                close (fd);
+            }
         }
-    }
 
-  if (get_private_data (container)->notify_socket_tree_fd < 0
-      && get_private_data (container)->host_notify_socket_path)
-    {
-      int fd = syscall_open_tree (AT_FDCWD, get_private_data (container)->host_notify_socket_path,
-                                  OPEN_TREE_CLONE | AT_RECURSIVE | OPEN_TREE_CLOEXEC);
-      if (fd >= 0)
-        get_private_data (container)->notify_socket_tree_fd = fd;
+      if (get_private_data (container)->notify_socket_tree_fd < 0
+          && get_private_data (container)->host_notify_socket_path)
+        {
+          int fd = syscall_open_tree (AT_FDCWD, get_private_data (container)->host_notify_socket_path,
+                                      OPEN_TREE_CLONE | AT_RECURSIVE | OPEN_TREE_CLOEXEC);
+          if (fd >= 0)
+            get_private_data (container)->notify_socket_tree_fd = fd;
+        }
     }
 
   get_old_root_fd (get_private_data (container));

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3496,6 +3496,7 @@ setup_mount_namespace (libcrun_container_t *container, bool no_pivot, char **roo
       cleanup_free char *dest_path = NULL;
       cleanup_close int mnt_fd = -1;
       bool recursive_bind, nofollow;
+      unsigned long mnt_flags = 0;
       struct stat st;
 
       if (mount_fds && mount_fds->fds[i] >= 0)
@@ -3506,7 +3507,6 @@ setup_mount_namespace (libcrun_container_t *container, bool no_pivot, char **roo
           && def->mounts[i]->source[0] == '/')
         {
           cleanup_free char *mnt_data = NULL;
-          unsigned long mnt_flags = 0;
           unsigned long mnt_extra = 0;
           uint64_t mnt_rec_clear = 0, mnt_rec_set = 0;
           size_t j;
@@ -3546,10 +3546,14 @@ setup_mount_namespace (libcrun_container_t *container, bool no_pivot, char **roo
           if (mount_fds && def->mounts[i]->source != NULL && ! has_cached_target)
             {
               libcrun_error_t tmp_err = NULL;
+              unsigned long propagation = MS_PRIVATE;
+
+              if (mnt_flags & (MS_SHARED | MS_SLAVE | MS_UNBINDABLE))
+                propagation = 0;
 
               mount_fds->fds[i] = get_bind_mount (AT_FDCWD, def->mounts[i]->source,
                                                   recursive_bind, false, nofollow,
-                                                  MS_PRIVATE, &tmp_err);
+                                                  propagation, &tmp_err);
               if (mount_fds->fds[i] < 0)
                 crun_error_release (&tmp_err);
             }

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1368,6 +1368,7 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
           int label_how, libcrun_error_t *err)
 {
   cleanup_free char *data_with_label = NULL;
+  const char *data_without_label = data;
   proc_fd_path_t target_buffer;
   const char *context_type = NULL;
   cleanup_close int ms_move_fd = -1;
@@ -1454,7 +1455,7 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
             }
           else
             {
-              cleanup_close int newfs = fsopen_mount (fstype, source, context_type, label, data);
+              cleanup_close int newfs = fsopen_mount (fstype, source, context_type, label, data_without_label);
               if (newfs >= 0)
                 ret = fs_move_mount_to (newfs, targetfd, NULL);
             }

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1070,6 +1070,77 @@ def test_mount_propagation_slave():
     logger.info("mountinfo output: %s", out)
     return -1
 
+def test_mount_propagation_shared():
+    """Verify rshared bind mounts preserve the source's shared peer group.
+
+    Regression test for https://github.com/containers/crun/issues/2122.
+    When pre-creating bind mounts via open_tree(OPEN_TREE_CLONE),
+    mount_setattr(MS_PRIVATE) removes the mount from the source's shared
+    peer group.  Passing propagation=0 instead preserves peer group
+    membership so host-to-container propagation works.
+    """
+    if is_rootless():
+        return (77, "requires root privileges")
+
+    source = "/usr"
+    host_peer = None
+    with open('/proc/self/mountinfo') as f:
+        for line in f:
+            fields = line.split()
+            if len(fields) >= 5 and fields[4] == source:
+                for field in fields[5:]:
+                    if field == '-':
+                        break
+                    if field.startswith('shared:'):
+                        host_peer = field
+                break
+        if host_peer is None:
+            for line in f:
+                pass
+            f.seek(0)
+            for line in f:
+                fields = line.split()
+                if len(fields) >= 5:
+                    root = fields[3]
+                    mountpoint = fields[4]
+                    if mountpoint == '/' or source.startswith(mountpoint + '/') or source == mountpoint:
+                        for field in fields[5:]:
+                            if field == '-':
+                                break
+                            if field.startswith('shared:'):
+                                host_peer = field
+                        if host_peer:
+                            break
+
+    if host_peer is None:
+        return (77, "source mount is not shared on host")
+
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'cat', '/proc/self/mountinfo']
+    add_all_namespaces(conf)
+    mount_opt = {"destination": "/mnt", "type": "bind", "source": source,
+                 "options": ["bind", "rshared"]}
+    conf['mounts'].append(mount_opt)
+    out, _ = run_and_get_output(conf, hide_stderr=True)
+    for line in out.splitlines():
+        fields = line.split()
+        if len(fields) < 5 or fields[4] != '/mnt':
+            continue
+        for field in fields[5:]:
+            if field == '-':
+                break
+            if field.startswith('shared:'):
+                if field == host_peer:
+                    return 0
+                logger.info("peer group mismatch: host has %s, container has %s", host_peer, field)
+                return -1
+        logger.info("bind mount at /mnt has no shared peer group")
+        logger.info("mountinfo line: %s", line)
+        return -1
+    logger.info("/mnt not found in mountinfo")
+    logger.info("mountinfo output: %s", out)
+    return -1
+
 def test_mount_tmpfs_size():
     """Verify tmpfs mounts with size= data option work via fsopen_mount."""
     conf = base_config()
@@ -1257,6 +1328,7 @@ all_tests = {
     "mount-propagation-private": test_mount_propagation_private,
     "mount-no-leak-to-host": test_mount_no_leak_to_host,
     "mount-propagation-slave": test_mount_propagation_slave,
+    "mount-propagation-shared": test_mount_propagation_shared,
     "mount-tmpfs-size": test_mount_tmpfs_size,
     "mount-tmpfs-size-userns": test_mount_tmpfs_size_userns,
     "mount-overlay-fs": test_mount_overlay_fs,


### PR DESCRIPTION
commit 25790ca1e22893523c3e78db745271d44976104b introduced the regression.

Pre-open needed device fds and the notify socket before setns(OPEN_TREE_NAMESPACE), while the host filesystem is still reachable.  After setns the host /dev is no longer accessible, causing device fd pre-opening to fail silently and create_missing_devs to create /dev/null as a regular file instead of bind-mounting the real character device.  Since a regular file has st_rdev == 0 (same as a pipe), libcrun_reopen_dev_null would then incorrectly redirect stdout/stderr to the fake /dev/null.

Also pass the original mount data (without the SELinux label) to fsopen_mount when an explicit context_type/label is provided. add_selinux_mount_label embeds the context into the data string, but fsopen_mount also sets it via fsconfig, causing a "duplicate or incompatible" error from the kernel.  The label-enriched data is only needed for the legacy mount() fallback path.

Closes: https://github.com/containers/crun/issues/2119