### PR TITLE
linux: restore read-only `/sys` in the sysfs userns fallback

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1075,6 +1075,16 @@ static int do_mount (libcrun_container_t *container, const char *source, int tar
                      const char *target, const char *fstype, unsigned long mountflags,
                      const void *data, int extra_flags, libcrun_error_t *err);
 
+static bool
+mount_option_exists (runtime_spec_schema_defs_mount *mnt, const char *option)
+{
+  size_t i;
+  for (i = 0; i < mnt->options_len; i++)
+    if (strcmp (mnt->options[i], option) == 0)
+      return true;
+  return false;
+}
+
 static runtime_spec_schema_defs_mount *
 find_mount_for (libcrun_container_t *container, const char *destination)
 {
@@ -1503,18 +1513,21 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
 
               if (ret > 0)
                 {
+                  runtime_spec_schema_defs_mount *cgroup_mount = find_mount_for (container, "/sys/fs/cgroup");
                   cleanup_close int mountfd = -1;
+                  cleanup_close int sysfd = -1;
                   int sys_old_root_fd = get_old_root_fd (get_private_data (container));
+                  bool ro = flags & MS_RDONLY;
 
                   if (sys_old_root_fd >= 0)
-                    mountfd = get_bind_mount (sys_old_root_fd, "sys", true, false, false, MS_PRIVATE, err);
+                    mountfd = get_bind_mount (sys_old_root_fd, "sys", true, ro, false, MS_PRIVATE, err);
                   if (mountfd < 0)
                     {
                       crun_error_release (err);
-                      mountfd = get_bind_mount (AT_FDCWD, "/sys", true, false, false, MS_PRIVATE, err);
+                      mountfd = get_bind_mount (AT_FDCWD, "/sys", true, ro, false, MS_PRIVATE, err);
                     }
 
-                  if (find_mount_for (container, "/sys/fs/cgroup") == NULL)
+                  if (cgroup_mount == NULL)
                     {
                       if (mountfd >= 0)
                         {
@@ -1539,7 +1552,18 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
                           if (UNLIKELY (ret < 0))
                             return crun_make_error (err, errno, "bind mount `/sys` from the host");
                         }
-                      return do_masked_or_readonly_path (container, "/sys/fs/cgroup", false, false, err);
+
+                      sysfd = open_mount_target (container, target, err);
+                      if (UNLIKELY (sysfd < 0))
+                        return sysfd;
+
+                      ret = do_remount (sysfd, target,
+                                        MS_REMOUNT | MS_BIND | (mountflags & ~ALL_PROPAGATIONS),
+                                        NULL, err);
+                      if (UNLIKELY (ret < 0))
+                        return ret;
+
+                      return do_masked_or_readonly_path (container, "/sys/fs/cgroup", true, false, err);
                     }
 
                   if (UNLIKELY (mountfd < 0))
@@ -1548,6 +1572,23 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
                   ret = fs_move_mount_to (mountfd, targetfd, NULL);
                   if (UNLIKELY (ret < 0))
                     return crun_make_error (err, errno, "move mount to `%s`", real_target);
+
+                  sysfd = open_mount_target (container, target, err);
+                  if (UNLIKELY (sysfd < 0))
+                    return sysfd;
+
+                  ret = do_remount (sysfd, target,
+                                    MS_REMOUNT | MS_BIND | (mountflags & ~ALL_PROPAGATIONS),
+                                    NULL, err);
+                  if (UNLIKELY (ret < 0))
+                    return ret;
+
+                  if (mount_option_exists (cgroup_mount, "ro") || mount_option_exists (cgroup_mount, "rro"))
+                    {
+                      ret = do_masked_or_readonly_path (container, "/sys/fs/cgroup", true, false, err);
+                      if (UNLIKELY (ret < 0))
+                        return ret;
+                    }
 
                   return 0;
                 }
@@ -5398,16 +5439,6 @@ send_mounts (int sync_socket_host, struct libcrun_fd_map *fds, size_t how_many, 
         }
     }
   return 0;
-}
-
-static bool
-mount_option_exists (runtime_spec_schema_defs_mount *mnt, const char *option)
-{
-  size_t i;
-  for (i = 0; i < mnt->options_len; i++)
-    if (strcmp (mnt->options[i], option) == 0)
-      return true;
-  return false;
 }
 
 static int

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1679,6 +1679,14 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
 #endif
 
           targetfd = fd;
