### PR TITLE
build: move the warning flags to configure, add --enable-werror

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
           run: |
             find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;
             ./autogen.sh
-            ./configure --enable-embedded-blake3 CFLAGS='-Wall -Werror' || { cat config.log; exit 1; }
+            ./configure --enable-embedded-blake3 --enable-werror || { cat config.log; exit 1; }
             make -j $(nproc) -C libocispec libocispec.la
             make git-version.h
             make -j $(nproc) libcrun.la
@@ -53,7 +53,7 @@ jobs:
 
             make -j $(nproc) clean
 
-            if ./configure --enable-embedded-blake3 --enable-shared CFLAGS='-Wall -Werror'; then
+            if ./configure --enable-embedded-blake3 --enable-shared --enable-werror; then
                         make -j $(nproc) -C libocispec libocispec.la
                         make git-version.h
                         make -j $(nproc) libcrun.la
@@ -194,7 +194,7 @@ jobs:
                   # symbols, so a build here catches API drift and missing
                   # exports (e.g. libcrun_container_spec, parse_json_file)
                   # before it reaches a release.
-                  ./configure --enable-embedded-blake3 --enable-shared --with-python-bindings --with-lua-bindings CFLAGS='-Wall -Werror'
+                  ./configure --enable-embedded-blake3 --enable-shared --with-python-bindings --with-lua-bindings --enable-werror
                   make -j $(nproc)
                   export LD_LIBRARY_PATH="$PWD/.libs:$LD_LIBRARY_PATH"
                   PYTHONPATH="$PWD/.libs" python3 python/test_python_bindings.py

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,10 @@ DIST_SUBDIRS = libocispec
 SUBDIRS = libocispec
 ACLOCAL_AMFLAGS = -I m4
 
+# The warning flags detected by configure.  automake puts AM_CFLAGS before
+# CFLAGS, so the user can still override any of them.
+AM_CFLAGS = $(WARN_CFLAGS)
+
 WD := $(shell pwd)
 # outdir is needed by the make_srpm build type on Fedora copr
 # https://docs.pagure.org/copr.copr/user_documentation.html#make-srpm
@@ -84,7 +88,7 @@ libcrun_SOURCES += src/libcrun/blake3/blake3.c \
 endif
 
 libcrun_la_SOURCES = $(libcrun_SOURCES)
-libcrun_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -fvisibility=hidden
+libcrun_la_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -fvisibility=hidden
 if ENABLE_COVERAGE
 libcrun_la_CFLAGS += $(COVERAGE_CFLAGS)
 libcrun_la_LDFLAGS = -Wl,--version-script=$(abs_top_srcdir)/libcrun.lds $(COVERAGE_LDFLAGS)
@@ -96,7 +100,7 @@ libcrun_la_LIBADD = libocispec/libocispec.la $(FOUND_LIBS) $(JSON_C_LIBS)
 # build a version with all the symbols visible for testing
 if BUILD_TESTS
 libcrun_testing_la_SOURCES = $(libcrun_SOURCES)
-libcrun_testing_la_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -fvisibility=default
+libcrun_testing_la_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -fvisibility=default
 if ENABLE_COVERAGE
 libcrun_testing_la_CFLAGS += $(COVERAGE_CFLAGS)
 libcrun_testing_la_LDFLAGS = $(COVERAGE_LDFLAGS)
@@ -107,7 +111,7 @@ endif
 if PYTHON_BINDINGS
 pyexec_LTLIBRARIES = python_crun.la
 python_crun_la_SOURCES = python/crun_python.c
-python_crun_la_CFLAGS = -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src $(PYTHON_CFLAGS)
+python_crun_la_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src $(PYTHON_CFLAGS)
 python_crun_la_LDFLAGS = -avoid-version -module $(PYTHON_LDFLAGS)
 python_crun_la_LIBADD = libcrun.la $(PYTHON_LIBS) $(FOUND_LIBS) $(JSON_C_LIBS)
 endif
