### PR TITLE
linux: run createContainer hooks after mounts are set up

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1352,6 +1352,19 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
   if (UNLIKELY (ret < 0))
     return ret;
 
+  ret = libcrun_do_pivot_root (container, entrypoint_args->context->no_pivot, &rootfs, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  /* sync 2 and 3 are sent as part of libcrun_set_mounts.  */
+  ret = libcrun_set_mounts (entrypoint_args, container, rootfs, send_sync_cb, &sync_socket, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  /* The createContainer hooks MUST run after the mounts are set up but before
+     the pivot_root.  When these hooks are present can_use_open_tree_namespace()
+     forces the deferred-pivot path, so the actual pivot happens later in
+     libcrun_finalize_mounts().  */
   if (def->hooks && def->hooks->create_container_len)
     {
       libcrun_error_t tmp_err = NULL;
@@ -1364,15 +1377,6 @@ container_init_setup (void *args, pid_t own_pid, char *notify_socket,
       if (UNLIKELY (ret != 0))
         return ret;
     }
-
-  ret = libcrun_do_pivot_root (container, entrypoint_args->context->no_pivot, &rootfs, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
-
-  /* sync 2 and 3 are sent as part of libcrun_set_mounts.  */
-  ret = libcrun_set_mounts (entrypoint_args, container, rootfs, send_sync_cb, &sync_socket, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
 
   ret = libcrun_finalize_mounts (entrypoint_args, container, rootfs, err);
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3456,7 +3456,8 @@ can_use_open_tree_namespace (libcrun_container_t *container)
   runtime_spec_schema_config_schema *def = container->container_def;
   struct libcrun_fd_map *mount_fds;
   bool has_hooks = def->hooks
-                   && (def->hooks->prestart_len || def->hooks->create_runtime_len);
+                   && (def->hooks->prestart_len || def->hooks->create_runtime_len
+                       || def->hooks->create_container_len);
   bool has_userns = get_private_data (container)->unshare_flags & CLONE_NEWUSER;
   size_t i;
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -280,6 +280,36 @@ def test_createContainer_hook():
         return -1
 
 
+def test_createContainer_hook_after_mounts():
+    """Test createContainer hook runs after mounts are set up (issue #2167).
+
+    Per the OCI runtime spec the createContainer hooks must be called after
+    the mount namespace has been set up but before pivot_root.  The hook runs
+    with the bundle as its working directory, so the container /proc mount is
+    visible at rootfs/proc.  rootfs/proc/self only exists once proc has been
+    mounted, so this fails if the hook runs before libcrun_set_mounts.
+    """
+    if is_rootless():
+        return (77, "requires root privileges")
+
+    conf = base_config()
+    add_all_namespaces(conf)
+    conf['process']['args'] = ['/init', 'true']
+
+    hook = {
+        "path": "/bin/sh",
+        "args": ["/bin/sh", "-c", "test -e rootfs/proc/self"]
+    }
+    conf['hooks'] = {"createContainer": [hook]}
+
+    try:
+        out, _ = run_and_get_output(conf, hide_stderr=True)
+        return 0
+    except Exception as e:
+        logger.info("test failed: %s", e)
+        return -1
+
+
 def test_startContainer_hook():
     """Test startContainer hook (runs inside container namespace)."""
     conf = base_config()
@@ -572,6 +602,7 @@ all_tests = {
     "test-createRuntime-hook": test_createRuntime_hook,
     "test-createRuntime-hook-bundle-path": test_createRuntime_hook_bundle_path,
     "test-createContainer-hook": test_createContainer_hook,
+    "test-createContainer-hook-after-mounts": test_createContainer_hook_after_mounts,
     "test-startContainer-hook": test_startContainer_hook,
     "test-hook-with-timeout": test_hook_with_timeout,
     "test-hook-receives-state": test_hook_receives_state,


### PR DESCRIPTION
PR #2094 moved libcrun_set_mounts after pivot_root but left the createContainer hooks before both, so they ran before /proc and other mounts existed, violating the OCI spec and breaking the NVIDIA Container Toolkit.

Add create_container_len to can_use_open_tree_namespace() so the deferred-pivot path is used, and move the hooks to run after libcrun_set_mounts and before the pivot in libcrun_finalize_mounts.

Fixes: https://github.com/containers/crun/issues/2167