### PR TITLE
add cppcheck to CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,6 +81,7 @@ jobs:
           #- test: centos10-build
           - test: clang-format
           - test: clang-check
+          - test: cppcheck
           - test: bindings
           - test: checkpoint-restore
           - test: fuzzing
@@ -183,6 +184,10 @@ jobs:
               clang-check)
                   sudo docker build -t crun-clang-check tests/clang-check
                   sudo docker run --privileged --rm -w /crun -v ${PWD}:/crun crun-clang-check
+              ;;
+              cppcheck)
+                  sudo docker build -t crun-cppcheck tests/cppcheck
+                  sudo docker run --rm -w /crun -v ${PWD}:/crun crun-cppcheck
               ;;
               enable-shared)
                   ./configure --enable-embedded-blake3 --enable-shared

--- a/Makefile.am
+++ b/Makefile.am
@@ -437,6 +437,21 @@ shellcheck:
 shfmt:
 	$(LIST_SH_FILES) | xargs shfmt -w
 
+# Static analysis with cppcheck.  Files copied into the source tree are not
+# analyzed.  varFuncNullUB is suppressed since a bare NULL is used as the
+# sentinel of the variadic helpers, and __has_attribute() is defined since
+# cppcheck cannot evaluate it.
+CPPCHECK_FLAGS = \
+	--quiet --force --inline-suppr --error-exitcode=1 \
+	--enable=warning,performance,portability \
+	--suppress=varFuncNullUB \
+	-D__has_attribute\(x\)=0 \
+	-i $(srcdir)/src/libcrun/blake3 \
+	-I $(builddir) -I $(srcdir)/src -I $(srcdir)/libocispec/src -I $(srcdir)/libocispec
+
+cppcheck:
+	cppcheck $(CPPCHECK_FLAGS) $(srcdir)/src $(srcdir)/tests/*.c $(srcdir)/contrib/*.c
+
 # Code coverage targets
 if ENABLE_COVERAGE
 
@@ -547,4 +562,4 @@ clean-local: coverage-clean
 # Coverage targets must not run in parallel due to race conditions in .gcda file writes
 .NOTPARALLEL: coverage-reset coverage-check coverage-html coverage-xml coverage-summary coverage-multi-env
 
-.PHONY: check-no-openat2 coverity sync generate-rust-bindings generate-signals.c generate-mount_flags.c clang-format shellcheck shfmt coverage-clean coverage-reset coverage-check coverage-html coverage-xml coverage-summary coverage-multi-env
+.PHONY: check-no-openat2 coverity sync generate-rust-bindings generate-signals.c generate-mount_flags.c clang-format shellcheck shfmt cppcheck coverage-clean coverage-reset coverage-check coverage-html coverage-xml coverage-summary coverage-multi-env

--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -482,7 +482,7 @@ write_network_resources (int dirfd_netclass, int dirfd_netprio, runtime_spec_sch
   int ret;
   if (net->class_id)
     {
-      len = snprintf (fmt_buf, sizeof (fmt_buf), "%d", net->class_id);
+      len = snprintf (fmt_buf, sizeof (fmt_buf), "%" PRIu32, net->class_id);
       if (UNLIKELY (len >= (int) sizeof (fmt_buf)))
         return crun_make_error (err, 0, "internal error: static buffer too small");
 
@@ -500,7 +500,8 @@ write_network_resources (int dirfd_netclass, int dirfd_netprio, runtime_spec_sch
 
       for (i = 0; i < net->priorities_len; i++)
         {
-          len = snprintf (fmt_buf, sizeof (fmt_buf), "%s %d\n", net->priorities[i]->name, net->priorities[i]->priority);
+          len = snprintf (fmt_buf, sizeof (fmt_buf), "%s %" PRIu32 "\n", net->priorities[i]->name,
+                          net->priorities[i]->priority);
           if (UNLIKELY (len >= (int) sizeof (fmt_buf)))
             return crun_make_error (err, 0, "internal error: static buffer too small");
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5455,8 +5455,8 @@ precreate_device (libcrun_container_t *container, int devs_dirfd, size_t i, libc
 {
   runtime_spec_schema_config_schema *def = container->container_def;
   runtime_spec_schema_defs_linux_device *device;
-  uid_t uid = get_overflow_uid ();
-  gid_t gid = get_overflow_gid ();
+  uid_t uid;
+  gid_t gid;
   char name[64];
   mode_t type;
   dev_t dev;
@@ -5475,11 +5475,8 @@ precreate_device (libcrun_container_t *container, int devs_dirfd, size_t i, libc
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "mknod `%s`", device->path);
 
-  if (def->linux)
-    {
-      uid = get_id_in_user_namespace (device->uid, true, def);
-      gid = get_id_in_user_namespace (device->gid, false, def);
-    }
+  uid = get_id_in_user_namespace (device->uid, true, def);
+  gid = get_id_in_user_namespace (device->gid, false, def);
 
   ret = fchownat (devs_dirfd, name, uid, gid, 0); /* lgtm [cpp/toctou-race-condition] */
   if (UNLIKELY (ret < 0))

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -4911,19 +4911,19 @@ read_error_from_sync_socket (int sync_socket_fd, int *error, char **str)
 {
   cleanup_free char *b = NULL;
   size_t size;
-  int code;
+  int code = 0;
   int ret;
 
   if (*error == 0)
     {
       ret = TEMP_FAILURE_RETRY (read (sync_socket_fd, &code, sizeof (code)));
-      if (UNLIKELY (ret < 0))
+      if (UNLIKELY (ret != (int) sizeof (code)))
         return false;
       *error = code;
     }
 
   ret = TEMP_FAILURE_RETRY (read (sync_socket_fd, &size, sizeof (size)));
-  if (UNLIKELY (ret < 0))
+  if (UNLIKELY (ret != (int) sizeof (size)))
     return false;
 
   if (size == 0)

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -21,6 +21,7 @@
 #include "utils.h"
 #include "ring_buffer.h"
 #include <stdarg.h>
+#include <inttypes.h>
 #include <unistd.h>
 #include <string.h>
 #include <libgen.h>
@@ -1679,7 +1680,7 @@ format_default_id_mapping (char **out, uid_t container_id, uid_t host_uid, uid_t
   if (container_id > 0)
     {
       uint32_t used = MIN (container_id, available);
-      ret = snprintf (buffer + written, remaining, "%d %d %d\n", 0, from, used);
+      ret = snprintf (buffer + written, remaining, "%d %" PRIu32 " %" PRIu32 "\n", 0, from, used);
       if (UNLIKELY (ret >= remaining))
         return crun_make_error (err, 0, "internal error: allocated buffer too small");
 
@@ -1700,7 +1701,7 @@ format_default_id_mapping (char **out, uid_t container_id, uid_t host_uid, uid_t
   /* Last mapping: use any id that is left.  */
   if (available)
     {
-      ret = snprintf (buffer + written, remaining, "%d %d %d\n", container_id + 1, from, available);
+      ret = snprintf (buffer + written, remaining, "%d %" PRIu32 " %" PRIu32 "\n", container_id + 1, from, available);
       if (UNLIKELY (ret >= remaining))
         return crun_make_error (err, 0, "internal error: allocated buffer too small");
       written += ret;

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -2445,7 +2445,7 @@ safe_write (int fd, const char *fname, const void *buf, size_t count, libcrun_er
   size_t written = 0;
   while (written < count)
     {
-      ssize_t w = write (fd, buf + written, count - written);
+      ssize_t w = write (fd, (const char *) buf + written, count - written);
       if (UNLIKELY (w < 0))
         {
           if (errno == EINTR || errno == EAGAIN)

--- a/tests/cppcheck/Dockerfile
+++ b/tests/cppcheck/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/fedora/fedora:latest
+
+RUN dnf install -y awk cppcheck git make json-c-devel 'dnf-command(builddep)' && dnf builddep -y crun
+
+COPY run-tests.sh /usr/local/bin
+
+ENTRYPOINT /usr/local/bin/run-tests.sh

--- a/tests/cppcheck/run-tests.sh
+++ b/tests/cppcheck/run-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -x
+
+cd /crun
+
+git config --global --add safe.directory /crun
+git clean -fdx
+./autogen.sh
+./configure --enable-embedded-blake3
+
+# The generated headers are needed to analyze the sources.
+make -C libocispec -j "$(nproc)"
+
+cppcheck --version
+make cppcheck


### PR DESCRIPTION
Add the [cppcheck](https://cppcheck.sourceforge.io/) static analyzer to CI,
and fix what it found.

The last commit adds a `cppcheck` make target (so it can be run locally, too)
and a CI job running it in a container, modelled after the existing
`clang-check` test.  Files copied into the source tree (blake3) are excluded.

Two knobs are needed to keep the output free of noise:

 * `varFuncNullUB` is suppressed, as a bare `NULL` is used as the sentinel of
   the variadic helpers such as `append_paths`;
 * `__has_attribute()` is defined on the command line, since the cppcheck
   preprocessor can not evaluate it, and the resulting syntax error makes it
   stop analyzing the rest of the file.

The preceding commits fix the issues found:

 * a short read or EOF in `read_error_from_sync_socket` resulted in using
   uninitialized data;
 * a redundant `def->linux` NULL check in `precreate_device`;
 * `%d` used to print `uint32_t` values;
 * pointer arithmetic on `void *` in `safe_write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)