@@ -115,7 +119,7 @@ endif
 if LUA_BINDINGS
 luaexec_LTLIBRARIES = luacrun.la
 luacrun_la_SOURCES = lua/lua_crun.c
-luacrun_la_CFLAGS = -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src $(LUA_INCLUDE)
+luacrun_la_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_srcdir)/libocispec/src -I $(abs_top_builddir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src $(LUA_INCLUDE)
 luacrun_la_LDFLAGS = -avoid-version -module
 luacrun_la_LIBADD = libcrun.la $(LUA_LIB) $(FOUND_LIBS)
 
@@ -144,7 +148,7 @@ dist-luarock: $(LUACRUN_ROCK)
 
 endif
 
-crun_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -D CRUN_LIBDIR="\"$(CRUN_LIBDIR)\""
+crun_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -D CRUN_LIBDIR="\"$(CRUN_LIBDIR)\""
 if ENABLE_COVERAGE
 crun_CFLAGS += $(COVERAGE_CFLAGS)
 endif
@@ -213,74 +217,74 @@ TESTS_LDADD = libcrun_testing.la $(FOUND_LIBS) $(JSON_C_LIBS)
 
 tests_init_LDADD =
 tests_init_LDFLAGS = -static-libgcc -all-static
-tests_init_CFLAGS = -g -O2
+tests_init_CFLAGS = $(WARN_CFLAGS) -g -O2
 tests_init_SOURCES = tests/init.c
 
 tests_no_openat2_LDADD =
-tests_no_openat2_CFLAGS = -g -O2
+tests_no_openat2_CFLAGS = $(WARN_CFLAGS) -g -O2
 tests_no_openat2_SOURCES = tests/no_openat2.c
 
-tests_tests_libcrun_utils_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_utils_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_utils_SOURCES = tests/tests_libcrun_utils.c
 tests_tests_libcrun_utils_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_utils_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_ring_buffer_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_ring_buffer_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_ring_buffer_SOURCES = tests/tests_libcrun_ring_buffer.c
 tests_tests_libcrun_ring_buffer_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_ring_buffer_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_intelrdt_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_intelrdt_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_intelrdt_SOURCES = tests/tests_libcrun_intelrdt.c
 tests_tests_libcrun_intelrdt_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_intelrdt_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_fuzzer_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_fuzzer_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_fuzzer_SOURCES = tests/tests_libcrun_fuzzer.c
 tests_tests_libcrun_fuzzer_LDADD = $(TESTS_LDADD) libocispec/libocispec.la $(JSON_C_LIBS)
 tests_tests_libcrun_fuzzer_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_errors_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_errors_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_errors_SOURCES = tests/tests_libcrun_errors.c
 tests_tests_libcrun_errors_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_errors_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_terminal_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_terminal_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_terminal_SOURCES = tests/tests_libcrun_terminal.c
 tests_tests_libcrun_terminal_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_terminal_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_custom_handler_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_custom_handler_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_custom_handler_SOURCES = tests/tests_libcrun_custom_handler.c
 tests_tests_libcrun_custom_handler_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_custom_handler_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_linux_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_linux_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_linux_SOURCES = tests/tests_libcrun_linux.c
 tests_tests_libcrun_linux_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_linux_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_signals_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_signals_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_signals_SOURCES = tests/tests_libcrun_signals.c
 tests_tests_libcrun_signals_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_signals_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_mount_flags_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_mount_flags_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_mount_flags_SOURCES = tests/tests_libcrun_mount_flags.c
 tests_tests_libcrun_mount_flags_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_mount_flags_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_chroot_realpath_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_chroot_realpath_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_chroot_realpath_SOURCES = tests/tests_libcrun_chroot_realpath.c
 tests_tests_libcrun_chroot_realpath_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_chroot_realpath_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_seccomp_notify_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_seccomp_notify_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_seccomp_notify_SOURCES = tests/tests_libcrun_seccomp_notify.c
 tests_tests_libcrun_seccomp_notify_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_seccomp_notify_LDFLAGS = $(crun_LDFLAGS)
 
-tests_tests_libcrun_cgroup_CFLAGS = -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
+tests_tests_libcrun_cgroup_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -I $(abs_top_builddir)/src -I $(abs_top_srcdir)/src
 tests_tests_libcrun_cgroup_SOURCES = tests/tests_libcrun_cgroup.c
 tests_tests_libcrun_cgroup_LDADD = $(TESTS_LDADD)
 tests_tests_libcrun_cgroup_LDFLAGS = $(crun_LDFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,36 @@ AC_PROG_SED
 AC_PROG_CC
 AM_PATH_PYTHON(3)
 
+dnl Compiler warnings.  They are not added to CFLAGS, which belongs to the
+dnl user, but to WARN_CFLAGS, that automake puts before CFLAGS so that the
+dnl user can still override any of them.
+AC_ARG_ENABLE([werror],
+	AS_HELP_STRING([--enable-werror], [treat compiler warnings as errors]))
+
+WARN_CFLAGS=
+crun_save_CFLAGS="$CFLAGS"
+for crun_flag in \
+	-Wall \
+	-Wextra \
+	-Wvla \
+	-Walloca \
+	-Wduplicated-cond \
+	-Wduplicated-branches \
+	-Winit-self \
+	-Wshift-overflow=2 ; do
+	AC_MSG_CHECKING([whether $CC accepts $crun_flag])
+	dnl -Werror is needed as clang only warns about the flags it does not know.
+	CFLAGS="$crun_save_CFLAGS $crun_flag -Werror"
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
+			  [AC_MSG_RESULT([yes])
+			   WARN_CFLAGS="$WARN_CFLAGS $crun_flag"],
+			  [AC_MSG_RESULT([no])])
+done
+CFLAGS="$crun_save_CFLAGS"
+
+AS_IF([test "x$enable_werror" = "xyes"], [WARN_CFLAGS="$WARN_CFLAGS -Werror"])
+AC_SUBST([WARN_CFLAGS])
+
 AC_PATH_PROG(MD2MAN, go-md2man)
 
 AM_CONDITIONAL([HAVE_MD2MAN], [test "x$ac_cv_path_MD2MAN" != x])

--- a/python/crun_python.c
+++ b/python/crun_python.c
@@ -447,7 +447,7 @@ container_spec (PyObject *self arg_unused, PyObject *args arg_unused)
 }
 
 static PyObject *
