### PR TITLE
mempolicy: treat empty nodes as unset

### DIFF
--- a/src/libcrun/mempolicy.c
+++ b/src/libcrun/mempolicy.c
@@ -130,7 +130,7 @@ libcrun_set_mempolicy (runtime_spec_schema_config_schema *def, libcrun_error_t *
     }
 
   /* kernel will take care of validating the nodes */
-  if (memory_policy->nodes)
+  if (! is_empty_string (memory_policy->nodes))
     {
       cleanup_free char *bitmask = NULL;
       size_t bitmask_size;


### PR DESCRIPTION
An empty `nodes` string is parsed as a non-NULL empty string, so `cpuset_string_to_bitmask()` returns a NULL bitmask of size 0, and the subsequent `memcpy(dst, NULL, 0)` violates memcpy's nonnull constraint.

Guard with `is_empty_string()`, the same way `libcrun_set_cpu_affinity_from_string()` does.

Fixes #2181

🤖 Generated with [Claude Code](https://claude.com/claude-code)