### PR TITLE
linux: do not use errno after crun_error_release

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1716,15 +1716,15 @@ do_mount_cgroup_v2 (libcrun_container_t *container, int targetfd, const char *ta
   ret = do_mount (container, "cgroup2", targetfd, target, "cgroup2", mountflags, data, LABEL_NONE, err);
   if (UNLIKELY (ret < 0))
     {
-      errno = crun_error_get_errno (err);
-      if (errno == EPERM || errno == EBUSY)
+      int saved_errno = crun_error_get_errno (err);
+      if (saved_errno == EPERM || saved_errno == EBUSY)
         {
           const char *unified_cgroup_path;
           const char *src_cgroup;
 
           crun_error_release (err);
 
-          if (errno == EBUSY)
+          if (saved_errno == EBUSY)
             {
               /* If we got EBUSY it means the cgroup file system is already mounted at the targetfd and we
                  cannot stack another one on top of it.  Attempt mounting a tmpfs below the cgroup mount.  */


### PR DESCRIPTION


__side note__:  An alternative implementation could be

```diff
diff --git a/src/libcrun/linux.c b/src/libcrun/linux.c
index 1607ff9e..08d05c97 100644
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1722,13 +1722,12 @@ do_mount_cgroup_v2 (libcrun_container_t *container, int targetfd, const char *ta
           const char *unified_cgroup_path;
           const char *src_cgroup;
 
-          crun_error_release (err);
-
           if (errno == EBUSY)
             {
               /* If we got EBUSY it means the cgroup file system is already mounted at the targetfd and we
                  cannot stack another one on top of it.  Attempt mounting a tmpfs below the cgroup mount.  */
 
+              crun_error_release (err);
               ret = do_mount (container, "tmpfs", targetfd, target, "tmpfs", MS_PRIVATE, "nr_blocks=1,nr_inodes=1", LABEL_NONE, err);
               if (LIKELY (ret == 0))
                 {
@@ -1741,9 +1740,9 @@ do_mount_cgroup_v2 (libcrun_container_t *container, int targetfd, const char *ta
                 }
 
               /* If the previous method failed, fall back to bind mounting the current cgroup.  */
-              crun_error_release (err);
             }
 
+          crun_error_release (err);
           unified_cgroup_path = get_private_data (container)->unified_cgroup_path;
 
           /* If everything else failed, bind mount from the current cgroup.  */
```