+
+          /* The bind mount shadowed the original targetfd, so refresh
+             real_target to point to the reopened mountpoint.  Otherwise the
+             classic mount(2) fallbacks below (used when mount_setattr is not
+             available, e.g. kernels < 5.12) operate on the shadowed path and
+             fail with EINVAL.  */
+          get_proc_self_fd_path (target_buffer, targetfd);
+          real_target = target_buffer;
         }
     }
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1382,6 +1382,113 @@ diagnose_mount_failure (int ret, libcrun_error_t *err, libcrun_container_t *cont
   return ret;
 }
 
+/* When creating a fresh sysfs mount fails inside a user namespace, fall back to
+   bind mounting the host /sys.  Returns 0 when the fallback handled the mount,
+   > 0 when it does not apply (the caller must report the original failure),
+   < 0 on error.  */
+static int
+sysfs_userns_fallback (libcrun_container_t *container, const char *target,
+                       const char *real_target, int targetfd,
+                       unsigned long mountflags, const char *fstype,
+                       libcrun_error_t *err)
+{
+  unsigned long flags = mountflags & ~(ALL_PROPAGATIONS_NO_REC | MS_RDONLY);
+  int ret;
+
+  if (! ((mountflags & MS_RDONLY) && targetfd > 0 && fstype && strcmp (fstype, "sysfs") == 0))
+    return 1;
+
+  /* If we are running in an user namespace, just bind mount /sys if creating
+     sysfs failed.  */
+  ret = check_running_in_user_namespace (err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  if (ret == 0)
+    return 1;
+
+  {
+    runtime_spec_schema_defs_mount *cgroup_mount = find_mount_for (container, "/sys/fs/cgroup");
+    cleanup_close int mountfd = -1;
+    cleanup_close int sysfd = -1;
+    int sys_old_root_fd = get_old_root_fd (get_private_data (container));
+    bool ro = flags & MS_RDONLY;
+
+    if (sys_old_root_fd >= 0)
+      mountfd = get_bind_mount (sys_old_root_fd, "sys", true, ro, false, MS_PRIVATE, err);
+    if (mountfd < 0)
+      {
+        crun_error_release (err);
+        mountfd = get_bind_mount (AT_FDCWD, "/sys", true, ro, false, MS_PRIVATE, err);
+      }
+
+    if (cgroup_mount == NULL)
+      {
+        if (mountfd >= 0)
+          {
+            ret = fs_move_mount_to (mountfd, targetfd, NULL);
+            if (UNLIKELY (ret < 0))
+              return crun_make_error (err, errno, "move mount `/sys` to `%s`", real_target);
+          }
+        else
+          {
+            crun_error_release (err);
+            if (sys_old_root_fd >= 0)
+              {
+                cleanup_free char *sys_path = NULL;
+                proc_fd_path_t sys_root_path;
+
+                get_proc_self_fd_path (sys_root_path, sys_old_root_fd);
+                xasprintf (&sys_path, "%s/sys", sys_root_path);
+                ret = mount (sys_path, real_target, NULL, MS_BIND | MS_REC, NULL);
+              }
+            else
+              ret = mount ("/sys", real_target, NULL, MS_BIND | MS_REC, NULL);
+            if (UNLIKELY (ret < 0))
+              return crun_make_error (err, errno, "bind mount `/sys` from the host");
+          }
+
+        sysfd = open_mount_target (container, target, err);
+        if (UNLIKELY (sysfd < 0))
+          return sysfd;
+
+        ret = do_remount (sysfd, target,
+                          MS_REMOUNT | MS_BIND | (mountflags & ~ALL_PROPAGATIONS),
+                          NULL, err);
+        if (UNLIKELY (ret < 0))
+          return ret;
+
+        return do_masked_or_readonly_path (container, "/sys/fs/cgroup", true, false, err);
+      }
+
+    if (UNLIKELY (mountfd < 0))
+      return mountfd;
+
+    ret = fs_move_mount_to (mountfd, targetfd, NULL);
+    if (UNLIKELY (ret < 0))
+      return crun_make_error (err, errno, "move mount to `%s`", real_target);
+
+    sysfd = open_mount_target (container, target, err);
+    if (UNLIKELY (sysfd < 0))
+      return sysfd;
+
+    ret = do_remount (sysfd, target,
+                      MS_REMOUNT | MS_BIND | (mountflags & ~ALL_PROPAGATIONS),
+                      NULL, err);
+    if (UNLIKELY (ret < 0))
+      return ret;
+
+    if (mount_option_exists (cgroup_mount, "ro") || mount_option_exists (cgroup_mount, "rro"))
+      {
+        ret = do_masked_or_readonly_path (container, "/sys/fs/cgroup", true, false, err);
+        if (UNLIKELY (ret < 0))
+          return ret;
+      }
+
+    return 0;
+  }
+}
+
 static int
 do_mount (libcrun_container_t *container, const char *source, int targetfd,
           const char *target, const char *fstype, unsigned long mountflags, const void *data,
@@ -1503,97 +1610,14 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
         {
           int saved_errno = errno;
 
-          if ((mountflags & MS_RDONLY) && targetfd > 0 && fstype && strcmp (fstype, "sysfs") == 0)
-            {
-              /* If we are running in an user namespace, just bind mount /sys if creating
-                 sysfs failed.  */
-              ret = check_running_in_user_namespace (err);
-              if (UNLIKELY (ret < 0))
-                return ret;
+          ret = sysfs_userns_fallback (container, target, real_target, targetfd,
+                                       mountflags, fstype, err);
+          if (ret == 0)
+            return 0;
+          if (UNLIKELY (ret < 0))
+            return ret;
 
-              if (ret > 0)
-                {
-                  runtime_spec_schema_defs_mount *cgroup_mount = find_mount_for (container, "/sys/fs/cgroup");
-                  cleanup_close int mountfd = -1;
-                  cleanup_close int sysfd = -1;
-                  int sys_old_root_fd = get_old_root_fd (get_private_data (container));
-                  bool ro = flags & MS_RDONLY;
-
-                  if (sys_old_root_fd >= 0)
-                    mountfd = get_bind_mount (sys_old_root_fd, "sys", true, ro, false, MS_PRIVATE, err);
-                  if (mountfd < 0)
-                    {
-                      crun_error_release (err);
-                      mountfd = get_bind_mount (AT_FDCWD, "/sys", true, ro, false, MS_PRIVATE, err);
-                    }
-
-                  if (cgroup_mount == NULL)
-                    {
-                      if (mountfd >= 0)
-                        {
-                          ret = fs_move_mount_to (mountfd, targetfd, NULL);
-                          if (UNLIKELY (ret < 0))
-                            return crun_make_error (err, errno, "move mount `/sys` to `%s`", real_target);
-                        }
-                      else
-                        {
-                          crun_error_release (err);
-                          if (sys_old_root_fd >= 0)
-                            {
-                              cleanup_free char *sys_path = NULL;
-                              proc_fd_path_t sys_root_path;
-
-                              get_proc_self_fd_path (sys_root_path, sys_old_root_fd);
-                              xasprintf (&sys_path, "%s/sys", sys_root_path);
-                              ret = mount (sys_path, real_target, NULL, MS_BIND | MS_REC, NULL);
-                            }
-                          else
-                            ret = mount ("/sys", real_target, NULL, MS_BIND | MS_REC, NULL);
-                          if (UNLIKELY (ret < 0))
-                            return crun_make_error (err, errno, "bind mount `/sys` from the host");
-                        }
-
-                      sysfd = open_mount_target (container, target, err);
-                      if (UNLIKELY (sysfd < 0))
-                        return sysfd;
-
-                      ret = do_remount (sysfd, target,
-                                        MS_REMOUNT | MS_BIND | (mountflags & ~ALL_PROPAGATIONS),
-                                        NULL, err);
-                      if (UNLIKELY (ret < 0))
-                        return ret;
-
-                      return do_masked_or_readonly_path (container, "/sys/fs/cgroup", true, false, err);
-                    }
-
-                  if (UNLIKELY (mountfd < 0))
-                    return mountfd;
-
-                  ret = fs_move_mount_to (mountfd, targetfd, NULL);
-                  if (UNLIKELY (ret < 0))
-                    return crun_make_error (err, errno, "move mount to `%s`", real_target);
-
-                  sysfd = open_mount_target (container, target, err);
-                  if (UNLIKELY (sysfd < 0))
-                    return sysfd;
-
-                  ret = do_remount (sysfd, target,
-                                    MS_REMOUNT | MS_BIND | (mountflags & ~ALL_PROPAGATIONS),
-                                    NULL, err);
-                  if (UNLIKELY (ret < 0))
-                    return ret;
-
-                  if (mount_option_exists (cgroup_mount, "ro") || mount_option_exists (cgroup_mount, "rro"))
-                    {
-                      ret = do_masked_or_readonly_path (container, "/sys/fs/cgroup", true, false, err);
-                      if (UNLIKELY (ret < 0))
-                        return ret;
-                    }
-
-                  return 0;
-                }
-            }
-
+          /* ret > 0: the fallback does not apply, report the original failure.  */
           ret = crun_make_error (err, saved_errno, "mount `%s` to `%s`", source, target);
 
           return diagnose_mount_failure (ret, err, container, fstype);

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -2044,9 +2044,15 @@ libcrun_create_dev (libcrun_container_t *container, int devfd, int srcfd,
 
       if (srcfd >= 0)
         {
-          ret = syscall_move_mount (srcfd, "", fd, "", MOVE_MOUNT_T_EMPTY_PATH | MOVE_MOUNT_F_EMPTY_PATH);
-          if (LIKELY (ret >= 0))
-            return 0;
+          ret = do_mount_setattr (false, normalized_path, srcfd, 0, MS_NOSUID | MS_NOEXEC, err);
+          if (LIKELY (ret == 0))
+            {
+              ret = syscall_move_mount (srcfd, "", fd, "", MOVE_MOUNT_T_EMPTY_PATH | MOVE_MOUNT_F_EMPTY_PATH);
+              if (LIKELY (ret >= 0))
+                return 0;
+            }
+          else
+            crun_error_release (err);
         }
 
       {

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1075,8 +1075,8 @@ static int do_mount (libcrun_container_t *container, const char *source, int tar
                      const char *target, const char *fstype, unsigned long mountflags,
                      const void *data, int extra_flags, libcrun_error_t *err);
 
-static bool
-has_mount_for (libcrun_container_t *container, const char *destination)
+static runtime_spec_schema_defs_mount *
+find_mount_for (libcrun_container_t *container, const char *destination)
 {
   size_t i;
   runtime_spec_schema_config_schema *def = container->container_def;
@@ -1084,9 +1084,9 @@ has_mount_for (libcrun_container_t *container, const char *destination)
   for (i = 0; i < def->mounts_len; i++)
     {
       if (strcmp (def->mounts[i]->destination, destination) == 0)
-        return true;
+        return def->mounts[i];
     }
-  return false;
+  return NULL;
 }
 
 static void
@@ -1514,7 +1514,7 @@ do_mount (libcrun_container_t *container, const char *source, int targetfd,
                       mountfd = get_bind_mount (AT_FDCWD, "/sys", true, false, false, MS_PRIVATE, err);
                     }
 
-                  if (! has_mount_for (container, "/sys/fs/cgroup"))
+                  if (find_mount_for (container, "/sys/fs/cgroup") == NULL)
                     {
                       if (mountfd >= 0)
                         {
@@ -1862,7 +1862,7 @@ do_mount_cgroup_v1 (libcrun_container_t *container, const char *source, int targ
         return ret;
 
       /* if there is already a mount specified, do not add a default one.  */
-      if (has_mount_for (container, source_subsystem))
+      if (find_mount_for (container, source_subsystem) != NULL)
         continue;
 
       ret = append_paths (&source_path, err, source_subsystem, subpath, NULL);

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -369,6 +369,36 @@ def test_mknod_char_device():
         return -1
     return 0
 
+def test_userns_precreated_devices_flags():
+    conf = base_config()
+    add_all_namespaces(conf, userns=True)
+    if not is_rootless():
+        fullMapping = [{"containerID": 0, "hostID": 0, "size": 4294967295}]
+        conf['linux']['uidMappings'] = fullMapping
+        conf['linux']['gidMappings'] = fullMapping
+
+    conf['process']['args'] = ['/init', 'cat', '/proc/self/mountinfo']
+
+    devices = ["/dev/null", "/dev/zero", "/dev/full", "/dev/tty",
+               "/dev/random", "/dev/urandom"]
+
+    out, _ = run_and_get_output(conf, hide_stderr=True)
+
+    found = set()
+    for line in out.split("\n"):
+        fields = line.split(" ")
+        if len(fields) < 6 or fields[4] not in devices:
+            continue
+        found.add(fields[4])
+        opts = fields[5].split(",")
+        if "nosuid" not in opts or "noexec" not in opts:
+            logger.error("device %s missing nosuid,noexec: %s", fields[4], fields[5])
+            return -1
+
+    if not found:
+        return (77, "no precreated device mounts (mknod path taken)")
+    return 0
+
 def test_dev_symlink_does_not_populate_outside_rootfs():
     if is_rootless():
         return (77, "requires root privileges")
@@ -509,6 +539,7 @@ all_tests = {
     "mknod-fifo-device": test_mknod_fifo_device,
     "mknod-char-device": test_mknod_char_device,
     "dev-symlink-does-not-populate-outside-rootfs": test_dev_symlink_does_not_populate_outside_rootfs,
+    "userns-precreated-devices-flags": test_userns_precreated_devices_flags,
     "allow-device-read-only": test_allow_device_read_only,
     "owner-device" : test_owner_device,
     "deny-devices" : test_deny_devices,

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -172,50 +172,62 @@ def test_mount_tmpfs_to_rootfs():
 def test_ro_cgroup():
     for cgroupns in [True, False]:
         for netns in [True, False]:
-            for has_cgroup_mount in [True, False]:
-                conf = base_config()
-                conf['process']['args'] = ['/init', 'cat', '/proc/self/mountinfo']
-                add_all_namespaces(conf, cgroupns=cgroupns, netns=netns)
-                mounts = [
-                    {
-	                "destination": "/sys",
-	                "type": "sysfs",
-	                "source": "sysfs",
-	                "options": [
-		            "nosuid",
-		            "noexec",
-		            "nodev",
-		            "ro"
-	                ]
-	            },
-                    {
-	                "destination": "/proc",
-	                "type": "proc"
-	            }
-                ]
+            for userns in [True, False]:
+                for has_cgroup_mount in [True, False]:
+                    conf = base_config()
+                    conf['process']['args'] = ['/init', 'cat', '/proc/self/mountinfo']
+                    add_all_namespaces(conf, cgroupns=cgroupns, netns=netns, userns=userns)
+                    mounts = [
+                        {
+	                    "destination": "/sys",
+	                    "type": "sysfs",
+	                    "source": "sysfs",
+	                    "options": [
+		                "nosuid",
+		                "noexec",
+		                "nodev",
+		                "ro"
+	                    ]
+	                },
+                        {
+	                    "destination": "/proc",
+	                    "type": "proc"
+	                }
+                    ]
 
-                if has_cgroup_mount:
-                    mounts.append({
-                        "destination": "/sys/fs/cgroup",
-                        "type": "cgroup",
-                        "source": "cgroup",
-                        "options": [
-                            "nosuid",
-                            "noexec",
-                            "nodev",
-                            "relatime",
-                            "ro"
-                        ]
-                    })
+                    if has_cgroup_mount:
+                        mounts.append({
+                            "destination": "/sys/fs/cgroup",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "options": [
+                                "nosuid",
+                                "noexec",
+                                "nodev",
+                                "relatime",
+                                "ro"
+                            ]
+                        })
 
-                conf['mounts'] = mounts
-                out, _ = run_and_get_output(conf, hide_stderr=True)
-                for i in reversed(out.split("\n")):
-                    if i.find("/sys/fs/cgroup") >= 0:
-                        if i.find("ro,") < 0:
-                            logger.error("fail with cgroupns=%s, netns=%s and cgroup_mount=%s, got %s", cgroupns, netns, has_cgroup_mount, i)
-                            return -1
-                        break
+                    conf['mounts'] = mounts
+                    out, _ = run_and_get_output(conf, hide_stderr=True)
+                    for i in reversed(out.split("\n")):
+                        fields = i.split(" ")
+                        if len(fields) < 6:
+                            continue
+                        if fields[4] == "/sys/fs/cgroup":
+                            if "ro" not in fields[5].split(","):
+                                logger.error("fail with cgroupns=%s, netns=%s, userns=%s and cgroup_mount=%s, got=%s", cgroupns, netns, userns, has_cgroup_mount, i)
+                                return -1
+                            break
+
+                    for i in out.split("\n"):
+                        fields = i.split(" ")
+                        if len(fields) >= 6 and fields[4] == "/sys":
+                            if "ro" not in fields[5].split(","):
+                                logger.error("fail with cgroupns=%s, netns=%s, userns=%s and cgroup_mount=%s, /sys options: %s", cgroupns, netns, userns, has_cgroup_mount, fields[5])
+                                return -1
+                            break
     return 0
 
 def test_mount_symlink_not_existing():


### PR DESCRIPTION
Related to #2178.

Since 1.29, `/sys` can end up mounted **read-write** even though the spec requests it read-only (`type: sysfs`, `"ro"`).

This happens when a container's user namespace doesn't own its network namespace: creating a fresh sysfs then fails, so crun falls back to bind-mounting the host's `/sys` instead. If the spec also has a `/sys/fs/cgroup` mount, that fallback drops the `ro` flag.

The root cause is a `get_bind_mount()` call in `do_mount()`. https://github.com/containers/crun/commit/9259e891a split it from one call into two and passed `rdonly=false` to both, even though this fallback exists specifically to preserve a read-only mount. This PR restores `rdonly=true`.

Also extends `mount-ro-cgroup` with a `userns` axis and a `/sys` read-only assertion — it fails on both 1.28 and 1.29, passes with this change.

I'm not fully confident this is the right fix: it also makes the no-`/sys/fs/cgroup`-mount case read-only, which was already broken on 1.28 too, so it goes a little beyond a minimal regression fix.