### PR TITLE
docs: fix grammar and formatting issues in crun.1.md

### DIFF
--- a/crun.1
+++ b/crun.1
@@ -298,7 +298,7 @@ Path to the file that will contain the new process PID.
 Allocate a pseudo TTY.
 
 .PP
-**-u \fIUSERSPEC\fP \fB--user\fP=\fIUSERSPEC\fP
+\fB-u\fP \fIUSERSPEC\fP \fB--user\fP=\fIUSERSPEC\fP
 Specify the user in the form UID[:GID].
 
 .SH LIST OPTIONS
@@ -516,7 +516,7 @@ Valid context types are:
   rootcontext
 
 .PP
-More information on how the context mount flags works see the \fBmount(8)\fR man page.
+More information on how the context mount flags work can be found in the \fBmount(8)\fR man page.
 
 .SH \fBrun.oci.seccomp.receiver=PATH\fR
 If the annotation \fBrun.oci.seccomp.receiver=PATH\fR is specified, the
@@ -689,7 +689,7 @@ rather than the file or directory the symbolic link points to.
 
 .SH r$FLAG mount options
 If a \fBr$FLAG\fR mount option is specified then the flag \fB$FLAG\fR is set
-recursively for each children mount.
+recursively for each child mount.
 
 .PP
 These flags are supported:
@@ -810,7 +810,7 @@ mapping if it overlaps multiple ranges in the user namespace.  In such
 a case, there won't be any error reported.
 
 .SH Automatically create user namespace
-When running as user different than root, an user namespace is
+When running as a user other than root, a user namespace is
 automatically created even if it is not specified in the config file.
 The current user is mapped to the ID 0 in the container, and any
 additional id specified in the files \fB/etc/subuid\fR and \fB/etc/subgid\fR

--- a/crun.1.md
+++ b/crun.1.md
@@ -240,7 +240,7 @@ Path to the file that will contain the new process PID.
 **-t** **--tty**
 Allocate a pseudo TTY.
 
-**-u _USERSPEC_ **--user**=_USERSPEC_
+**-u** _USERSPEC_ **--user**=_USERSPEC_
 Specify the user in the form UID[:GID].
 
 ## LIST OPTIONS
@@ -423,7 +423,7 @@ Valid context types are:
   defcontext
   rootcontext
 
-More information on how the context mount flags works see the `mount(8)` man page.
+More information on how the context mount flags work can be found in the `mount(8)` man page.
 
 ## `run.oci.seccomp.receiver=PATH`
 
@@ -600,7 +600,7 @@ rather than the file or directory the symbolic link points to.
 ## r$FLAG mount options
 
 If a `r$FLAG` mount option is specified then the flag `$FLAG` is set
-recursively for each children mount.
+recursively for each child mount.
 
 These flags are supported:
 
@@ -690,7 +690,7 @@ a case, there won't be any error reported.
 
 ## Automatically create user namespace
 
-When running as user different than root, an user namespace is
+When running as a user other than root, a user namespace is
 automatically created even if it is not specified in the config file.
 The current user is mapped to the ID 0 in the container, and any
 additional id specified in the files `/etc/subuid` and `/etc/subgid`


### PR DESCRIPTION
**Description:**
This commit fixes a few minor typographical and formatting issues in the `crun` man page:
- Fixed a missing markdown bold marker for the `-u/--user` option.
- Fixed grammar: "how the context mount flags works" -> "work".
- Fixed grammar: "each children mount" -> "each child mount".
- Fixed grammar: "an user namespace" -> "a user namespace".
