### PR TITLE
utils: fix digit test in atou()

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -1462,7 +1462,7 @@ static unsigned
 atou (char **s)
 {
   unsigned x;
-  for (x = 0; **s - '0' < 10; ++*s)
+  for (x = 0; **s >= '0' && **s <= '9'; ++*s)
     x = 10 * x + (**s - '0');
   return x;
 }


### PR DESCRIPTION
I reported this privately first. @giuseppe confirmed it is not a security issue and suggested a regular PR, so this is framed purely as a correctness fix.

### The problem

`src/libcrun/utils.c:1465`

```c
for (x = 0; **s - '0' < 10; ++*s)
```

`**s` promotes to `int`, so the comparison is signed and has no lower bound. With a signed `char`, every byte below `'0'` is negative and therefore also below 10, so the loop keeps running instead of stopping. `'\0'` is one of those bytes, so a `passwd` line whose uid field is empty or ends at the terminator makes the parser walk past the end of the string.

### Where it came from

The helper is musl's, from `src/passwd/getpwent_a.c`, which writes the loop as `**s-'0'<10U`. The `U` forces the usual arithmetic conversions to unsigned and is what gives the comparison its lower bound.

- `6ed7babb8f` ("Define fgetpwent_r if it does not exist", #389) imported it **with** the suffix.
- `158211e7ca` ("Fix syntax and unsigned warning", same PR, 43 minutes later) reindented the block and dropped the suffix. The PR thread records the reason: the Alpine build failed with `error: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Werror=sign-compare]`.

`lxc/lxc` (`src/include/getgrgid_r.c`) and `google/libnss-cache` (`compat/getpwent_r.c`) vendored the same parser and kept the `U`.

### Why a range test rather than restoring `10U` or casting

Restoring `10U` reintroduces the 2020 build failure. I compiled all four forms with `-Wall -Wextra -Wsign-compare -Werror`:

| form | builds clean |
|---|---|
| `**s - '0' < 10` (current) | yes |
| `**s - '0' < 10U` (musl) | **no**, `-Wsign-compare` |
| `(unsigned) (**s - '0') < 10` | yes |
| `**s >= '0' && **s <= '9'` (this PR) | yes |

The three fixed forms accept exactly the same bytes. Checked over the full `char` range:

```
cast/range/musl agree on all 256 char values: YES
bytes that keep the CURRENT loop running: 186 of 256
bytes that keep the FIXED loop running:   10 of 256
```

The range test needs no cast, keeps the build warning free, and matches the idiom already used in `status.c:50`.

<details>
<summary>program used for the two numbers above</summary>

```c
#include <stdio.h>
int main (void) {
  int diff = 0;
  for (int i = -128; i <= 255; i++) {
    char c = (char) i;
    int cast  = (unsigned) (c - '0') < 10;
    int range = (c >= '0' && c <= '9');
    int muslu = (c - '0') < 10U;
    if (cast != range || cast != muslu) { printf ("MISMATCH byte %d\n", i); diff++; }
  }
  int keeps_old = 0, keeps_fixed = 0;
  for (int i = -128; i <= 127; i++) {
    char c = (char) i;
    if ((c - '0') < 10) keeps_old++;
    if (c >= '0' && c <= '9') keeps_fixed++;
  }
  printf ("cast/range/musl agree on all 256 char values: %s\n", diff ? "NO" : "YES");
  printf ("bytes that keep the CURRENT loop running: %d of 256\n", keeps_old);
  printf ("bytes that keep the FIXED loop running:   %d of 256\n", keeps_fixed);
  return 0;
}
```

Built with `cc -fsigned-char -O0`.
</details>

### What I verified and what I did not

The block is inside `#ifndef HAVE_FGETPWENT_R`, so it is only compiled against a libc that does not provide `fgetpwent_r`, which is the musl case. I ran the checks above with a standalone program on macOS/clang using `-fsigned-char` to match the x86-64 default for `DEFAULT_SIGNED_CHAR`. **I did not build crun itself and did not run `make check`**, since I do not have a musl Linux host where this block would be compiled. The change is one line and behaviour-identical to upstream musl, but CI is the real check here.

I did not run `make clang-format` for the same reason; the line follows the spacing already used in `status.c:50`.

### Unrelated, happy to send separately if useful

`tests/tests_libcrun_fuzzer.c` has ten modes, and the `-1` "all" mode loops `for (i = 0; i <= 8; i++)`, so mode 9 (`cpuset_string_to_bitmask`) only runs when `FUZZING_MODE=9` is set explicitly. There is also no mode covering this passwd parser, which would fit naturally since it takes a buffer and a length directly.
