### PR TITLE
cgroup: fix redundant NULL check in maybe_make_cgroup_threaded

### DIFF
--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -83,9 +83,12 @@ maybe_make_cgroup_threaded (const char *path, libcrun_error_t *err)
   char *it;
   int ret;
 
+  if (path == NULL)
+    return 0;
+
   path = consume_slashes (path);
 
-  if (path == NULL || path[0] == '\0')
+  if (path[0] == '\0')
     return 0;
 
   ret = append_paths (&cgroup_path_type, err, CGROUP_ROOT, path, "cgroup.type", NULL);


### PR DESCRIPTION
The `consume_slashes()` macro dereferences its argument (`while (*_s == '/')`), so checking `path` for `NULL` *after* calling it is too late — a NULL `path` would crash before the check ever runs.

Move the NULL check before `consume_slashes()`, keeping the empty-string check after it (still needed for inputs like `"///"`).

Fixes the CodeQL alert https://github.com/containers/crun/security/code-scanning/16 (`cpp/redundant-null-check-simple`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)