### PR TITLE
utils: fix read argument buffer pointer

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -776,7 +776,7 @@ libcrun_initialize_apparmor (libcrun_error_t *err)
       return crun_make_error (err, errno, "open `/sys/module/apparmor/parameters/enabled`");
     }
 
-  size = TEMP_FAILURE_RETRY (read (fd, &buf, 2));
+  size = TEMP_FAILURE_RETRY (read (fd, buf, 2));
 
   apparmor_enabled = size > 0 && buf[0] == 'Y' ? 1 : 0;
 


### PR DESCRIPTION
I wrote a small patch to reduce the size of a buffer in the function
int libcrun_initialize_apparmor (libcrun_error_t *err)

After doing that I wanted to see if Google Gemini had any feedback of my change, so I pasted in the new implementation
into the AI tab in https://www.google.com/

Gemini suggested replacing `&buf` with `buf`

__Side note__: I will provide my buffer size reduction patch in another PR