### PR TITLE
scheduler: fix cpu affinity handling

### DIFF
--- a/src/libcrun/scheduler.c
+++ b/src/libcrun/scheduler.c
@@ -78,19 +78,26 @@ syscall_sched_setattr (pid_t pid, struct sched_attr_s *attr, unsigned int flags)
 #endif
 }
 
+/* Maximum number of CPUs the reset mask can cover.  The mask passed to
+   sched_setaffinity is truncated by the kernel to its own cpumask size, so
+   using a mask larger than the number of CPUs on the system is safe, while a
+   mask that is too small fails with EINVAL when the target cgroup only allows
+   CPUs outside of it.  */
+#define MAX_CPU_MASK_BITS (64 * 1024)
+
 int
 libcrun_reset_cpu_affinity_mask (pid_t pid, libcrun_error_t *err)
 {
+  cpu_set_t mask[MAX_CPU_MASK_BITS / (CHAR_BIT * sizeof (cpu_set_t))];
   int ret;
-  cpu_set_t mask;
 
   /* Reset the inherited cpu affinity. Old kernels do that automatically, but
      new kernels remember the affinity that was set before the cgroup move.
      This is undesirable, because it inherits the systemd affinity when the container
      should really move to the container space cpus.
      See: https://issues.redhat.com/browse/OCPBUGS-15102   */
-  memset (&mask, 0xFF, sizeof (cpu_set_t));
-  ret = sched_setaffinity (pid, sizeof (mask), &mask);
+  memset (mask, 0xFF, sizeof (mask));
+  ret = sched_setaffinity (pid, sizeof (mask), mask);
   if (UNLIKELY (ret < 0))
     return crun_make_error (err, errno, "sched_setaffinity");
   return 0;

--- a/src/libcrun/scheduler.c
+++ b/src/libcrun/scheduler.c
@@ -253,7 +253,7 @@ libcrun_set_cpu_affinity_from_string (pid_t pid, const char *str, libcrun_error_
 
   alloc_size = CPU_ALLOC_SIZE (bitmask_size * CHAR_BIT);
 
-  cpuset = CPU_ALLOC (alloc_size);
+  cpuset = CPU_ALLOC (bitmask_size * CHAR_BIT);
   if (UNLIKELY (cpuset == NULL))
     OOM ();
 


### PR DESCRIPTION
Two independent fixes in `src/libcrun/scheduler.c`.

**1. Affinity reset is broken on systems with more than 1024 CPUs**

`libcrun_reset_cpu_affinity_mask` used a plain `cpu_set_t`, which only covers
1024 CPUs. On a bigger system, when the container cgroup only allows CPUs
above that limit (say, `cpuset.cpus` is `1024-1030`), the mask has no CPU in
common with the allowed set and the container fails to start with:

    sched_setaffinity: Invalid argument

Use a 64K bit mask instead. The kernel truncates the mask to its own cpumask
size, so a mask larger than the number of CPUs on the system is harmless,
while a mask that is too small breaks as described above.

**2. Buffer overflow in `libcrun_set_cpu_affinity_from_string`**

`CPU_ALLOC` takes the number of CPUs, but it was passed `alloc_size`, the
already converted byte count. This allocates a set `CHAR_BIT` times smaller
than needed, so the following `CPU_ZERO_S` and `CPU_SET_S` calls write past
the end of the buffer once the CPU numbers in the affinity string exceed the
size of the allocation. The string comes from `process.execCPUAffinity` in the
OCI config, and `cpuset_string_to_bitmask` only limits it to `1 << 20`, without
checking it against the CPUs that are actually present -- so this is reachable
on any machine, e.g. with `execCPUAffinity` set to `0-2000`.

No tests included. The second one is reproducible anywhere under ASan; the
first one needs a system with more than 1024 CPUs, where it was verified
manually. Happy to add a test case for the second one if wanted.

Fixes: RHEL-248536
