### PR TITLE
fix regression in 1.29

### DIFF
--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -305,7 +305,13 @@ read_pids_cgroup (int dfd, bool recurse, pid_t **pids, size_t *n_pids, size_t *a
 
   tasksfd = openat (dfd, "cgroup.procs", O_RDONLY | O_CLOEXEC);
   if (tasksfd < 0)
-    return crun_make_error (err, errno, "open `cgroup.procs`");
+    {
+      /* The cgroup was removed concurrently (e.g. while killing the
+         container), there are no processes left to account for.  */
+      if (errno == ENOENT || errno == ENODEV)
+        return 0;
+      return crun_make_error (err, errno, "open `cgroup.procs`");
+    }
 
   ret = read_all_fd (tasksfd, "cgroup.procs", &buffer, &len, err);
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -735,6 +735,7 @@ libcrun_cgroup_pause_unpause_path (const char *cgroup_path, const bool pause, li
 int
 cgroup_killall_path (const char *path, int signal, libcrun_error_t *err)
 {
+  bool frozen = false;
   int ret;
   size_t i;
   cleanup_free pid_t *pids = NULL;
@@ -758,15 +759,20 @@ cgroup_killall_path (const char *path, int signal, libcrun_error_t *err)
       crun_error_release (err);
     }
 
+  /* Freeze the cgroup so that the processes cannot fork while they are being
+     killed.  Once frozen, make sure the cgroup is always thawed again on any
+     exit path, otherwise the container would be left frozen and unresponsive.  */
   ret = libcrun_cgroup_pause_unpause_path (path, true, err);
   if (UNLIKELY (ret < 0))
     crun_error_release (err);
+  else
+    frozen = true;
 
   ret = libcrun_cgroup_read_pids_from_path (path, true, &pids, err);
   if (UNLIKELY (ret < 0))
     {
       if (crun_error_get_errno (err) != ENOENT)
-        return ret;
+        goto thaw;
 
       /* If the file doesn't exist then the container was already killed.  */
       crun_error_release (err);
@@ -776,14 +782,26 @@ cgroup_killall_path (const char *path, int signal, libcrun_error_t *err)
     {
       ret = kill (pids[i], signal);
       if (UNLIKELY (ret < 0 && errno != ESRCH))
-        return crun_make_error (err, errno, "kill process `%d`", pids[i]);
+        {
+          ret = crun_make_error (err, errno, "kill process `%d`", pids[i]);
+          goto thaw;
+        }
     }
 
-  ret = libcrun_cgroup_pause_unpause_path (path, false, err);
-  if (UNLIKELY (ret < 0))
-    crun_error_release (err);
+  ret = 0;
 
-  return 0;
+thaw:
+  if (frozen)
+    {
+      libcrun_error_t thaw_err = NULL;
+
+      /* Thawing is best-effort: do not clobber a pending error with a
+         thaw failure, but never leave the cgroup frozen.  */
+      if (libcrun_cgroup_pause_unpause_path (path, false, &thaw_err) < 0)
+        crun_error_release (&thaw_err);
+    }
+
+  return ret;
 }
 
 static int

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -1074,13 +1074,16 @@ libcrun_migrate_all_pids_to_cgroup (pid_t init_pid, char *from, char *to, libcru
   if (cgroup_mode < 0)
     return cgroup_mode;
 
+  /* Freeze the source cgroup for a consistent view of its processes while they
+     are migrated, but make sure it is always thawed again on error, otherwise
+     it would be left frozen.  */
   ret = libcrun_cgroup_pause_unpause_path (from, true, err);
   if (UNLIKELY (ret < 0))
     return ret;
 
   ret = libcrun_cgroup_read_pids_from_path (from, true, &pids, err);
   if (UNLIKELY (ret < 0))
-    return ret;
+    goto thaw;
 
   from_len = strlen (from);
 
@@ -1091,18 +1094,34 @@ libcrun_migrate_all_pids_to_cgroup (pid_t init_pid, char *from, char *to, libcru
 
       ret = libcrun_get_cgroup_process (pids[i], &pid_path, false, err);
       if (UNLIKELY (ret < 0))
-        return ret;
+        goto thaw;
 
       /* Make sure the pid is in the cgroup we are migrating from.  */
       if (! has_prefix (pid_path, from))
-        return crun_make_error (err, 0, "error migrating pid %d.  It is not in the cgroup `%s`", pids[i], from);
+        {
+          ret = crun_make_error (err, 0, "error migrating pid %d.  It is not in the cgroup `%s`", pids[i], from);
+          goto thaw;
+        }
 
       /* Build the destination cgroup path, keeping the same hierarchy.  */
       xasprintf (&dest_cgroup, "%s%s", to, pid_path + from_len);
 
       ret = enter_cgroup (cgroup_mode, pids[i], init_pid, dest_cgroup, false, err);
       if (UNLIKELY (ret < 0))
-        return ret;
+        goto thaw;
+    }
+
+  ret = 0;
+
+thaw:
+  if (UNLIKELY (ret < 0))
+    {
+      libcrun_error_t thaw_err = NULL;
+
+      /* Best-effort thaw: keep the original error but never leave the cgroup frozen.  */
+      if (libcrun_cgroup_pause_unpause_path (from, false, &thaw_err) < 0)
+        crun_error_release (&thaw_err);
+      return ret;
     }
 
   ret = libcrun_cgroup_pause_unpause_path (from, false, err);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -3488,6 +3488,26 @@ can_use_open_tree_namespace (libcrun_container_t *container)
   return true;
 }
 
+/* Only tmpfs mounts inherit the mode of the directory they are mounted
+   over, and only when the mount does not already request an explicit mode=
+   option.  This mirrors append_tmpfs_mode_if_missing() used by the fallback
+   mount() path.  File systems such as proc, sysfs and mqueue have a root
+   inode mode defined by the kernel that must not be overridden.  */
+static bool
+mount_inherits_mountpoint_mode (runtime_spec_schema_defs_mount *mount)
+{
+  size_t i;
+
+  if (mount->type == NULL || strcmp (mount->type, "tmpfs") != 0)
+    return false;
+
+  for (i = 0; i < mount->options_len; i++)
+    if (has_prefix (mount->options[i], "mode="))
+      return false;
+
+  return true;
+}
+
 static int
 setup_mount_namespace (libcrun_container_t *container, bool no_pivot, char **rootfs, libcrun_error_t *err)
 {
@@ -3593,7 +3613,7 @@ setup_mount_namespace (libcrun_container_t *container, bool no_pivot, char **roo
       ret = append_paths (&dest_path, err, *rootfs, def->mounts[i]->destination, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
-      if (stat (dest_path, &st) == 0)
+      if (mount_inherits_mountpoint_mode (def->mounts[i]) && stat (dest_path, &st) == 0)
         {
           proc_fd_path_t fd_path;
           int procfd = get_procfd (get_private_data (container), err);

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -135,6 +135,47 @@ def test_mount_tmpfs_permissions():
     logger.info("actual output: %s", out)
     return -1
 
+def test_mount_proc_mode():
+    # The procfs root inode mode is defined by the kernel (0555) and must
+    # not be overridden with the mode of the directory it is mounted over.
+    # Regression test for a bug where crun copied the mountpoint mode onto
+    # the mount root, turning /proc into 0755 and breaking the
+    # /proc/<pid>/fd magic-symlink path (used e.g. to publish O_TMPFILE via
+    # linkat).
+    def prepare_rootfs(rootfs):
+        path = os.path.join(rootfs, "proc")
+        if not os.path.exists(path):
+            os.mkdir(path)
+        os.chmod(path, 0o755)
+
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'mode', '/proc']
+    add_all_namespaces(conf)
+    out, _ = run_and_get_output(conf, hide_stderr=True, callback_prepare_rootfs=prepare_rootfs)
+    if out.strip() == "555":
+        return 0
+    logger.info("proc mode test failed: expected '555', got '%s'", out)
+    return -1
+
+def test_mount_tmpfs_explicit_mode():
+    # An explicit mode= option on a tmpfs mount must be honored and not
+    # overridden with the mode of the mountpoint directory.  Regression test
+    # for a tmpfs such as /dev/shm requested with mode=1777 ending up 0755.
+    def prepare_rootfs(rootfs):
+        path = os.path.join(rootfs, "test-tmpfs")
+        os.mkdir(path)
+        os.chmod(path, 0o700)
+
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'mode', '/test-tmpfs']
+    add_all_namespaces(conf)
+    conf['mounts'].append({"destination": "/test-tmpfs", "type": "tmpfs", "source": "tmpfs", "options": ["mode=1777"]})
+    out, _ = run_and_get_output(conf, hide_stderr=True, callback_prepare_rootfs=prepare_rootfs)
+    if out.strip() == "1777":
+        return 0
+    logger.info("tmpfs explicit mode test failed: expected '1777', got '%s'", out)
+    return -1
+
 def test_mount_bind_to_rootfs():
     if is_rootless():
         return (77, "requires root for bind mount to rootfs")
@@ -1322,6 +1363,8 @@ all_tests = {
     "mount-bind-mount-symlink-nofollow": test_bind_mount_symlink_nofollow,
     "mount-bind-mount-file-nofollow": test_bind_mount_file_nofollow,
     "mount-tmpfs-permissions": test_mount_tmpfs_permissions,
+    "mount-proc-mode": test_mount_proc_mode,
+    "mount-tmpfs-explicit-mode": test_mount_tmpfs_explicit_mode,
     "mount-add-remove-mounts": test_add_remove_mounts,
     "mount-help": test_mount_help,
     "annotation-mount-context-type": test_annotation_mount_context_type,


### PR DESCRIPTION
More details in each commit.

The most important fix is:

linux: do not clobber mount root mode for proc/sysfs/mqueue

 For proc the mountpoint in the image is usually 0755, so procfs (whose root must be 0555) ends up 0755.  On some kernels this breaks the /proc/<pid>/fd magic-symlink path used to publish an O_TMPFILE via linkat(), e.g. rpm-ostree failing with "Operation not supported" (coreos/fedora-coreos-tracker#2205).  The same override breaks a tmpfs /dev/shm created with mode=1777, causing "could not open shared memory segment: Permission denied" (#2176).

Before this regression (crun 1.28) only tmpfs mounts inherited the mountpoint mode, and only when no explicit mode= option was given, via append_tmpfs_mode_if_missing() which sets the mode as a mount option.  That function is still used by the fallback mount() path.

Restrict the fchmodat() to the same cases: tmpfs mounts without an explicit mode= option.  proc, sysfs, mqueue and cgroup2 keep their kernel-defined root mode, matching 1.28 behavior.