### PR TITLE
linux: fix redundant ternary operator condition in do_notify_socket()

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3002,7 +3002,7 @@ do_notify_socket (libcrun_container_t *container, libcrun_error_t *err)
     return 0;
 
   ret = libcrun_get_state_directory (&state_dir,
-                                     (container->context ? container->context->state_root : NULL),
+                                     container->context->state_root,
                                      container->context->id, err);
   if (UNLIKELY (ret < 0))
     return ret;


### PR DESCRIPTION
**Description:**
The condition `errno ? errno : 0` in `do_notify_socket()` evaluates `errno` but functionally results in just returning `errno` regardless of whether it is true or false.

This commit simplifies the logic by removing the redundant ternary operator and directly passing `errno` into the error handler.

Fixes: #2142
