### PR TITLE
ci: run the test suite under the address and undefined behaviour sanitizers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,6 +64,7 @@ jobs:
           - test: disable-systemd
           - test: check
           - test: check-no-openat2
+          - test: check-sanitizers
           - test: check-systemd
           - test: enable-shared
           - test: embedded-blake3
@@ -96,7 +97,7 @@ jobs:
 
           sudo add-apt-repository -y ppa:criu/ppa
           # add-apt-repository runs apt-get update so we don't have to.
-          sudo apt-get install -q -y criu automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget libsystemd-dev gperf clang-format libjson-c-dev containerd runc libasan6 libprotobuf-c-dev mawk python3-dev lua5.4 liblua5.4-dev
+          sudo apt-get install -q -y criu automake libtool autotools-dev libseccomp-dev git make libcap-dev cmake pkg-config gcc wget libsystemd-dev gperf clang-format libjson-c-dev containerd runc libasan6 libubsan1 libprotobuf-c-dev mawk python3-dev lua5.4 liblua5.4-dev
           # Fedora (used by maintainers as well as for packaging) has newer
           # md2man than in Ubuntu, so we have to install it from source.
           GOBIN=~/.local/bin go install github.com/cpuguy83/go-md2man/v2@latest

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,22 +88,24 @@ libcrun_SOURCES += src/libcrun/blake3/blake3.c \
 endif
 
 libcrun_la_SOURCES = $(libcrun_SOURCES)
-libcrun_la_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -fvisibility=hidden
+libcrun_la_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -fvisibility=hidden $(SANITIZER_CFLAGS)
 if ENABLE_COVERAGE
 libcrun_la_CFLAGS += $(COVERAGE_CFLAGS)
-libcrun_la_LDFLAGS = -Wl,--version-script=$(abs_top_srcdir)/libcrun.lds $(COVERAGE_LDFLAGS)
+libcrun_la_LDFLAGS = -Wl,--version-script=$(abs_top_srcdir)/libcrun.lds $(COVERAGE_LDFLAGS) $(SANITIZER_LDFLAGS)
 else
-libcrun_la_LDFLAGS = -Wl,--version-script=$(abs_top_srcdir)/libcrun.lds
+libcrun_la_LDFLAGS = -Wl,--version-script=$(abs_top_srcdir)/libcrun.lds $(SANITIZER_LDFLAGS)
 endif
 libcrun_la_LIBADD = libocispec/libocispec.la $(FOUND_LIBS) $(JSON_C_LIBS)
 
 # build a version with all the symbols visible for testing
 if BUILD_TESTS
 libcrun_testing_la_SOURCES = $(libcrun_SOURCES)
-libcrun_testing_la_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -fvisibility=default
+libcrun_testing_la_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -fvisibility=default $(SANITIZER_CFLAGS)
 if ENABLE_COVERAGE
 libcrun_testing_la_CFLAGS += $(COVERAGE_CFLAGS)
-libcrun_testing_la_LDFLAGS = $(COVERAGE_LDFLAGS)
+libcrun_testing_la_LDFLAGS = $(COVERAGE_LDFLAGS) $(SANITIZER_LDFLAGS)
+else
+libcrun_testing_la_LDFLAGS = $(SANITIZER_LDFLAGS)
 endif
 libcrun_testing_la_LIBADD = libocispec/libocispec.la $(JSON_C_LIBS)
 endif
@@ -148,7 +150,7 @@ dist-luarock: $(LUACRUN_ROCK)
 
 endif
 
-crun_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -D CRUN_LIBDIR="\"$(CRUN_LIBDIR)\""
+crun_CFLAGS = $(WARN_CFLAGS) -I $(abs_top_builddir)/libocispec/src -I $(abs_top_srcdir)/libocispec/src $(JSON_C_CFLAGS) -D CRUN_LIBDIR="\"$(CRUN_LIBDIR)\"" $(SANITIZER_CFLAGS)
 if ENABLE_COVERAGE
 crun_CFLAGS += $(COVERAGE_CFLAGS)
 endif
