### PR TITLE
Linux: Fix Non-Recursive Propagation Finalize Leaking Nested Submounts to Host (#2197)

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1571,7 +1571,7 @@ apply_propagation_flags (const char *target, int targetfd, const char *real_targ
   if (targetfd >= 0)
     {
       libcrun_error_t tmp_err = NULL;
-      ret = do_mount_setattr (false, target, targetfd, 0, mountflags & ALL_PROPAGATIONS, &tmp_err);
+      ret = do_mount_setattr ((mountflags & MS_REC) != 0, target, targetfd, 0, mountflags & ALL_PROPAGATIONS, &tmp_err);
       if (LIKELY (ret == 0))
         propagation_done = true;
       else


### PR DESCRIPTION
Fixes #2197 (also cross-referenced from distrobox#2203: https://github.com/89luca89/distrobox/issues/2203).

Testing:
- Ran `test_mounts.py` on unpatched vs. patched builds — identical pass/fail, no regressions.
- Reproduced the real scenario on a real machine: `distrobox create --root --init` + enter, checked host `/dev/pts`/`/dev/ptmx` and `sudo -v` before and after. With the patch, nothing on the host changed and `sudo` kept working.

The fix was verified on my system by  me , Checked/tested on direct podman , distrobox & otter ( my own tool )

Who this hits: anyone bind-mounting `/dev` as `rslave` and mounting their own devpts inside — this is exactly what Otter and distrobox both do for rootful `--init` containers, which is the confirmed-affected case in both issues.

The bug: when a mount like `/dev` is bind-mounted `rslave`, crun is supposed to isolate the whole tree from the host — including nested mounts already inside it, like the host's real `/dev/pts`. Since 1.29, the finalize step only isolates the top-level mount and skips anything nested. So a container mounting its own devpts at `/dev/pts` can leak straight through to the host's real `/dev/pts`, breaking PTY allocation host-wide (`sudo` stops working, terminals fail, etc).

The fix: one line — make the finalize step recursive when the original mount was recursive

I have not run the full test suite , So I cant guarantee zero regression but I think there shouldnt be any as its a minimal & tested change