### PR TITLE
cgroup: fix NULL device access and restore the no-cgroup invariant

### DIFF
--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -586,8 +586,10 @@ write_devices_resources_v1 (int dirfd, runtime_spec_schema_defs_linux_device_cgr
           FMT_DEV (devs[i]->minor, fmt_buf_minor);
 #undef FMT_DEV
 
+          /* `access` is optional, and libocispec leaves it NULL when it is not
+             specified.  Printing a NULL pointer with %s is undefined.  */
           len = snprintf (fmt_buf, FMT_BUF_LEN, "%s %s:%s %s", devs[i]->type, fmt_buf_major, fmt_buf_minor,
-                          devs[i]->access);
+                          devs[i]->access ? devs[i]->access : "");
           if (UNLIKELY (len >= FMT_BUF_LEN))
             return crun_make_error (err, 0, "internal error: static buffer too small");
         }

--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -106,6 +106,9 @@ is_rwm (const char *str, libcrun_error_t *err)
   bool w = false;
   bool m = false;
 
+  if (str == NULL)
+    str = "";
+
   for (it = str; *it; it++)
     switch (*it)
       {

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -167,6 +167,11 @@ setup_rt_runtime (runtime_spec_schema_config_linux_resources *resources,
   if (resources == NULL || resources->cpu == NULL)
     return 0;
 
+  /* Without a cgroup path append_paths() below would end up at the cgroup
+     root, so refuse rather than change the root cgroup settings.  */
+  if (is_empty_string (path))
+    return crun_make_error (err, 0, "cannot set the RT runtime without a cgroup");
+
   if (has_suffix (path, ".scope"))
     need_set_parent = false;
 
@@ -2117,6 +2122,9 @@ get_cgroup_scope_path (const char *cgroup_path, const char *scope)
 {
   char *path_to_scope = NULL;
   char *cur;
+
+  if (is_empty_string (cgroup_path))
+    return NULL;
 
   path_to_scope = xstrdup (cgroup_path);
 

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -545,6 +545,12 @@ destroy_cgroup_path (const char *path, int mode, libcrun_error_t *err)
   const int max_attempts = 500;
   int ret;
 
+  /* Without a path there is nothing to destroy.  Bail out early, since
+     append_paths() stops at the first NULL argument and would otherwise
+     be left pointing at the cgroup root.  */
+  if (is_empty_string (path))
+    return 0;
+
   do
     {
       repeat = false;

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -558,10 +558,10 @@ libcrun_cgroup_make_status (libcrun_container_status_t *status)
 
   ret = xmalloc0 (sizeof *ret);
 
-  if (status->cgroup_path)
+  if (! is_empty_string (status->cgroup_path))
     ret->path = xstrdup (status->cgroup_path);
 
-  if (status->scope)
+  if (! is_empty_string (status->scope))
     ret->scope = xstrdup (status->scope);
 
   if (is_empty_string (status->cgroup_path) && is_empty_string (status->scope))

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -117,7 +117,7 @@ libcrun_cgroup_is_container_paused (struct libcrun_cgroup_status *status, bool *
   int cgroup_mode;
   int ret;
 
-  if (cgroup_path == NULL || cgroup_path[0] == '\0')
+  if (cgroup_path == NULL)
     return 0;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -18,6 +18,7 @@
 import json
 import os
 import subprocess
+import tempfile
 import time
 from tests_utils import *
 
@@ -555,6 +556,67 @@ def test_update_unified_resources():
             run_crun_command(["delete", "-f", cid])
 
 
+def run_crun_expect_failure(args):
+    """Run a crun command that must fail, returning (returncode, output).
+
+    Unlike run_crun_command() the output includes stderr, and a command
+    killed by a signal is reported instead of raising.
+    """
+    cmd = [get_crun_path(), "--root", get_tests_root_status()] + args
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                          close_fds=False)
+    return proc.returncode, proc.stdout.decode('utf-8', errors='ignore')
+
+
+def check_update_without_cgroup(resources_args):
+    """Update a container running without cgroups and expect a clean refusal."""
+    conf = base_config()
+    add_all_namespaces(conf)
+    conf['process']['args'] = ['/init', 'pause']
+
+    cid = None
+    try:
+        _, cid = run_and_get_output(conf, command='run', detach=True,
+                                    cgroup_manager='disabled', hide_stderr=True)
+
+        code, out = run_crun_expect_failure(['--cgroup-manager=disabled', 'update']
+                                            + resources_args + [cid])
+        if code < 0:
+            logger.info("crun update was killed by signal %d", -code)
+            return -1
+        if code == 0:
+            logger.info("crun update unexpectedly succeeded")
+            return -1
+        if "cannot set limits without cgroups" not in out:
+            logger.info("unexpected error message: %s", out)
+            return -1
+        return 0
+    except Exception as e:
+        logger.info("Exception: %s", e)
+        return -1
+    finally:
+        if cid is not None:
+            run_crun_command(["delete", "-f", cid])
+
+
+def test_update_without_cgroup_memory():
+    """Updating a limit without cgroups must fail with a clear message."""
+    return check_update_without_cgroup(['--memory', '104857600'])
+
+
+def test_update_without_cgroup_device_no_access():
+    """A device rule without `access` must not crash the no-cgroup path."""
+    resources = {'devices': [{'allow': True, 'type': 'c', 'major': 1, 'minor': 3}]}
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(resources, f)
+        resources_file = f.name
+
+    try:
+        return check_update_without_cgroup(['-r', resources_file])
+    finally:
+        os.unlink(resources_file)
+
 all_tests = {
     "update-memory-limit": test_update_memory_limit,
     "update-cpu-shares": test_update_cpu_shares,
@@ -569,6 +631,8 @@ all_tests = {
     "update-cpuset-mems": test_update_cpuset_mems,
     "update-multiple-resources": test_update_multiple_resources,
     "update-unified-resources": test_update_unified_resources,
+    "update-without-cgroup-memory": test_update_without_cgroup_memory,
+    "update-without-cgroup-device-no-access": test_update_without_cgroup_device_no_access,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
Alternative to #2203, which is included here as the first commit (authorship preserved).

#2203 by itself fixes a crash in a branch that cannot currently be reached: `libcrun_cgroup_make_status()` stores an empty string where the rest of the tree expects NULL for "no cgroup", so `update_cgroup_resources()`'s `path == NULL` guard never fires.

The same defect makes `crun update` on a container started with `--cgroup-manager=disabled` report:

    open `memory.max` for writing: No such file or directory

instead of

    cannot set limits without cgroups

The series fixes the latent NULL dereferences first and flips the invariant last, so no single commit leaves a reachable crash:

1. `is_rwm()` NULL access (#2203, by @SAY-5)
2. the sibling `snprintf("%s", NULL)` in the cgroup v1 device writer, also reported in #2195
3. empty-path guards in `destroy_cgroup_path()`, `get_cgroup_scope_path()` and `setup_rt_runtime()`
4. `libcrun_cgroup_make_status()` -- the root cause
5. two tests, which fail on current main (one of them with SIGSEGV) and need neither cgroups nor root

Closes #2195

cc @eriksjolund