### PR TITLE
linux: add NULL check for container->context->id

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3003,7 +3003,7 @@ do_notify_socket (libcrun_container_t *container, libcrun_error_t *err)
 
   ret = libcrun_get_state_directory (&state_dir,
                                      (container->context ? container->context->state_root : NULL),
-                                     container->context->id, err);
+                                     (container->context ? container->context->id : NULL), err);
   if (UNLIKELY (ret < 0))
     return ret;
 
@@ -5492,7 +5492,7 @@ prepare_and_send_dev_mounts (libcrun_container_t *container, int sync_socket_hos
 
   ret = libcrun_get_state_directory (&state_dir,
                                      (container->context ? container->context->state_root : NULL),
-                                     container->context->id, err);
+                                     (container->context ? container->context->id : NULL), err);
   if (UNLIKELY (ret < 0))
     return ret;
 


### PR DESCRIPTION
Closes: #2142
The calls to `libcrun_get_state_directory()` guard the state_root argument with a NULL check on container->context, but pass container->context->id unconditionally.  
Apply the same defensive check to the id argument, as suggested in the issue discussion. 
The same pattern appears in both `do_notify_socket()` and `prepare_and_send_dev_mounts()`, so fix both call sites.