### PR TITLE
seccomp: add error path tests, simplify action/operator lookup

### DIFF
--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -111,49 +111,33 @@ syscall_seccomp (unsigned int operation, unsigned int flags, void *args)
 static int
 get_seccomp_operator (const char *name, enum scmp_compare *op, libcrun_error_t *err)
 {
-  const char *p;
+  static const struct
+  {
+    const char *name;
+    enum scmp_compare op;
+  } operators[] = {
+    { "NE", SCMP_CMP_NE },
+    { "LT", SCMP_CMP_LT },
+    { "LE", SCMP_CMP_LE },
+    { "EQ", SCMP_CMP_EQ },
+    { "GE", SCMP_CMP_GE },
+    { "GT", SCMP_CMP_GT },
+    { "MASKED_EQ", SCMP_CMP_MASKED_EQ },
+  };
+  const char *p = name;
+  size_t i;
 
-  p = name;
-  if (strncmp (p, "SCMP_CMP_", 9))
+  if (! has_prefix (p, "SCMP_CMP_"))
     goto fail;
 
-  p += 9;
+  p += sizeof ("SCMP_CMP_") - 1;
 
-  if (strcmp (p, "NE") == 0)
-    {
-      *op = SCMP_CMP_NE;
-      return 0;
-    }
-  if (strcmp (p, "LT") == 0)
-    {
-      *op = SCMP_CMP_LT;
-      return 0;
-    }
-  if (strcmp (p, "LE") == 0)
-    {
-      *op = SCMP_CMP_LE;
-      return 0;
-    }
-  if (strcmp (p, "EQ") == 0)
-    {
-      *op = SCMP_CMP_EQ;
-      return 0;
-    }
-  if (strcmp (p, "GE") == 0)
-    {
-      *op = SCMP_CMP_GE;
-      return 0;
-    }
-  if (strcmp (p, "GT") == 0)
-    {
-      *op = SCMP_CMP_GT;
-      return 0;
-    }
-  if (strcmp (p, "MASKED_EQ") == 0)
-    {
-      *op = SCMP_CMP_MASKED_EQ;
-      return 0;
-    }
+  for (i = 0; i < sizeof (operators) / sizeof (operators[0]); i++)
+    if (strcmp (p, operators[i].name) == 0)
+      {
+        *op = operators[i].op;
+        return 0;
+      }
 
 fail:
   return crun_make_error (err, 0, "seccomp get operator `%s`", name);
@@ -162,39 +146,39 @@ fail:
 static int
 get_seccomp_action (const char *name, int errno_ret, uint32_t *action, libcrun_error_t *err)
 {
-  const char *p;
+  static const struct
+  {
+    const char *name;
+    uint32_t action;
+  } actions[] = {
+    { "ALLOW", SCMP_ACT_ALLOW },
+    { "KILL", SCMP_ACT_KILL },
+    { "TRAP", SCMP_ACT_TRAP },
+#  ifdef SCMP_ACT_LOG
+    { "LOG", SCMP_ACT_LOG },
+#  endif
+#  ifdef SCMP_ACT_KILL_PROCESS
+    { "KILL_PROCESS", SCMP_ACT_KILL_PROCESS },
+#  endif
+#  ifdef SCMP_ACT_KILL_THREAD
+    { "KILL_THREAD", SCMP_ACT_KILL_THREAD },
+#  endif
+#  ifdef SCMP_ACT_NOTIFY
+    { "NOTIFY", SCMP_ACT_NOTIFY },
+#  endif
+  };
+  const char *p = name;
+  size_t i;
 
-  p = name;
-  if (strncmp (p, "SCMP_ACT_", 9))
+  if (! has_prefix (p, "SCMP_ACT_"))
     goto fail;
 
-  p += 9;
+  p += sizeof ("SCMP_ACT_") - 1;
 
-  if (strcmp (p, "ALLOW") == 0)
-    {
-      *action = SCMP_ACT_ALLOW;
-      return 0;
-    }
+  /* These two embed errno_ret, so they cannot be looked up in the table.  */
   if (strcmp (p, "ERRNO") == 0)
     {
       *action = SCMP_ACT_ERRNO (errno_ret);
-      return 0;
-    }
-  if (strcmp (p, "KILL") == 0)
-    {
-      *action = SCMP_ACT_KILL;
-      return 0;
-    }
-#  ifdef SCMP_ACT_LOG
-  if (strcmp (p, "LOG") == 0)
-    {
-      *action = SCMP_ACT_LOG;
-      return 0;
-    }
-#  endif
-  if (strcmp (p, "TRAP") == 0)
-    {
-      *action = SCMP_ACT_TRAP;
       return 0;
     }
   if (strcmp (p, "TRACE") == 0)
@@ -202,32 +186,18 @@ get_seccomp_action (const char *name, int errno_ret, uint32_t *action, libcrun_e
       *action = SCMP_ACT_TRACE (errno_ret);
       return 0;
     }
-#  ifdef SCMP_ACT_KILL_PROCESS
-  if (strcmp (p, "KILL_PROCESS") == 0)
-    {
-      *action = SCMP_ACT_KILL_PROCESS;
-      return 0;
-    }
-#  endif
-#  ifdef SCMP_ACT_KILL_THREAD
-  if (strcmp (p, "KILL_THREAD") == 0)
-    {
-      *action = SCMP_ACT_KILL_THREAD;
-      return 0;
-    }
-#  endif
-#  ifdef SCMP_ACT_NOTIFY
-  if (strcmp (p, "NOTIFY") == 0)
-    {
-      *action = SCMP_ACT_NOTIFY;
-      return 0;
-    }
-#  endif
+
+  for (i = 0; i < sizeof (actions) / sizeof (actions[0]); i++)
+    if (strcmp (p, actions[i].name) == 0)
+      {
+        *action = actions[i].action;
+        return 0;
+      }
 
 fail:
   return crun_make_error (err, 0, "seccomp get action `%s`", name);
 }
-#endif
+#endif /* HAVE_SECCOMP */
 
 static void
 make_lowercase (char *str)

--- a/tests/test_seccomp.py
+++ b/tests/test_seccomp.py
@@ -464,6 +464,158 @@ def test_annotation_seccomp_fail_unknown_syscall():
         return -1
 
 
+# Environment-related failures that mean the test cannot run here rather than
+# that crun rejected the configuration.
+unsupported_env_errors = ["mount", "proc", "permission", "rootfs", "private", "busy"]
+
+
+def run_and_expect_error(conf, expected):
+    """Run a container expected to be rejected, and check the error message.
+
+    Returns 0 if crun failed and the error message contains every string in
+    EXPECTED, 77 if the failure looks unrelated to the configuration under
+    test, and -1 otherwise.
+    """
+    try:
+        run_and_get_output(conf)
+    except subprocess.CalledProcessError as e:
+        output = e.output.decode('utf-8', errors='ignore') if e.output else ''
+        if all(x in output for x in expected):
+            return 0
+        if any(x in output.lower() for x in unsupported_env_errors):
+            return (77, "not available in nested namespaces")
+        logger.info("unexpected error message: %s", output)
+        return -1
+    except Exception as e:
+        if any(x in str(e).lower() for x in unsupported_env_errors):
+            return (77, "not available in nested namespaces")
+        logger.info("Exception: %s", e)
+        return -1
+
+    logger.info("container creation succeeded unexpectedly")
+    return -1
+
+
+def test_seccomp_invalid_default_action():
+    """An unknown defaultAction must be rejected."""
+    conf = base_config()
+    add_all_namespaces(conf)
+
+    conf['linux']['seccomp'] = {
+        'defaultAction': 'SCMP_ACT_NOT_AN_ACTION',
+    }
+
+    conf['process']['args'] = ['/init', 'true']
+
+    return run_and_expect_error(conf, ["seccomp get action", "SCMP_ACT_NOT_AN_ACTION"])
+
+
+def test_seccomp_invalid_action():
+    """An unknown action on a syscall rule must be rejected."""
+    conf = base_config()
+    add_all_namespaces(conf)
+
+    conf['linux']['seccomp'] = {
+        'defaultAction': 'SCMP_ACT_ALLOW',
+        'syscalls': [
+            {
+                'names': ['ioctl'],
+                'action': 'SCMP_ACT_NOT_AN_ACTION',
+            }
+        ]
+    }
+
+    conf['process']['args'] = ['/init', 'true']
+
+    return run_and_expect_error(conf, ["seccomp get action", "SCMP_ACT_NOT_AN_ACTION"])
+
+
+def test_seccomp_action_missing_prefix():
+    """An action without the SCMP_ACT_ prefix must be rejected."""
+    conf = base_config()
+    add_all_namespaces(conf)
+
+    conf['linux']['seccomp'] = {
+        'defaultAction': 'ALLOW',
+    }
+
+    conf['process']['args'] = ['/init', 'true']
+
+    return run_and_expect_error(conf, ["seccomp get action", "ALLOW"])
+
+
+def test_seccomp_invalid_operator():
+    """An unknown argument comparison operator must be rejected."""
+    conf = base_config()
+    add_all_namespaces(conf)
+
+    # The action must differ from the default one, otherwise the rule is
+    # skipped before the operator is looked at.
+    conf['linux']['seccomp'] = {
+        'defaultAction': 'SCMP_ACT_ALLOW',
+        'syscalls': [
+            {
+                'names': ['ioctl'],
+                'action': 'SCMP_ACT_ERRNO',
+                'errnoRet': 1,
+                'args': [
+                    {
+                        'index': 1,
+                        'value': 0x5401,
+                        'op': 'SCMP_CMP_NOT_AN_OP'
+                    }
+                ]
+            }
+        ]
+    }
+
+    conf['process']['args'] = ['/init', 'true']
+
+    return run_and_expect_error(conf, ["seccomp get operator", "SCMP_CMP_NOT_AN_OP"])
+
+
+def test_seccomp_operator_missing_prefix():
+    """An operator without the SCMP_CMP_ prefix must be rejected."""
+    conf = base_config()
+    add_all_namespaces(conf)
+
+    conf['linux']['seccomp'] = {
+        'defaultAction': 'SCMP_ACT_ALLOW',
+        'syscalls': [
+            {
+                'names': ['ioctl'],
+                'action': 'SCMP_ACT_ERRNO',
+                'errnoRet': 1,
+                'args': [
+                    {
+                        'index': 1,
+                        'value': 0x5401,
+                        'op': 'EQ'
+                    }
+                ]
+            }
+        ]
+    }
+
+    conf['process']['args'] = ['/init', 'true']
+
+    return run_and_expect_error(conf, ["seccomp get operator", "EQ"])
+
+def test_seccomp_invalid_flag():
+    """An unknown seccomp filter flag must be rejected."""
+    conf = base_config()
+    add_all_namespaces(conf)
+
+    conf['linux']['seccomp'] = {
+        'defaultAction': 'SCMP_ACT_ALLOW',
+        'flags': ['SECCOMP_FILTER_FLAG_NOT_A_FLAG'],
+    }
+
+    conf['process']['args'] = ['/init', 'true']
+
+    return run_and_expect_error(conf, ["unknown seccomp option", "SECCOMP_FILTER_FLAG_NOT_A_FLAG"])
+
+
 all_tests = {
     "seccomp-listener": test_seccomp_listener,
     "seccomp-block-syscall": test_seccomp_block_syscall,
@@ -477,6 +629,12 @@ all_tests = {
     "seccomp-comparison-ops": test_seccomp_comparison_ops,
     "seccomp-flags": test_seccomp_flags,
     "annotation-seccomp-fail-unknown-syscall": test_annotation_seccomp_fail_unknown_syscall,
+    "seccomp-invalid-default-action": test_seccomp_invalid_default_action,
+    "seccomp-invalid-action": test_seccomp_invalid_action,
+    "seccomp-action-missing-prefix": test_seccomp_action_missing_prefix,
+    "seccomp-invalid-operator": test_seccomp_invalid_operator,
+    "seccomp-operator-missing-prefix": test_seccomp_operator_missing_prefix,
+    "seccomp-invalid-flag": test_seccomp_invalid_flag,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #2023.

Adds the missing test coverage for the seccomp error paths, then replaces the if/strcmp chains in `get_seccomp_action()` and `get_seccomp_operator()` with static tables. No functional change.

cc @eriksjolund