### PR TITLE
krun: support TAP-backed networking

### DIFF
--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -564,7 +564,7 @@ libkrun_exec (void *cookie, libcrun_container_t *container, const char *pathname
 }
 
 static int
-libkrun_start_passt (void *cookie, libcrun_container_t *container)
+libkrun_configure_network (void *cookie, libcrun_container_t *container)
 {
   struct krun_config *kconf = (struct krun_config *) cookie;
   pid_t pid;
@@ -717,9 +717,9 @@ libkrun_configure_container (void *cookie, enum handler_configure_phase phase,
   if (phase != HANDLER_CONFIGURE_AFTER_MOUNTS)
     return 0;
 
-  ret = libkrun_start_passt (cookie, container);
+  ret = libkrun_configure_network (cookie, container);
   if (UNLIKELY (ret < 0))
-    return crun_make_error (err, errno, "start passt");
+    return crun_make_error (err, errno, "configure krun network");
 
   /* Do nothing if /dev/kvm is already present in spec */
   if (spec_has_device (def, "/dev/kvm"))


### PR DESCRIPTION
## Summary

Add support for attaching a krun microVM to an existing TAP interface using
libkrun's `krun_add_net_tap()` API.

The TAP interface can be selected with the OCI annotation:

    krun.tap_name=<name>

or through `.krun_vm.json`:

    {
      "tap_name": "<name>"
    }

As with the other krun configuration options, the OCI annotation takes
precedence over `.krun_vm.json`.

Using a TAP interface enables a virtio-net device and disables the default
TSI networking. `krun.tap_name` and `krun.use_passt` are mutually exclusive.

crun only attaches the existing TAP interface; creation and configuration of
the TAP interface remain outside the scope of the runtime. This provides a
conventional virtio-net path for workloads that need VM-like networking
rather than the default TSI backend.

## Implementation

The first commit renames `libkrun_start_passt()` to
`libkrun_configure_network()`, since it is now where the network backend is
selected rather than only where passt starts. This commit has no behavior
change.

The second commit adds the TAP configuration. The krun handler resolves
`krun_add_net_tap()` dynamically, following the existing libkrun integration
pattern, and reports a clear error if the symbol is unavailable in the
installed libkrun.

String configuration parsing is added for `tap_name`, including validation
for empty values and incorrect `.krun_vm.json` types. Network configuration
errors are propagated through `libcrun_error_t`, so the new failure modes are
reported to the caller instead of being reduced to a generic init-process
error.

The mutual-exclusion check runs before passt is started.

The TAP device is added with flags `0`, leaving guest address configuration
outside the scope of crun. The guest MAC uses the same value as the existing
passt networking path.

libkrun opens the TAP backend later, when the virtio-net device is activated
during guest startup, rather than synchronously inside `krun_add_net_tap()`.
As a consequence, an unavailable TAP may fail during device activation or
guest boot rather than during crun's configuration phase. crun does not add
separate TAP pre-validation as part of this change.

## Testing

- `make clang-format`
- `git diff --check`
- `make -j$(nproc)`

Manually tested on x86_64 with libkrun v1.19.4 with virtio-net support and
rootless Podman:

- Booted a krun microVM through `krun.tap_name` using a real TAP interface
  and verified the guest virtio-net interface and routed connectivity.
- Verified `krun.tap_name` parsing through an OCI annotation.
- Verified `tap_name` parsing through `.krun_vm.json`.
- Verified that the OCI annotation takes precedence over `.krun_vm.json`.
- Verified that an empty TAP name is rejected before guest startup.
- Verified that a non-string `tap_name` in `.krun_vm.json` is rejected.
- Verified that `krun.tap_name` together with `krun.use_passt` is rejected
  before passt is started.
- Verified that configuration errors are propagated back through the OCI
  runtime with their specific error messages.

The real TAP path was also exercised through ASF's routed microVM mode:

https://github.com/javimox/asf