### PR TITLE
linux: fix NULL deref on mount without a type

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5910,6 +5910,12 @@ init_container (libcrun_container_t *container, int sync_socket_container, struc
       for (i = 0; i < def->mounts_len; i++)
         {
           int fd = -1;
+
+          /* The mount type is optional in the OCI configuration, e.g. bind mounts
+             are usually specified without it.  */
+          if (def->mounts[i]->type == NULL)
+            continue;
+
           /* If for any reason the mount cannot be opened, ignore errors and continue.
              An error will be generated later if it is not possible to join the namespace.
           */

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -624,6 +624,57 @@ def test_domainname_with_uts_namespace():
         return -1
 
 
+def test_join_namespaces_mount_without_type():
+    """A mount without an explicit "type" must not crash when joining namespaces.
+
+    Reproduces the "pod with a userns + CDI device" case: the container joins
+    the user and IPC namespaces of another container and has a bind mount with
+    no "type" specified, which is optional in the OCI spec.
+
+    See https://github.com/containers/crun/issues/1948
+    """
+
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'pause']
+    add_all_namespaces(conf, userns=True)
+
+    try:
+        _, first_id = run_and_get_output(conf, detach=True)
+    except subprocess.CalledProcessError:
+        return (77, "user namespace not available in nested namespaces")
+
+    try:
+        state = json.loads(run_crun_command(["state", first_id]))
+        ns_path = "/proc/%d/ns" % state['pid']
+
+        conf = base_config()
+        conf['process']['args'] = ['/init', 'echo', 'hello']
+        add_all_namespaces(conf, userns=True)
+        for ns in conf['linux']['namespaces']:
+            if ns['type'] in ('user', 'ipc'):
+                ns['path'] = os.path.join(ns_path, ns['type'])
+
+        # a bind mount with no "type"
+        conf['mounts'].append({
+            "destination": "/var/file",
+            "source": get_init_path(),
+            "options": ["bind", "ro"],
+        })
+
+        out, _ = run_and_get_output(conf)
+        if "hello" not in out:
+            return -1
+    except subprocess.CalledProcessError as e:
+        output = e.output.decode('utf-8', errors='ignore') if e.output else ''
+        if is_nested_namespace_error(output):
+            return (77, "namespace not available in nested namespaces")
+        logger.info("test failed: %s", e)
+        return -1
+    finally:
+        run_crun_command(["delete", "-f", first_id])
+    return 0
+
+
 all_tests = {
     "pid-namespace": test_pid_namespace,
     "network-namespace": test_network_namespace,
@@ -639,6 +690,7 @@ all_tests = {
     "namespace-path-sharing": test_namespace_path_sharing,
     "hostname-without-uts": test_hostname_without_uts_namespace,
     "domainname-with-uts": test_domainname_with_uts_namespace,
+    "join-namespaces-mount-without-type": test_join_namespaces_mount_without_type,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1948.

When a container joins an existing PID or IPC namespace and a new user namespace
is created, `init_container` iterates over all the mounts and compares their type
against `proc` and `mqueue`. The type is optional in the OCI configuration though,
and is normally not set for bind mounts, so `strcmp` is called with a `NULL`
argument and the init process crashes. The failure surfaces as the rather opaque

```
read status from sync socket
```

This is reproducible with podman by running a container with a CDI device in a pod
that has a user namespace, since mounts in a CDI specification usually have no type.

Second commit adds a test case that joins the user and IPC namespaces of another
container with a typeless bind mount; it fails without the fix.