### PR TITLE
net_device: drop unnecessary variable

### DIFF
--- a/src/libcrun/net_device.c
+++ b/src/libcrun/net_device.c
@@ -152,7 +152,6 @@ name_to_index (int sock, const char *ifname, char *buffer, size_t buffer_size, l
   struct nlmsghdr *nlh;
   struct nl_req *req;
   uint32_t seq;
-  int index = 0;
   ssize_t len;
   int ret;
 
@@ -191,15 +190,11 @@ name_to_index (int sock, const char *ifname, char *buffer, size_t buffer_size, l
       if (nlh->nlmsg_type == RTM_NEWLINK)
         {
           struct ifinfomsg *ifi = NLMSG_DATA (nlh);
-          index = ifi->ifi_index;
-          return index;
+          return ifi->ifi_index;
         }
     }
 
-  if (index == 0)
-    return crun_make_error (err, 0, "could not find device `%s`", ifname);
-
-  return index;
+  return crun_make_error (err, 0, "could not find device `%s`", ifname);
 }
 
 static int


### PR DESCRIPTION
I was reading the source code file _net_device.c_ and thought I found two unnecessary variables. Claude Opus 4.8 told me that only one was valid. (My original patch didn't even compile so I should have been able to realize this by myself)

<details>
<summary>Click me for details</summary>

In the the Claude web interface I entered the following text

```
Today I wrote a patch to simplify crun. I noticed that some variables could be removed because they were unnecessary.
Could you help me find more of these fixes? Here is the patch that I wrote:

diff --git a/src/libcrun/net_device.c b/src/libcrun/net_device.c
index 8c5b54f0..8c55ee5d 100644
--- a/src/libcrun/net_device.c
+++ b/src/libcrun/net_device.c
@@ -152,7 +152,6 @@ name_to_index (int sock, const char *ifname, char *buffer, size_t buffer_size, l
   struct nlmsghdr *nlh;
   struct nl_req *req;
   uint32_t seq;
-  int index = 0;
   ssize_t len;
   int ret;

@@ -191,15 +190,11 @@ name_to_index (int sock, const char *ifname, char *buffer, size_t buffer_size, l
       if (nlh->nlmsg_type == RTM_NEWLINK)
         {
           struct ifinfomsg *ifi = NLMSG_DATA (nlh);
-          index = ifi->ifi_index;
-          return index;
+          return ifi->ifi_index;
         }
     }

-  if (index == 0)
-    return crun_make_error (err, 0, "could not find device `%s`", ifname);
-
-  return index;
+  return crun_make_error (err, 0, "could not find device `%s`", ifname);
}

static int
@@ -247,7 +242,6 @@ get_ip_addresses (int sock, uint32_t ifindex, struct ip_addr **out_ips, char *bu
   size_t ips_len = 0;
   int optval = 1;
   uint32_t seq;
-  ssize_t len;
   int ret;

#ifdef NETLINK_GET_STRICT_CHK
@@ -269,7 +263,7 @@ get_ip_addresses (int sock, uint32_t ifindex, struct ip_addr **out_ips, char *bu
   if (UNLIKELY (ret < 0))
     return ret;

-  while ((len = TEMP_FAILURE_RETRY (recv (sock, buffer, buffer_size, 0))) > 0)
+  while (TEMP_FAILURE_RETRY (recv (sock, buffer, buffer_size, 0)) > 0)
     {
       struct nlmsghdr *nlh;

@@ -311,9 +305,7 @@ get_ip_addresses (int sock, uint32_t ifindex, struct ip_addr **out_ips, char *bu
           copy_ip_addr (nlh, &ips[ips_len - 1]);
         }
     }
-  if (UNLIKELY (len < 0))
-    return crun_make_error (err, errno, "recv");
-  return 0;
+  return crun_make_error (err, errno, "recv");
}

static int
```

Claude told me that only the first removal was correct (the variable `index`). My patch didn't even compile.

Claude asked some follow up questions about taking a  deeper look to find other unnecessary variables. 
In the end Claude didn't find any more unnecessary variables if I understand the Claude output correctly. 


</details>