@@ -158,16 +160,16 @@ crun_SOURCES = src/crun.c src/run.c src/delete.c src/kill.c src/pause.c src/unpa
 
 if DYNLOAD_LIBCRUN
 if ENABLE_COVERAGE
-crun_LDFLAGS = -Wl,--unresolved-symbols=ignore-all $(CRUN_LDFLAGS) $(COVERAGE_LDFLAGS)
+crun_LDFLAGS = -Wl,--unresolved-symbols=ignore-all $(CRUN_LDFLAGS) $(COVERAGE_LDFLAGS) $(SANITIZER_LDFLAGS)
 else
-crun_LDFLAGS = -Wl,--unresolved-symbols=ignore-all $(CRUN_LDFLAGS)
+crun_LDFLAGS = -Wl,--unresolved-symbols=ignore-all $(CRUN_LDFLAGS) $(SANITIZER_LDFLAGS)
 endif
 else
 crun_LDADD = libcrun.la $(FOUND_LIBS) $(JSON_C_LIBS)
 if ENABLE_COVERAGE
-crun_LDFLAGS = $(CRUN_LDFLAGS) $(COVERAGE_LDFLAGS)
+crun_LDFLAGS = $(CRUN_LDFLAGS) $(COVERAGE_LDFLAGS) $(SANITIZER_LDFLAGS)
 else