-get_verbosity (PyObject *self arg_unused, PyObject *args)
+get_verbosity (PyObject *self arg_unused, PyObject *args arg_unused)
 {
   return PyLong_FromLong (libcrun_get_verbosity());
 }
@@ -481,7 +481,7 @@ static PyMethodDef CrunMethods[] = {
    "Update the constraints of a container."},
   {"spec", container_spec, METH_VARARGS,
    "Generate a new configuration file."},
-  {"make_context", (PyCFunction) make_context, METH_VARARGS | METH_KEYWORDS,
+  {"make_context", (PyCFunction) (void (*) (void)) make_context, METH_VARARGS | METH_KEYWORDS,
    "Create a context object."},
   {"set_verbosity", set_verbosity, METH_VARARGS, "Set the logging verbosity."},
   {"get_verbosity", get_verbosity, METH_NOARGS, "Get the logging verbosity."},
@@ -495,6 +495,10 @@ struct PyModuleDef crun_mod =
    NULL,
    0,
    CrunMethods,
+   NULL,
+   NULL,
+   NULL,
+   NULL,
   };
 
 PyMODINIT_FUNC

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -1381,7 +1381,7 @@ has_bpf_fs ()
 {
   struct statfs stat;
 
-  return statfs (SYS_FS_BPF, &stat) == 0 && (stat.f_type == BPF_FS_MAGIC);
+  return statfs (SYS_FS_BPF, &stat) == 0 && (stat.f_type == (typeof (stat.f_type)) BPF_FS_MAGIC);
 }
 
 static int

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -1813,6 +1813,8 @@ write_pid_file (const char *pid_file, pid_t pid, libcrun_error_t *err)
   return write_file_at_with_flags (AT_FDCWD, O_CREAT | O_TRUNC, 0700, pid_file, buf, buf_len, err);
 }
 
