### PR TITLE
ci: re-enable the CentOS 10 build

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
           - test: oci-validation
           - test: alpine-build
           - test: centos9-build
-          #- test: centos10-build
+          - test: centos10-build
           - test: clang-format
           - test: clang-check
           - test: cppcheck

--- a/tests/centos10-build/Dockerfile
+++ b/tests/centos10-build/Dockerfile
@@ -2,7 +2,8 @@ FROM quay.io/centos/centos:stream10-development
 
 RUN yum  --enablerepo='appstream'  --enablerepo='baseos' --enablerepo='crb' install -y make \
     automake autoconf gettext criu-devel libtool gcc libcap-devel systemd-devel \
-    libseccomp-devel python3 libtool git protobuf-c protobuf-c-devel xz glibc-static json-c-devel
+    libseccomp-devel python3 libtool git protobuf-c protobuf-c-devel xz glibc-static json-c-devel \
+    iproute iptables
 
 COPY run-tests.sh /usr/local/bin
 

--- a/tests/centos10-build/Dockerfile
+++ b/tests/centos10-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10
 
 RUN yum  --enablerepo='appstream'  --enablerepo='baseos' --enablerepo='crb' install -y make \
     automake autoconf gettext criu-devel libtool gcc libcap-devel systemd-devel \

--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -101,7 +101,7 @@ def _get_cmdline(cid, tests_root):
 def run_cr_test(conf, before_checkpoint_cb=None, before_restore_cb=None):
     cid = None
     cr_dir = os.path.join(get_tests_root(), 'checkpoint')
-    work_dir = 'work-dir'
+    work_dir = os.path.join(get_tests_root(), 'work-dir')
     try:
         logger.info("run_cr_test: starting container")
         _, cid = run_and_get_output(
@@ -199,7 +199,7 @@ def test_cr_pre_dump():
 
     cid = None
     cr_dir = os.path.join(get_tests_root(), 'pre-dump')
-    work_dir = 'work-dir'
+    work_dir = os.path.join(get_tests_root(), 'work-dir')
     try:
         _, cid = run_and_get_output(
             conf,


### PR DESCRIPTION
~~Based on (and currently includes) #2221, draft until that one is merged.~~

The `centos10-build` job has been disabled since 8801bc46 (May 2024), because
"the repos are still not stable enough to add it to the CI".  CentOS Stream 10
has been released since, so switch the image from `stream10-development` to
`stream10` and put the job back into the test matrix.

Three things had to be fixed first, none of them in crun or CRIU:

1. The image has no `ip`.  CRIU shells out to it to save the addresses of a
   network namespace it is dumping:

       Error (criu/util.c:642): execvp("ip", ...) failed: No such file or directory
       Error (criu/net.c:1969): net: IP tool failed on addr save
       Error (criu/cr-dump.c:1975): Dumping FAILED.

2. The image has no `iptables-save` either, needed to read the ruleset back.

3. The checkpoint/restore tests pass a relative `--work-path`, leaving the CRIU
   work directory behind in the build tree, which `make distcheck` rejects:

       ERROR: files left in build directory after distclean:
       ./work-dir/stats-dump
       ./work-dir/irmap-cache
       ./work-dir/dump.log

   That one is not CentOS specific, it just went unnoticed because this is the
   only job running `distcheck`.

With those in place the job passes in about 3 minutes: 528 tests, 479 passed,
49 skipped, 0 failed, all six checkpoint/restore tests green in both of the
`distcheck` runs.  `test_devices.py`'s `net-devices` test, which was silently
skipping with "ip command not found", now runs too.

Worth noting for the record: the `iptables-legacy-save` errors in the log are
noise, not a failure.  CRIU deliberately looks for the legacy tools when
dumping a netns ruleset, to avoid mixing with nft-created rules, and simply
skips the dump when they are absent -- CentOS Stream 10 has no
`iptables-legacy` package at all:

    net: skipping iptables dump - no legacy version present

Network locking is unaffected: CentOS builds CRIU with
`NETWORK_LOCK_DEFAULT=NETWORK_LOCK_NFTABLES`, and crun no longer forces
iptables (#1627, fixed by #1628).