-crun_LDFLAGS = $(CRUN_LDFLAGS)
+crun_LDFLAGS = $(CRUN_LDFLAGS) $(SANITIZER_LDFLAGS)
 endif
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -455,6 +455,24 @@ AS_IF([test "x$enable_coverage" = "xyes"], [
 
 AM_CONDITIONAL([ENABLE_COVERAGE], [test "x$enable_coverage" = "xyes"])
 
+dnl address and undefined behaviour sanitizers
+AC_ARG_ENABLE([sanitizers],
+	AS_HELP_STRING([--enable-sanitizers], [Build with the address and undefined behaviour sanitizers (for testing only)]),
+	[enable_sanitizers=$enableval], [enable_sanitizers=no])
+
+AS_IF([test "x$enable_sanitizers" = "xyes"], [
+	dnl Without -fno-sanitize-recover the undefined behaviour sanitizer only
+	dnl prints what it finds and lets the program carry on, so a test suite
+	dnl run would stay green no matter what it reported.
+	SANITIZER_CFLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g"
+	SANITIZER_LDFLAGS="-fsanitize=address -fsanitize=undefined"
+])
+
+dnl Substituted unconditionally, and empty unless --enable-sanitizers was
+dnl given, so that the flags can simply be appended where they are needed.
+AC_SUBST([SANITIZER_CFLAGS])
+AC_SUBST([SANITIZER_LDFLAGS])
+
 AC_SEARCH_LIBS([argp_parse], [argp], [], [AC_MSG_ERROR([*** argp functions not found - install libargp or argp_standalone])])
 
 AM_CONDITIONAL([PYTHON_BINDINGS], [test "x$with_python_bindings" = "xyes"])

--- a/src/exec.c
+++ b/src/exec.c
@@ -299,7 +299,7 @@ crun_command_exec (struct crun_global_arguments *global_args, int argc, char **a
       if (exec_options.cap_size > 0)
         {
           runtime_spec_schema_config_schema_process_capabilities *capabilities
-              = xmalloc (sizeof (runtime_spec_schema_config_schema_process_capabilities));
+              = xmalloc0 (sizeof (runtime_spec_schema_config_schema_process_capabilities));
 
           capabilities->effective = exec_options.cap;
           capabilities->effective_len = exec_options.cap_size;

--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -1039,7 +1039,7 @@ static int
 write_cpu_resources (int dirfd_cpu, bool cgroup2, runtime_spec_schema_config_linux_resources_cpu *cpu,
                      libcrun_error_t *err)
 {
-  int len, period_len;
+  int len, period_len = 0;
   int ret;
   char fmt_buf[64];
   int64_t period = -1;

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -97,6 +97,21 @@ check)
     group "tests as rootless in a user namespace" \
         unshare -r make check ASAN_OPTIONS=detect_leaks=false || dump_log
     ;;
+check-sanitizers)
+    # Run the test suite against a build with the address and undefined
+    # behaviour sanitizers.  The run as root and the rootless one reach
+    # different code -- cgroup setup, the mount handling and the user
+    # namespace paths above all -- so both are worth doing under them.
+    sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+    build --disable-dl --enable-sanitizers
+
+    group "tests as root, sanitizers" \
+        sudo make check ASAN_OPTIONS=detect_leaks=false \
+        UBSAN_OPTIONS=print_stacktrace=1 || dump_log
+    group "tests as rootless, sanitizers" \
+        make check ASAN_OPTIONS=detect_leaks=false \
+        UBSAN_OPTIONS=print_stacktrace=1 || dump_log
+    ;;
 check-no-openat2)
     # Run the test suite with openat2(2) forced to fail with
     # ENOSYS, so that the safe_openat() fallback used on kernels

--- a/tests/fuzzing/run-tests.sh
+++ b/tests/fuzzing/run-tests.sh
@@ -6,18 +6,29 @@ TIMEOUT=${TIMEOUT:=10}
 RUN_TIME=${RUN_TIME:=600}
 VERBOSITY=${VERBOSITY:=}
 
-N_TESTS=9
+N_TESTS=10
 
 SINGLE_RUN_TIME=$((RUN_TIME / N_TESTS))
 
 CORPUS=${CORPUS:=/testcases}
 
+# Upper bound on the number of crash artifacts replayed by verify_crashes.
+MAX_VERIFY=${MAX_VERIFY:=200}
+
+FUZZER=tests/tests_libcrun_fuzzer
+
 git config --global --add safe.directory /crun
 git clean -fdx
 ./autogen.sh
-./configure --enable-embedded-blake3 HFUZZ_CC_UBSAN=1 HFUZZ_CC_ASAN=1 CC=hfuzz-clang CPPFLAGS="-D FUZZER" CFLAGS="-ggdb3 -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-div,indirect-calls"
+# hfuzz-clang decides whether to add the sanitizers by looking these up with
+# getenv(2) as it compiles, so they have to be in the environment of the
+# build.  Passed to configure instead, they only ever reached configure
+# itself, and the sanitizers were silently left out of the whole build.
+export HFUZZ_CC_ASAN=1 HFUZZ_CC_UBSAN=1
+
+./configure --enable-embedded-blake3 CC=hfuzz-clang CPPFLAGS="-D FUZZER" CFLAGS="-ggdb3 -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-div,indirect-calls"
 make -j "$(nproc)"
-make -j "$(nproc)" tests/tests_libcrun_fuzzer
+make -j "$(nproc)" "$FUZZER"
 
 mkdir rootfs
 mkdir random-data
@@ -27,13 +38,105 @@ function run_test {
     TEST_CASE=$2
 
     # shellcheck disable=SC2086
-    result=$(honggfuzz --exit_upon_crash $VERBOSITY --run_time "$SINGLE_RUN_TIME" --timeout "$TIMEOUT" -T -i "$TEST_CASE" -- tests/tests_libcrun_fuzzer 2>&1 | tail -n 2)
+    result=$(honggfuzz --exit_upon_crash $VERBOSITY --run_time "$SINGLE_RUN_TIME" --timeout "$TIMEOUT" -T -i "$TEST_CASE" -- "$FUZZER" 2>&1 | tail -n 2)
     echo "$result"
     echo "$result" | grep -q crashes_count:0
 }
 
-run_test 0 "$CORPUS"/config-json
-run_test 1 "$CORPUS"/config-json
+# Replay crash artifacts, one per process, with the sanitizers told to write
+# a report for anything they catch.  A genuine memory error in crun is
+# reported by ASan/UBSan, which are still live in the process that hits it.
+# A container process killed after execve() has left the sanitizer runtime
+# behind with the rest of its address space and produces nothing.  Fail only
+# on the former.
+function verify_crashes {
+    local crashdir=$1
+    local logdir="$crashdir/replay"
+    local list ordered artifact out rc n=0 failed=0
+
+    rm -rf "$logdir"
+    mkdir -p "$logdir"
+
+    # De-duplicate by content: honggfuzz stamps the pid and the time into the
+    # names of the artifacts it cannot unwind, so the same input shows up
+    # again and again under different names.
+    list=$(find "$crashdir" -maxdepth 1 -type f -name '*.fuzz' -print0 |
+        xargs -0 -r sha256sum | sort -u -k1,1 | cut -d' ' -f3-)
+
+    if test -z "$list"; then
+        echo "no crash artifacts for mode $FUZZING_MODE"
+        return 0
+    fi
+
+    # Replay the ones honggfuzz managed to unwind first: a zero stack hash is
+    # the signature of a process that died with its address space already
+    # gone, which is what the noise looks like.
+    ordered=$({
+        grep -v '\.STACK\.0\.' <<<"$list" || true
+        grep '\.STACK\.0\.' <<<"$list" || true
+    } | head -n "$MAX_VERIFY")
+
+    while read -r artifact; do
+        test -n "$artifact" || continue
+
+        n=$((n + 1))
+        out="$logdir/$n"
+        mkdir -p "$out"
+
+        rc=0
+        env FUZZING_MODE="$FUZZING_MODE" \
+            ASAN_OPTIONS="handle_segv=1:abort_on_error=1:detect_leaks=0:log_path=$out/san" \
+            UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1:log_path=$out/san" \
+            timeout -s KILL "$TIMEOUT" "$FUZZER" "$artifact" >"$out/output" 2>&1 || rc=$?
+
+        # 137 is the SIGKILL from timeout(1): the replay hung, which the
+        # fuzzing run reports separately as a timeout, not as a crash.
+        if test "$rc" -ne 0 && test "$rc" -ne 137 && test "$rc" -ne 124; then
+            echo "REPRODUCED: $artifact exited with $rc"
+            failed=1
+        fi
+
+        # The sanitizers cannot always create the log file -- a report from
+        # inside the container is written after pivot_root(2), where the path
+        # no longer resolves -- so check the captured output as well.
+        if compgen -G "$out/san.*" >/dev/null ||
+            grep -qE 'ERROR: (Address|Undefined|Leak|Memory)Sanitizer|runtime error:' "$out/output"; then
+            echo "REPRODUCED: $artifact, sanitizer report:"
+            cat "$out"/san.* "$out/output" 2>/dev/null || true
+            failed=1
+        fi
+    done <<<"$ordered"
+
+    echo "mode $FUZZING_MODE: $(wc -l <<<"$list") unique artifacts, $n replayed, failed=$failed"
+    test "$failed" -eq 0
+}
+
+# Modes 0 and 1 fork and run a real container, and cannot be judged by the
+# crash counter honggfuzz prints.  honggfuzz attaches with
+# PTRACE_O_TRACEFORK, so every process the container spawns is traced too,
+# and any of them dying from a signal is recorded as a crash of the target --
+# including the ones that are supposed to die: killed by the fuzzed seccomp
+# profile, killed by the kernel because a fuzzed rlimit made execve() fail
+# past the point of no return, or killed by the runtime itself during
+# cleanup.  None of honggfuzz's filters help: the crash counter is
+# incremented before the stackhash blocklist is consulted, and --verifier
+# gives up on a crash it could not unwind.  So run to completion and let
+# verify_crashes decide.
+function run_container_test {
+    export FUZZING_MODE=$1
+    TEST_CASE=$2
+    CRASH_DIR="crashes-$FUZZING_MODE"
+
+    mkdir -p "$CRASH_DIR"
+
+    # shellcheck disable=SC2086
+    honggfuzz $VERBOSITY --run_time "$SINGLE_RUN_TIME" --timeout "$TIMEOUT" -T --crashdir "$CRASH_DIR" -i "$TEST_CASE" -- "$FUZZER" 2>&1 | tail -n 2
+
+    verify_crashes "$CRASH_DIR"
+}
+
+run_container_test 0 "$CORPUS"/config-json
+run_container_test 1 "$CORPUS"/config-json
 run_test 2 "$CORPUS"/seccomp
 run_test 3 "$CORPUS"/signals
 run_test 4 "$CORPUS"/paths

--- a/tests/tests_libcrun_fuzzer.c
+++ b/tests/tests_libcrun_fuzzer.c
@@ -31,8 +31,10 @@
 #include <string.h>
 #include <signal.h>
 #include <fcntl.h>
+#include <errno.h>
 #include <limits.h>
 #include <sys/prctl.h>
+#include <sys/wait.h>
 
 static int test_mode = -1;
 
@@ -311,6 +313,32 @@ test_parse_idmapped_mounts (uint8_t *buf, size_t len)
   return 0;
 }
 
+/* The harness is a subreaper, so everything the container leaves behind is
+   reparented here.  Reap it before returning: a process that outlives its
+   iteration has its death attributed to whatever input runs next, which
+   makes the artifacts point at the wrong test case.  Bounded, because a
+   container process is under no obligation to ever exit.  */
+static void
+reap_children (void)
+{
+  int i;
+
+  for (i = 0; i < 1000; i++)
+    {
+      int status;
+      pid_t pid;
+
+      pid = waitpid (-1, &status, WNOHANG);
+      if (pid > 0)
+        continue;
+      if (pid < 0 && errno == ECHILD)
+        return;
+
+      /* Children exist, none has exited yet.  */
+      usleep (1000);
+    }
+}
+
 static int
 run_one_container (uint8_t *buf, size_t len, bool detach)
 {
@@ -359,6 +387,8 @@ run_one_container (uint8_t *buf, size_t len, bool detach)
     crun_error_release (&err);
   if (libcrun_container_delete (&ctx, container->container_def, id, true, &err) < 0)
     crun_error_release (&err);
+
+  reap_children ();
   return 0;
 }
 
@@ -462,16 +492,6 @@ LLVMFuzzerTestOneInput (uint8_t *buf, size_t len)
   return 0;
 }
 
