### PR TITLE
tests: make cgroups-path-def-slice robust under unshare

### DIFF
--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -805,7 +805,7 @@ def test_bind_mount_symlink_nofollow_procfs():
     conf['mounts'].append(mount_opt)
 
     try:
-        out, _ = run_and_get_output(conf, hide_stderr=True, callback_prepare_rootfs=prepare_rootfs)
+        out, _ = run_and_get_output(conf, hide_stderr=True)
         return -1
     except Exception as e:
         logger.info("error %s", e)

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -587,18 +587,20 @@ def test_systemd_cgroups_path_def_slice():
 
     cid = None
     try:
-        _, cid = run_and_get_output(conf, hide_stderr=True, cgroup_manager="systemd", detach=True)
+        try:
+            _, cid = run_and_get_output(conf, hide_stderr=True, cgroup_manager="systemd", detach=True)
+        except subprocess.CalledProcessError:
+            return (77, "systemd cannot manage the container in this environment")
+
         state = run_crun_command(['state', cid])
         scope = json.loads(state)['systemd-scope']
 
-        want='system.slice'
-        if is_rootless():
-            want='user.slice'
+        want = 'user.slice' if is_rootless() else 'system.slice'
 
-        got = subprocess.check_output(['systemctl', 'show','-PSlice', scope], close_fds=False).decode().strip()
-        # try once more against the user manager, as if one exists, crun will prefer it; see bug #1197
+        got = systemctl_show(scope, 'Slice', user=is_rootless())
+        # try once more against the other manager
         if got != want:
-            got = subprocess.check_output(['systemctl', '--user', 'show','-PSlice', scope], close_fds=False).decode().strip()
+            got = systemctl_show(scope, 'Slice', user=not is_rootless())
 
         if got != want:
             logger.info("Got Slice %s, want %s", got, want)

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -39,6 +39,7 @@ logger = logging.getLogger('crun.tests')
 __all__ = ['logger', 'base_config', 'run_and_get_output', 'run_crun_command', 'run_crun_command_raw',
            'parse_proc_status', 'add_all_namespaces', 'tests_main', 'is_rootless',
            'is_cgroup_v2_unified', 'is_sched_deadline_available', 'get_crun_feature_string', 'running_on_systemd',
+           'systemctl_show',
            'get_tests_root', 'get_tests_root_status', 'get_init_path', 'get_crun_path',
            'get_cgroup_manager', 'get_test_environment']
 
@@ -463,6 +464,13 @@ def run_crun_command_raw(args):
 def running_on_systemd():
     with open('/proc/1/comm') as f:
         return "systemd" in f.readline()
+
+def systemctl_show(unit, prop, user=False):
+    cmd = ['systemctl'] + (['--user'] if user else []) + ['show', '-P', prop, unit]
+    try:
+        return subprocess.check_output(cmd, stderr=subprocess.DEVNULL, close_fds=False).decode().strip()
+    except Exception:
+        return None
 
 def tests_main(all_tests):
     os.environ["LANG"] = "C"


### PR DESCRIPTION
A rootless container is managed by the user's systemd instance, so its scope must be queried on the user bus.  The test queried the system bus first and let a failing check_output abort the whole test, so under "unshare -rmn" (where the system bus is unreachable) it failed instead of falling back to the user bus.  Add a systemctl_show() helper that returns a unit property, or None when its manager is unreachable