+#define MAX_EVENTS 10
+
 static int
 wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
 {
@@ -1821,13 +1823,12 @@ wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
   int ret, container_exit_code = 0, last_process;
   cleanup_close int terminal_fd_from = -1;
   cleanup_close int terminal_fd_to = -1;
-  const size_t max_events = 10;
   cleanup_close int epollfd = -1;
   cleanup_close int signalfd = -1;
   sigset_t mask;
-  int in_fds[max_events];
+  int in_fds[MAX_EVENTS];
   int in_fds_len = 0;
-  int out_fds[max_events];
+  int out_fds[MAX_EVENTS];
   int out_fds_len = 0;
   size_t i;
 
@@ -1838,7 +1839,7 @@ wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
   if (args == NULL || args->context == NULL)
     return crun_make_error (err, 0, "internal error: context is empty");
 
-  for (i = 0; i < max_events; i++)
+  for (i = 0; i < MAX_EVENTS; i++)
     {
       in_fds[i] = -1;
       out_fds[i] = -1;
@@ -1953,13 +1954,13 @@ wait_for_process (struct wait_for_process_args *args, libcrun_error_t *err)
 
   while (1)
     {
-      struct epoll_event events[max_events];
+      struct epoll_event events[MAX_EVENTS];
       struct signalfd_siginfo si;
       struct winsize ws;
       int i, nr_events;
       ssize_t res;
 
-      nr_events = TEMP_FAILURE_RETRY (epoll_wait (epollfd, events, max_events, -1));
+      nr_events = TEMP_FAILURE_RETRY (epoll_wait (epollfd, events, MAX_EVENTS, -1));
       if (UNLIKELY (nr_events < 0))
         return crun_make_error (err, errno, "epoll_wait");
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -449,7 +449,8 @@ parse_idmapped_mount_option (runtime_spec_schema_config_schema *def, bool is_uid
           mappings = is_uids ? def->linux->uid_mappings : def->linux->gid_mappings;
 
           for (i = 0; i < mappings_len; i++)
-            if (value[1] >= mappings[i]->container_id && value[1] < mappings[i]->container_id + mappings[i]->size)
+            if (value[1] >= (int64_t) mappings[i]->container_id
+                && value[1] < (int64_t) mappings[i]->container_id + (int64_t) mappings[i]->size)
               break;
 
           if (i == mappings_len)
@@ -7281,25 +7282,15 @@ libcrun_safe_chdir (const char *path, libcrun_error_t *err)
   return 0;
 }
 
+/* Run the callback in the namespace referred to by PIDFD.  It is done in a
+   separate function so that no variable of the caller is live across the
+   vfork.  */
 static int
-run_in_container_namespace (libcrun_container_status_t *status, int (*callback) (void *, libcrun_error_t *), void *arg, libcrun_error_t *err)
+run_callback_in_namespace (int pidfd, int (*callback) (void *, libcrun_error_t *), void *arg, libcrun_error_t *err)
 {
-  cleanup_close int pidfd = -1;
-  pid_t pid = status->pid;
   int wait_status = 0;
+  pid_t pid;
   int ret;
-
-  pidfd = syscall_pidfd_open (pid, 0);
-  if (UNLIKELY (pidfd < 0))
-    return crun_make_error (err, errno, "pidfd_open");
-
-  /* Check if the container is still running after opening the pidfd.  */
-  ret = libcrun_is_container_running (status, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
-
-  if (ret == 0)
-    return crun_make_error (err, 0, "container not running");
 
   /* must be vfork to propagate the error from the child proc.  */
   pid = vfork ();
@@ -7337,6 +7328,28 @@ run_in_container_namespace (libcrun_container_status_t *status, int (*callback) 
      object populated by the child is available to the parent.
      Do not call crun_make_error() here. */
   return get_process_exit_status (wait_status);
+}
+
+static int
+run_in_container_namespace (libcrun_container_status_t *status, int (*callback) (void *, libcrun_error_t *), void *arg, libcrun_error_t *err)
+{
+  cleanup_close int pidfd = -1;
+  pid_t pid = status->pid;
+  int ret;
+
+  pidfd = syscall_pidfd_open (pid, 0);
+  if (UNLIKELY (pidfd < 0))
+    return crun_make_error (err, errno, "pidfd_open");
+
+  /* Check if the container is still running after opening the pidfd.  */
+  ret = libcrun_is_container_running (status, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  if (ret == 0)
+    return crun_make_error (err, 0, "container not running");
+
+  return run_callback_in_namespace (pidfd, callback, arg, err);
 }
 
 struct umount_in_a_container_args

--- a/src/libcrun/net_device.c
+++ b/src/libcrun/net_device.c
@@ -431,34 +431,15 @@ do_move_link_to_ns_and_wait (int sock, char *buffer, size_t buffer_size, int ifi
   return wait_for_ack (sock, seq, buffer, buffer_size, err);
 }
 
-int
-move_network_device (const char *ifname, const char *newifname, int netns_fd, libcrun_error_t *err)
+/* Run the setup in the target namespace.  It is done in a separate function
+   so that no variable of the caller is live across the vfork.  */
+static int
+setup_network_device_in_ns (char *buffer, size_t buffer_size, int netns_fd, const char *newifname,
+                            struct ip_addr *ips, libcrun_error_t *err)
 {
-  const size_t buffer_size = 8192;
-  cleanup_ip_addrs struct ip_addr *ips = NULL;
-  cleanup_free char *buffer = xmalloc (buffer_size);
-  cleanup_close int sock = -1;
   int wait_status;
-  int ifindex;
   pid_t pid;
   int ret;
-
-  sock = open_netlink_fd (err);
-  if (sock < 0)
-    return sock;
-
-  ifindex = name_to_index (sock, ifname, buffer, buffer_size, err);
-  if (UNLIKELY (ifindex < 0))
-    return ifindex;
-
-  ret = get_ip_addresses (sock, ifindex, &ips, buffer, buffer_size, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
-
-  /* Move the device to the target network namespace.  */
-  ret = do_move_link_to_ns_and_wait (sock, buffer, buffer_size, ifindex, netns_fd, newifname, err);
-  if (UNLIKELY (ret < 0))
-    return ret;
 
   /* must be vfork to propagate the error from the child proc.  */
   pid = vfork ();
@@ -489,4 +470,34 @@ move_network_device (const char *ifname, const char *newifname, int netns_fd, li
     }
 
   return 0;
+}
+
+int
+move_network_device (const char *ifname, const char *newifname, int netns_fd, libcrun_error_t *err)
+{
+  const size_t buffer_size = 8192;
+  cleanup_ip_addrs struct ip_addr *ips = NULL;
+  cleanup_free char *buffer = xmalloc (buffer_size);
+  cleanup_close int sock = -1;
+  int ifindex;
+  int ret;
+
+  sock = open_netlink_fd (err);
+  if (sock < 0)
+    return sock;
+
+  ifindex = name_to_index (sock, ifname, buffer, buffer_size, err);
+  if (UNLIKELY (ifindex < 0))
+    return ifindex;
+
+  ret = get_ip_addresses (sock, ifindex, &ips, buffer, buffer_size, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  /* Move the device to the target network namespace.  */
+  ret = do_move_link_to_ns_and_wait (sock, buffer, buffer_size, ifindex, netns_fd, newifname, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  return setup_network_device_in_ns (buffer, buffer_size, netns_fd, newifname, ips, err);
 }

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -2456,10 +2456,11 @@ safe_write (int fd, const char *fname, const void *buf, size_t count, libcrun_er
   return 0;
 }
 
+#define MAX_PARTS 32
+
 int
 append_paths (char **out, libcrun_error_t *err, ...)
 {
-  const size_t MAX_PARTS = 32;
   const char *parts[MAX_PARTS];
   size_t sizes[MAX_PARTS];
   size_t total_len = 0;

--- a/tests/alpine-build/run-tests.sh
+++ b/tests/alpine-build/run-tests.sh
@@ -3,5 +3,5 @@
 set -e
 cd /crun
 ./autogen.sh
-./configure --enable-embedded-blake3 CFLAGS='-Wall -Wextra -Werror' --disable-systemd
+./configure --enable-embedded-blake3 --enable-werror --disable-systemd
 make -j "$(nproc)"

--- a/tests/centos10-build/run-tests.sh
+++ b/tests/centos10-build/run-tests.sh
@@ -7,14 +7,14 @@ git config --global --add safe.directory /crun
 
 git clean -fdx
 ./autogen.sh
-./configure --enable-embedded-blake3 CFLAGS='-Wall -Wextra -Werror'
+./configure --enable-embedded-blake3 --enable-werror
 make -j "$(nproc)"
 
 make -j "$(nproc)" distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-embedded-blake3"
 
 git clean -fdx
 ./autogen.sh
-./configure --enable-embedded-blake3 CFLAGS='-Wall -Wextra -Werror' --disable-systemd
+./configure --enable-embedded-blake3 --enable-werror --disable-systemd
 make -j "$(nproc)"
 
 make -j "$(nproc)" distcheck

--- a/tests/centos9-build/run-tests.sh
+++ b/tests/centos9-build/run-tests.sh
@@ -7,10 +7,10 @@ git config --global --add safe.directory /crun
 
 git clean -fdx
 ./autogen.sh
-./configure --enable-embedded-blake3 CFLAGS='-Wall -Wextra -Werror'
+./configure --enable-embedded-blake3 --enable-werror
 make -j "$(nproc)"
 
 git clean -fdx
 ./autogen.sh
-./configure --enable-embedded-blake3 CFLAGS='-Wall -Wextra -Werror' --disable-systemd
+./configure --enable-embedded-blake3 --enable-werror --disable-systemd
 make -j "$(nproc)"

--- a/tests/clang-check/run-tests.sh
+++ b/tests/clang-check/run-tests.sh
@@ -6,7 +6,7 @@ cd /crun
 git config --global --add safe.directory /crun
 git clean -fdx
 ./autogen.sh
-./configure --enable-embedded-blake3 CFLAGS='-Wall -Wextra -Werror' CC=clang
+./configure --enable-embedded-blake3 --enable-werror CC=clang
 intercept-build make
 
 echo -e "\n\n----------------------------- clang-check -------------------------------\n\n"

--- a/tests/containerd/run-tests.sh
+++ b/tests/containerd/run-tests.sh
@@ -9,7 +9,7 @@ set -e
 (
     cd /crun
     ./autogen.sh
-    ./configure --enable-embedded-blake3 CFLAGS='-Wall -Wextra -Werror'
+    ./configure --enable-embedded-blake3 --enable-werror
     make -j "$(nproc)"
     cp crun /usr/bin/runc
 )

--- a/tests/cri-o/run-tests.sh
+++ b/tests/cri-o/run-tests.sh
@@ -11,7 +11,7 @@ set -e
     git config --global --add safe.directory /crun
     git clean -fdx
     ./autogen.sh
-    ./configure --enable-embedded-blake3 CFLAGS='-Wall -Wextra -Werror' --prefix=/usr
+    ./configure --enable-embedded-blake3 --enable-werror --prefix=/usr
     make -j "$(nproc)"
     make install
 )

--- a/tests/init.c
+++ b/tests/init.c
@@ -308,8 +308,9 @@ sd_notify ()
     error (EXIT_FAILURE, errno, "socket");
 
   notify_socket_unix_name.sun_family = AF_UNIX;
-  strncpy (notify_socket_unix_name.sun_path, notify_socket_name,
-           sizeof (notify_socket_unix_name.sun_path));
+  if (strlen (notify_socket_name) >= sizeof (notify_socket_unix_name.sun_path))
+    error (EXIT_FAILURE, 0, "NOTIFY_SOCKET is too long");
+  strcpy (notify_socket_unix_name.sun_path, notify_socket_name);
 
   ret = sendto (notify_socket_fd, ready_data, ready_data_len, 0,
                 (struct sockaddr *) &notify_socket_unix_name, sizeof (notify_socket_unix_name));
@@ -441,7 +442,7 @@ dump_net_interface (const char *ifname)
             error (EXIT_FAILURE, 0, "netlink error");
 
           ifa = NLMSG_DATA (nlh);
-          if (ifa->ifa_index != ifindex)
+          if (ifa->ifa_index != (unsigned int) ifindex)
             continue;
 
           rta_it = IFA_RTA (ifa);

--- a/tests/podman/run-tests.sh
+++ b/tests/podman/run-tests.sh
@@ -12,7 +12,7 @@ set -xeuo pipefail
     git config --global --add safe.directory /crun
     git clean -fdx
     ./autogen.sh
-    ./configure --enable-embedded-blake3 CFLAGS='-Wall -Wextra -Werror' --prefix=/usr
+    ./configure --enable-embedded-blake3 --enable-werror --prefix=/usr
     make -j "$(nproc)"
     make install
 )

--- a/tests/tests_libcrun_chroot_realpath.c
+++ b/tests/tests_libcrun_chroot_realpath.c
@@ -244,35 +244,42 @@ make_symlink_tree (char *root, size_t root_size)
   if (tmpdir == NULL)
     return 77;
 
-  snprintf (path, sizeof (path), "%s/file", root);
+  if (snprintf (path, sizeof (path), "%s/file", root) >= (int) sizeof (path))
+    return 77;
   fd = creat (path, 0600);
   if (fd < 0)
     return 77;
   close (fd);
 
-  snprintf (path, sizeof (path), "%s/link", root);
+  if (snprintf (path, sizeof (path), "%s/link", root) >= (int) sizeof (path))
+    return 77;
   if (symlink ("file", path) < 0)
     return 77;
 
-  snprintf (path, sizeof (path), "%s/dir", root);
+  if (snprintf (path, sizeof (path), "%s/dir", root) >= (int) sizeof (path))
+    return 77;
   if (mkdir (path, 0700) < 0)
     return 77;
 
-  snprintf (path, sizeof (path), "%s/dir/file", root);
+  if (snprintf (path, sizeof (path), "%s/dir/file", root) >= (int) sizeof (path))
+    return 77;
   fd = creat (path, 0600);
   if (fd < 0)
     return 77;
   close (fd);
 
-  snprintf (path, sizeof (path), "%s/dir/link", root);
+  if (snprintf (path, sizeof (path), "%s/dir/link", root) >= (int) sizeof (path))
+    return 77;
   if (symlink ("file", path) < 0)
     return 77;
 
-  snprintf (path, sizeof (path), "%s/dir/up", root);
+  if (snprintf (path, sizeof (path), "%s/dir/up", root) >= (int) sizeof (path))
+    return 77;
   if (symlink ("../file", path) < 0)
     return 77;
 
-  snprintf (path, sizeof (path), "%s/dir/abs", root);
+  if (snprintf (path, sizeof (path), "%s/dir/abs", root) >= (int) sizeof (path))
+    return 77;
   if (symlink ("/file", path) < 0)
     return 77;
 
@@ -288,7 +295,8 @@ cleanup_symlink_tree (const char *root)
 
   for (i = 0; files[i]; i++)
     {
-      snprintf (path, sizeof (path), "%s/%s", root, files[i]);
+      if (snprintf (path, sizeof (path), "%s/%s", root, files[i]) >= (int) sizeof (path))
+        continue;
       if (remove (path) < 0)
         continue;
     }

--- a/tests/tests_libcrun_intelrdt.c
+++ b/tests/tests_libcrun_intelrdt.c
@@ -84,7 +84,7 @@ test_get_rdt_value ()
     {                                                    \
       char *result = NULL;                               \
       int r = get_rdt_value (&result, L3, MB, SCHEMATA); \
-      if (strlen (result) != r)                          \
+      if (strlen (result) != (size_t) r)                 \
         return 1;                                        \
       int cmp = strcmp (result, EXPECTED);               \
       free (result);                                     \

--- a/tests/wasmedge-build/run-tests.sh
+++ b/tests/wasmedge-build/run-tests.sh
@@ -11,7 +11,7 @@ rm -rf /usr/bin/crun /usr/local/bin/crun-wasm /usr/bin/crun-wasm
 git config --global --add safe.directory /crun
 git clean -fdx
 ./autogen.sh
-./configure --enable-embedded-blake3 CFLAGS='-Wall -Wextra -Werror' --with-wasmedge --prefix=/usr
+./configure --enable-embedded-blake3 --enable-werror --with-wasmedge --prefix=/usr
 make -j "$(nproc)"
 make install
 


### PR DESCRIPTION
The warning flags used to live in the CI scripts: `CFLAGS='-Wall -Wextra -Werror'`,
repeated in a dozen places, `-Wall -Werror` in some of them, and nothing at all for
the test programs and the python and lua bindings.  This moves them into the build
system, so they are used by every build and can be changed in one place.

## How it is wired

`configure` builds a `WARN_CFLAGS` variable, testing every flag before using it, so
that a compiler that does not know a flag does not break the build.  The flags are
added to `AM_CFLAGS` (and to every per target `_CFLAGS`, as automake lets those
override `AM_CFLAGS`), **not** to `CFLAGS`, which stays the user's: automake puts
`AM_CFLAGS` before `CFLAGS`, so a distro or a user can still override anything.

`-Werror` is *not* enabled by default; it is added by `--enable-werror`, which is
what the CI now passes.  A new compiler warning will therefore not break the build
for users and packagers.

The flags are `-Wall -Wextra` plus `-Wvla -Walloca -Wduplicated-cond
-Wduplicated-branches -Winit-self -Wshift-overflow=2`, which are clean today.

## What it found

Applying `-Wall -Wextra` where it had never been applied turned up:

 * `move_network_device` and `run_in_container_namespace` both had a variable live
   across a `vfork` call (`-Wclobbered`);
 * on 32 bit architectures, the relative mapping lookup compared a `long` against a
   `uint32_t`, making the comparison unsigned, and the sum it was compared against
   could overflow;
 * `has_bpf_fs` compared `statfs.f_type` with `BPF_FS_MAGIC`, which does not fit in
   a signed int;
 * arrays sized by a `const` variable, which are VLAs;
 * in the test programs, `snprintf` results not checked for truncation and a
   `strncpy` into `sun_path` that could leave the string unterminated;
 * in the python bindings, a cast between incompatible function types and a
   partially initialized `PyModuleDef`.

Verified with GCC and clang, on glibc and musl, 64 and 32 bit, with and without the
python and lua bindings, including the test programs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)