### PR TITLE
status: use else-if clause

### DIFF
--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -623,7 +623,7 @@ rmdirfd (const char *namedir, int fd, libcrun_error_t *err)
                     goto retry_unlink;
                 }
             }
-          if (ret < 0 && errno == ENOTEMPTY)
+          else if (ret < 0 && errno == ENOTEMPTY)
             {
               cleanup_close int cfd = -1;
 


### PR DESCRIPTION
Remove ambiguity of where errno was set. There is no ambiguity as of today because `openat()` and `umount2()` don't set errno to `ENOTEMPTY` but this might change in the future.