### PR TITLE
linux: do not skip EACCES in do_masked_or_readonly_path

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1226,6 +1226,8 @@ do_masked_or_readonly_path (libcrun_container_t *container, const char *rel_path
       if (errno != ENOENT && errno != EACCES)
         return pathfd;
 
+      if (errno == EACCES)
+        libcrun_debug ("skipping inaccessible path `%s`", rel_path);
       crun_error_release (err);
       return 0;
     }


### PR DESCRIPTION
**Description:**
When attempting to open a masked or read-only path, `crun` was silently ignoring both `ENOENT` and `EACCES` errors. 

To maintain consistency with `runc`'s fail-closed behavior, this commit updates the logic so that only `ENOENT` is silently ignored. If `EACCES` is encountered, the error is now properly propagated, preventing potential protection bypasses if a masked/readonly paths entry cannot be opened due to permissions.

Fixes: #2139
