### PR TITLE
ci: add a build with libkrun

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,6 +74,7 @@ jobs:
           - test: fuzzing
           - test: codespell
           - test: wasmedge-build
+          - test: krun-build
     steps:
       - name: checkout
         uses: actions/checkout@v7

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -153,7 +153,7 @@ containerd)
 oci-validation)
     run_container "${privileged[@]}"
     ;;
-alpine-build | centos9-build | system-blake3)
+alpine-build | centos9-build | system-blake3 | krun-build)
     # These only build crun, they never run a container, so they need
     # none of the privileges the tests above do.
     run_container

--- a/tests/krun-build/Dockerfile
+++ b/tests/krun-build/Dockerfile
@@ -1,0 +1,12 @@
+FROM quay.io/fedora/fedora:latest
+
+# Install the deps for building crun with libkrun support.  The krun handler is
+# only compiled when configured with --with-libkrun, so without a build like
+# this one it is never compiled in CI.
+RUN dnf install -y awk make python git gcc automake autoconf libcap-devel \
+		systemd-devel json-c-devel libseccomp-devel pkg-config diffutils \
+		go-md2man glibc-static python3-libmount libtool which libkrun-devel
+
+COPY run-tests.sh /usr/local/bin
+
+ENTRYPOINT ["/usr/local/bin/run-tests.sh"]

--- a/tests/krun-build/run-tests.sh
+++ b/tests/krun-build/run-tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+# Build crun with libkrun support.  Running a krun container needs libkrun,
+# KVM and passt, none of which are available here, so this only makes sure the
+# krun handler keeps compiling and ends up in the binary.
+cd /crun
+
+git config --global --add safe.directory /crun
+git clean -fdx
+./autogen.sh
+# -Wno-error=comment: libkrun.h up to at least 1.19.0 has a "/*" inside a
+# comment, which -Werror would turn into a build failure of its own.
+./configure --enable-embedded-blake3 --enable-werror --with-libkrun \
+    CFLAGS="-O2 -g -Wno-error=comment"
+make -j "$(nproc)"
+
+if ! ./crun --version | grep -q LIBKRUN; then
+    echo "the krun handler is missing from the built crun"
+    ./crun --version
+    exit 1
+fi


### PR DESCRIPTION
~~Based on (and currently includes) #2221, draft until that one is merged.~~

The krun handler is only compiled when configure is given `--with-libkrun`, which never happens in CI, so `src/libcrun/handlers/krun.c` is not built there at all and can break unnoticed -- as it nearly did in #2227.

Add a Fedora based build that configures with `--with-libkrun` and checks that the resulting binary reports the `LIBKRUN` feature. Actually running a krun container needs libkrun, KVM and passt, which are not available on the runners, so this is a compile time check only.

One thing had to be worked around: the build cannot use `--enable-werror` as is, because `libkrun.h` (up to at least 1.19.0, the version in Fedora) has a `/*` inside a comment:

```
/usr/include/libkrun.h:726:61: error: '/*' within comment [-Werror=comment]
```

That fails the build before any crun code is compiled, so `-Werror` is kept and just that one warning is turned back into a warning.

Verified locally by building the image and running `tests/krun-build/run-tests.sh` against a clean checkout: the build passes and `crun --version` reports `+LIBKRUN`.

