### PR TITLE
utils: use || instead of | in waitpid_ignore_stopped

### DIFF
--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -450,7 +450,7 @@ waitpid_ignore_stopped (pid_t pid, int *status, int options)
       ret = TEMP_FAILURE_RETRY (waitpid (pid, &s, options));
       if (ret < 0)
         return ret;
-  } while (WIFSTOPPED (s) | WIFCONTINUED (s));
+  } while (WIFSTOPPED (s) || WIFCONTINUED (s));
 
   if (status)
     *status = s;


### PR DESCRIPTION
Claude Opus 5 helped finding the bug and writing this PR.

# utils: use `||` instead of `|` in `waitpid_ignore_stopped`



## What

One-line change in `src/libcrun/utils.h`:

```diff
-  } while (WIFSTOPPED (s) | WIFCONTINUED (s));
+  } while (WIFSTOPPED (s) || WIFCONTINUED (s));
```

## Why

`WIFSTOPPED()` and `WIFCONTINUED()` are boolean predicates, but POSIX only requires
them to evaluate to a non-zero value for a matching status — not to exactly `1`.
Combining them with `|` relies on a normalization the standard does not guarantee.

This is in the same spirit as 910eb16 ("utils: normalize `S_ISDIR()` result to 0 or 1").

## Is this a bug fix?

No — and I would rather say so plainly than oversell it. Both glibc and musl expand
these macros to a comparison, so they already yield `0` or `1` and the loop behaves
correctly on every platform crun supports. Both operands are also side-effect-free,
so nothing changes from restoring short-circuit evaluation. Treat this as a
readability and robustness cleanup.

## Testing

- No behavioral change is expected; the generated code is expected to be identical
  on glibc and musl.
- Builds cleanly with `-Wall -Wextra`.
- The existing integration tests exercise this path heavily — `waitpid_ignore_stopped()`
  has 12 call sites across `container.c`, `linux.c`, `seccomp.c`, `net_device.c`
  and `utils.c`, covering container teardown, `exec`, and the seccomp notify helper.






