### PR TITLE
ci: speed up the emulated cross-arch builds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,14 @@ jobs:
           submodules: true
           set-safe-directory: true
 
+      # Running autoreconf natively is much faster than under emulation.
+      # The generated files are architecture independent.
+      - name: Generate the configure script
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends autoconf automake libtool pkg-config
+          ./autogen.sh
+
       - uses: uraimo/run-on-arch-action@v3.2.0
         name: Build
         id: build
@@ -40,7 +48,7 @@ jobs:
 
           install: |
             apt-get update -y
-            apt-get install -y automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libjson-c-dev libprotobuf-c-dev clang mawk
+            apt-get install -y libseccomp-dev git make libcap-dev cmake pkg-config gcc wget go-md2man libsystemd-dev gperf clang-format libjson-c-dev libprotobuf-c-dev clang mawk
 
           run: |
             find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,24 +5,25 @@ on: [push, pull_request]
 jobs:
   build_job:
     runs-on: ubuntu-latest
-    name: Build on ${{ matrix.arch }}
+    name: Build ${{ matrix.build }} on ${{ matrix.arch }}
     permissions:
       contents: read
       packages: write
 
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - arch: armv7
-            distro: ubuntu_latest
-#          - arch: aarch64
-#            distro: ubuntu_latest
-#          - arch: s390x
-#            distro: ubuntu_latest
-#          - arch: ppc64le
-#            distro: ubuntu_latest
-          - arch: riscv64
-            distro: ubuntu_latest
+        # The static and the shared build are separate jobs: under emulation
+        # each one takes tens of minutes, so running them in parallel roughly
+        # halves the wall clock time.
+        build: [static, shared]
+        arch:
+          - armv7
+#          - aarch64
+#          - s390x
+#          - ppc64le
+          - riscv64
+        distro: [ubuntu_latest]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -52,7 +53,7 @@ jobs:
 
           run: |
             find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;
-            ./tests/ci.sh cross
+            ./tests/ci.sh cross-${{ matrix.build }}
 
   Test:
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -49,14 +49,20 @@ cross_configure() {
 # Everything is roughly 20x slower under emulation, so nothing else is built,
 # and a plain "make crun" does not do: the generated headers are not among
 # its prerequisites, so they have to be made first.
-cross_build() {
-    # The status of each command is checked explicitly: "set -e" does not
-    # apply inside a function whose caller looks at its exit status.
-    cross_configure "$@" || return
+cross_make() {
     make -j "$(nproc)" -C libocispec libocispec.la &&
         make git-version.h &&
         make -j "$(nproc)" libcrun.la &&
         make -j "$(nproc)" crun
+}
+
+# The cross architecture counterpart of build(), with any extra configure
+# arguments in "$@".
+cross_build() {
+    # The status of each command is checked explicitly: "set -e" does not
+    # apply inside a function whose caller looks at its exit status.
+    group configure cross_configure "$@" || return
+    group build cross_make
 }
 
 # Build the container image for the current test from tests/<test>/Dockerfile
@@ -200,17 +206,16 @@ codespell)
 wasmedge-build)
     run_container "${privileged[@]}" -v containers:/var/lib/containers:rw -w /crun
     ;;
-cross)
-    group "static build" cross_build || {
+cross-static)
+    cross_build || {
         cat config.log
         exit 1
     }
-
-    make -j "$(nproc)" clean
-
+    ;;
+cross-shared)
     # A shared build that cannot be configured is not treated as a failure,
     # which is what the exit status of 2 from cross_configure means here.
-    group "shared build" cross_build --enable-shared || test $? -eq 2
+    cross_build --enable-shared || test $? -eq 2
     ;;
 *)
     echo "unknown test: $test_name" >&2

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -215,7 +215,9 @@ cross-static)
 cross-shared)
     # A shared build that cannot be configured is not treated as a failure,
     # which is what the exit status of 2 from cross_configure means here.
