### PR TITLE
Fix dead code in chroot_realpath and its CRIU callers

### DIFF
--- a/src/libcrun/chroot_realpath.c
+++ b/src/libcrun/chroot_realpath.c
@@ -83,11 +83,10 @@ char *chroot_realpath(const char *chroot, const char *path, char resolved_path[]
 	path = copy_path;
 	max_path = copy_path + PATH_MAX - chroot_len - 3;
 
-	/* Start with the chroot path. */
+	/* Start with the chroot path.  It is copied verbatim so that the
+	   result is always prefixed by CHROOT and callers can strip it. */
 	strcpy(new_path, chroot);
 	new_path += chroot_len;
-	while (*new_path == '/' && new_path > got_path)
-		new_path--;
 	got_path_root = new_path;
 	*new_path++ = '/';
 

--- a/src/libcrun/chroot_realpath.c
+++ b/src/libcrun/chroot_realpath.c
@@ -47,6 +47,16 @@
 
 #define MAX_READLINKS 32
 
+/* Resolve PATH as if CHROOT was the root directory, storing the result in
+   RESOLVED_PATH (which must be at least PATH_MAX bytes long).
+
+   On success the returned path is prefixed by CHROOT, except in the trivial
+   case where CHROOT is NULL, empty, or "/", where PATH is returned unchanged.
+   A component of PATH that does not exist is not an error: the part that
+   could be resolved is returned with the rest of PATH appended to it.
+
+   On failure NULL is returned and errno is set to either ENAMETOOLONG or
+   ELOOP, or to any error readlink(2) can report except ENOENT and EINVAL. */
 char *chroot_realpath(const char *chroot, const char *path, char resolved_path[])
 {
 	char copy_path[PATH_MAX];

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -4576,7 +4576,7 @@ libcrun_write_json_containers_list (libcrun_context_t *context, FILE *out, libcr
       json_gen_string (gen, "created", strlen ("created"));
       json_gen_string (gen, status.created, strlen (status.created));
       json_gen_string (gen, "owner", strlen ("owner"));
-      json_gen_string (gen, status.owner, strlen (status.owner));
+      json_gen_string (gen, status.owner, safe_strlen (status.owner));
       json_gen_map_close (gen);
 
       libcrun_free_container_status (&status);

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -752,7 +752,10 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
           if (UNLIKELY (dest_in_root == NULL))
             return crun_make_error (err, errno, "unable to resolve external bind mount `%s` under rootfs", def->mounts[i]->destination);
 
-          dest_in_root += strlen (status->rootfs);
+          /* When the rootfs is "/" or not set, chroot_realpath returns the
+             path unchanged, so strip the prefix only when it is there.  */
+          if (has_prefix (dest_in_root, status->rootfs))
+            dest_in_root += safe_strlen (status->rootfs);
 
           ret = libcriu_wrapper->criu_add_ext_mount (dest_in_root, dest_in_root);
           if (UNLIKELY (ret < 0))
@@ -1062,7 +1065,10 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
           if (UNLIKELY (dest_in_root == NULL))
             return crun_make_error (err, errno, "unable to resolve external bind mount destination `%s` under rootfs", def->mounts[i]->destination);
 
-          dest_in_root += strlen (status->rootfs);
+          /* When the rootfs is "/" or not set, chroot_realpath returns the
+             path unchanged, so strip the prefix only when it is there.  */
+          if (has_prefix (dest_in_root, status->rootfs))
+            dest_in_root += safe_strlen (status->rootfs);
 
           ret = libcriu_wrapper->criu_add_ext_mount (dest_in_root, def->mounts[i]->source);
           if (UNLIKELY (ret < 0))

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -711,7 +711,7 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
   if (UNLIKELY (ret < 0))
     return ret;
 
-  ret = write_file (descriptors_path, status->external_descriptors, strlen (status->external_descriptors), err);
+  ret = write_file (descriptors_path, status->external_descriptors, safe_strlen (status->external_descriptors), err);
   if (UNLIKELY (ret < 0))
     return crun_error_wrap (err, "error saving CRIU descriptors file");
 

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -750,14 +750,9 @@ libcrun_container_checkpoint_linux_criu (libcrun_container_status_t *status, lib
 
           dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf);
           if (UNLIKELY (dest_in_root == NULL))
-            {
-              if (errno != ENOENT)
-                return crun_make_error (err, errno, "unable to resolve external bind mount `%s` under rootfs", def->mounts[i]->destination);
-              else
-                dest_in_root = def->mounts[i]->destination;
-            }
-          else
-            dest_in_root += strlen (status->rootfs);
+            return crun_make_error (err, errno, "unable to resolve external bind mount `%s` under rootfs", def->mounts[i]->destination);
+
+          dest_in_root += strlen (status->rootfs);
 
           ret = libcriu_wrapper->criu_add_ext_mount (dest_in_root, dest_in_root);
           if (UNLIKELY (ret < 0))
@@ -1065,13 +1060,9 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
 
           dest_in_root = chroot_realpath (status->rootfs, def->mounts[i]->destination, buf);
           if (UNLIKELY (dest_in_root == NULL))
-            {
-              if (errno != ENOENT)
-                return crun_make_error (err, errno, "unable to resolve external bind mount destination `%s` under rootfs", def->mounts[i]->destination);
-              dest_in_root = def->mounts[i]->destination;
-            }
-          else
-            dest_in_root += strlen (status->rootfs);
+            return crun_make_error (err, errno, "unable to resolve external bind mount destination `%s` under rootfs", def->mounts[i]->destination);
+
+          dest_in_root += strlen (status->rootfs);
 
           ret = libcriu_wrapper->criu_add_ext_mount (dest_in_root, def->mounts[i]->source);
           if (UNLIKELY (ret < 0))

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -299,8 +299,11 @@ libcrun_write_container_status (const char *state_root, const char *id, libcrun_
   GEN_KEY (gen, "detached");
   GEN_OR_FAIL (json_gen_bool (gen, status->detached));
 
-  GEN_KEY (gen, "external_descriptors");
-  GEN_STR (gen, status->external_descriptors);
+  if (status->external_descriptors)
+    {
+      GEN_KEY (gen, "external_descriptors");
+      GEN_STR (gen, status->external_descriptors);
+    }
 
   GEN_OR_FAIL (json_gen_map_close (gen));
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -351,7 +351,7 @@ safe_openat_fallback (int dirfd, const char *rootfs, const char *path, int flags
   cleanup_close int fd = -1;
   char resolved[PATH_MAX];
   char buffer[PATH_MAX];
-  size_t rootfs_len = is_empty_string (rootfs) ? 0 : strlen (rootfs);
+  size_t rootfs_len = safe_strlen (rootfs);
   int ret;
 
   /* chroot_realpath resolves the last component as well, so when O_NOFOLLOW

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -21,6 +21,7 @@
 #include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <errno.h>
 #include <argp.h>
 #include "error.h"
@@ -413,6 +414,13 @@ static inline bool
 is_empty_string (const char *s)
 {
   return s == NULL || s[0] == '\0';
+}
+
+/* Like strlen(), but a NULL string has length 0.  */
+static inline size_t
+safe_strlen (const char *s)
+{
+  return s == NULL ? 0 : strlen (s);
 }
 
 static inline bool

--- a/src/libcrun/utils.h
+++ b/src/libcrun/utils.h
@@ -361,7 +361,12 @@ LIBCRUN_PUBLIC int parse_json_file (json_object **out, const char *jsondata, str
 static inline int
 has_prefix (const char *str, const char *prefix)
 {
-  size_t prefix_len = strlen (prefix);
+  size_t prefix_len;
+
+  if (! str || ! prefix)
+    return 0;
+
+  prefix_len = strlen (prefix);
   return strlen (str) >= prefix_len && memcmp (str, prefix, prefix_len) == 0;
 }
 
@@ -369,7 +374,12 @@ has_prefix (const char *str, const char *prefix)
 static inline int
 has_dir_prefix (const char *str, const char *prefix)
 {
-  size_t prefix_len = strlen (prefix);
+  size_t prefix_len;
+
+  if (! str || ! prefix)
+    return 0;
+
+  prefix_len = strlen (prefix);
   return strlen (str) > prefix_len && memcmp (str, prefix, prefix_len) == 0 && str[prefix_len] == '/';
 }
 


### PR DESCRIPTION
Started from #2194 (unreachable code in `criu.c`), grew a couple of NULL-safety
helpers on the way.

`chroot_realpath()` never fails with `ENOENT` -- a path component that does not
exist is not an error, the part that could be resolved is returned instead. Both
CRIU call sites had a fallback for that case, which was dead. While there, the
function's contract is now written down, and a trailing-slash loop that never
ran is gone.

The last commit fixes a real bug next door: the resolved path is prefixed with
the rootfs *except* when the rootfs is `/`, empty, or unset, where it comes back
unchanged. Advancing by the rootfs length unconditionally then eats the leading
characters of the path itself, so CRIU would get `etc/hosts` instead of
`/etc/hosts`.

The first three commits are prerequisites: `safe_strlen()`, NULL-safe
`has_prefix()`/`has_dir_prefix()`, and a status-parsing NULL dereference they
uncovered.