-static void
-sig_chld (int sig arg_unused)
-{
-  int status;
-  pid_t p;
-  do
-    p = waitpid (-1, &status, WNOHANG);
-  while (p > 0);
-}
-
 int
 main (int argc, char **argv)
 {
@@ -481,7 +501,10 @@ main (int argc, char **argv)
 
   if (prctl (PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) < 0)
     libcrun_fail_with_error (1, "%s", "cannot set subreaper");
-  signal (SIGCHLD, sig_chld);
+
+  /* Children are reaped synchronously by reap_children(), not from a
+     SIGCHLD handler: the handler used to consume the status of the very
+     processes libcrun_container_run() is waiting for.  */
 
   if (argc > 1)
     {


### PR DESCRIPTION
Run the test suite under the address and undefined behaviour sanitizers.

Nothing did so far: the check jobs already pass `ASAN_OPTIONS` to every
`make check`, but nothing was ever built with a sanitizer, so the variable --
and the `libasan6` the workflow installs -- did nothing. The only sanitizer
build is the fuzzing one, which covers what the fuzzing targets reach and
nothing else.

Four commits, the first two being what turning it on immediately found:

1. `exec:` the capabilities structure was allocated with `xmalloc` and every
   field filled in except the `_residual` json_object pointer, which the
   generated free function hands to `json_object_put`. glibc happens to return
   zeroed memory there; with the sanitizer's allocator
   `crun exec --cap CAP_KILL` segfaults on exit, after the exec succeeded.
2. `cgroup:` `-Werror` fails the sanitizer build on a `maybe-uninitialized`
   that gcc only sees once the sanitizers change what it inlines. The warning
   is wrong -- `period_len` is only read when `period_str` is set, and they are
   set together -- but the build has to pass.
3. `build: add --enable-sanitizers`. The flags go into their own substituted
   variables appended to the per-target flags, the way `--enable-coverage`
   does, rather than into `CFLAGS`. In `CFLAGS` they would reach `tests/init`,
   which is linked statically, and they would make the configure check for a
   working `-static` fail, which silently disables the entire test suite.
   Note `-fno-sanitize-recover`: without it UBSan only prints and the suite
   stays green regardless.
4. `ci: add a check-sanitizers job`, root and rootless -- the two reach
   different code, cgroup setup and the mount and user namespace paths above
   all.

The new job passes. The `testing-farm` failures are unrelated; they fail on
every PR right now.