-    cross_build --enable-shared || test $? -eq 2
+    # --disable-static: without it libtool compiles every object twice, PIC
+    # and non-PIC, and the non-PIC ones are the static job's business.
+    cross_build --enable-shared --disable-static || test $? -eq 2
     ;;
 *)
     echo "unknown test: $test_name" >&2

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -38,7 +38,11 @@ build() {
 # configure arguments in "$@".  Returns 2, rather than 1, when configure
 # itself fails, so that the caller can tell that apart from a build failure.
 cross_configure() {
-    ./configure --enable-embedded-blake3 --enable-werror "$@" || return 2
+    # --disable-maintainer-mode: the workflow runs autogen.sh natively before
+    # entering the emulated container, and make must never decide to rerun the
+    # autotools here, where they are very slow.
+    ./configure --disable-maintainer-mode --enable-embedded-blake3 \
+        --enable-werror "$@" || return 2
 }
 
 # Build just the crun binary, for the emulated cross architecture builds.
@@ -197,8 +201,6 @@ wasmedge-build)
     run_container "${privileged[@]}" -v containers:/var/lib/containers:rw -w /crun
     ;;
 cross)
-    ./autogen.sh
-
     group "static build" cross_build || {
         cat config.log
         exit 1


### PR DESCRIPTION
~~Based on and currently includes #2221; draft until that one is merged.~~

The `Build on <arch>` jobs run under QEMU emulation, where everything is
roughly 20x slower than native, and each job built the tree twice in
sequence: configure, build, `make clean`, configure, build. On riscv64 the
median of 17 recent jobs on unrelated pull requests is 31 minutes.

Three changes:

1. Run `./autogen.sh` natively on the runner, before entering the emulated
   container. What autoreconf generates is architecture independent, and it
   takes ~4s natively instead of ~100s emulated. `--disable-maintainer-mode`
   is passed as well, so that make can never decide to rerun the autotools
   under emulation, and the autotools packages are dropped from the
   container.

2. Build static and shared in separate jobs, so that they run in parallel.
   This needs a real second matrix dimension rather than more `include`
   entries: `include` objects that all set `arch` are applied to the same
   combinations, each one overriding the previous, which would leave a
   single arch. `fail-fast: false` is set as well, so that one failing
   architecture or build type no longer cancels the others. This also drops
   the `make clean` between the two builds, which alone took 160-210s.

3. Pass `--disable-static` to the shared build. Without it libtool compiles
   every object twice, PIC and non-PIC, which doubles the compile phase --
   about two thirds of the job. The non-PIC objects are already covered by
   the static job.

Wall clock of the build jobs:

| | before (n=17 riscv64, n=18 armv7) | after |
| --- | --- | --- |
| riscv64 | 31m13s median, 23m49s-32m40s | 12m33s / 12m44s |
| armv7 | 17m28s median, 13m44s-19m37s | 7m30s / 7m28s |

The "before" numbers are every successful `Build on <arch>` job of #2221
and #2222; the "after" ones are the shared and the static job of the one
run of this PR whose container image was still cached (see below).

Two things to keep in mind when reading the timings of individual runs:

- The emulated runners vary by a factor of two. `configure` is single
  threaded and identical in both build types, so it is a good yardstick: it
  ranges from 126s to 221s across these runs, and everything else scales
  with it. Normalised against it, the numbers above are consistent -- about
  1430s before and about 575s after.
- Changing the `install:` list invalidates the container image that
  run-on-arch-action caches in GHCR, and a pull request from a fork cannot
  push the rebuilt image back (`denied: installation not allowed to Write
  organization package`), so most runs of this PR pay 260-390s for apt
  instead of ~88s. That goes away once the image is rebuilt on the main
  branch.

Two notes on things that did not work or are left alone:

- The pre-existing asymmetry between the two builds is preserved: a shared
  build that cannot be configured is still not treated as a failure. Happy
  to make both strict in a follow-up if that was not intentional.
- Sharing a `config.cache` between the two configure rounds via
  `configure -C` does not work here: `configure.ac` does
  `export CFLAGS="$CFLAGS -fPIC"` for the shared build, so the top level and
  the libocispec subdir enter the cache with different environments and
  configure aborts with `changes in the environment can compromise the
  build`. This happens even with a completely fresh cache.

