### PR TITLE
utils: fall back to uid_map on OpenVZ

### DIFF
--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -794,37 +794,33 @@ check_running_in_user_namespace (libcrun_error_t *err)
     return ret;
 
   ret = stat ("/proc/self/ns/user", &st);
-  if (UNLIKELY (ret < 0))
+  if (ret == 0)
     {
-      /* If the file does not exist, then the kernel does not support user namespaces and we for sure aren't in one.  */
-      if (errno == ENOENT)
+      /* The inode is definitive when it matches.  OpenVZ virtualizes the
+         namespace inode numbers exposed through procfs, so a mismatch must fall
+         back to the uid_map detection there.  */
+      if (st.st_ino == PROC_USER_INIT_INO)
         {
           run_in_userns = 0;
           return run_in_userns;
         }
-      return crun_make_error (err, errno, "stat `/proc/self/ns/user`");
+
+      if (! running_in_openvz ())
+        {
+          run_in_userns = 1;
+          return run_in_userns;
+        }
     }
+  else if (UNLIKELY (errno != ENOENT))
+    return crun_make_error (err, errno, "stat `/proc/self/ns/user`");
 
-  /* The inode is definitive when it matches.  OpenVZ virtualizes the namespace
-     inode numbers exposed through procfs, so a mismatch must fall back to the
-     uid_map detection there.  */
-  if (st.st_ino == PROC_USER_INIT_INO)
-    {
-      run_in_userns = 0;
-      return run_in_userns;
-    }
+  /* Kernels older than 3.8 do not expose the user namespace here even though
+     they can still support user namespaces, so the uid_map is all we have.  */
+  ret = check_running_in_user_namespace_uid_map (err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
-  if (running_in_openvz ())
-    {
-      ret = check_running_in_user_namespace_uid_map (err);
-      if (UNLIKELY (ret < 0))
-        return ret;
-
-      run_in_userns = ret;
-      return run_in_userns;
-    }
-
-  run_in_userns = 1;
+  run_in_userns = ret;
   return run_in_userns;
 }
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -745,6 +745,43 @@ crun_dir_p (const char *path, bool nofollow, libcrun_error_t *err)
   return crun_dir_p_at (AT_FDCWD, path, nofollow, err);
 }
 
+/* Detect the user namespace from the mapping in /proc/self/uid_map.  It cannot
+   tell apart the initial user namespace from a user namespace with a full
+   identity mapping, so it is used only as a fallback.  */
+static int
+check_running_in_user_namespace_uid_map (libcrun_error_t *err)
+{
+  cleanup_free char *buffer = NULL;
+  size_t len;
+  int ret;
+
+  ret = read_all_file ("/proc/self/uid_map", &buffer, &len, err);
+  if (UNLIKELY (ret < 0))
+    {
+      /* If the file does not exist, then the kernel does not support user namespaces and we for sure aren't in one.  */
+      if (crun_error_get_errno (err) == ENOENT)
+        {
+          crun_error_release (err);
+          return 0;
+        }
+      return ret;
+    }
+
+  return strstr (buffer, "4294967295") ? 0 : 1;
+}
+
+/* OpenVZ exposes /proc/vz both on the host and inside containers, while
+   /proc/bc is only exposed on the host.  This follows systemd's OpenVZ
+   detection.  */
+static bool
+running_in_openvz ()
+{
+  if (access ("/proc/vz", F_OK) < 0)
+    return false;
+
+  return access ("/proc/bc", F_OK) < 0 && errno == ENOENT;
+}
+
 int
 check_running_in_user_namespace (libcrun_error_t *err)
 {
@@ -768,7 +805,26 @@ check_running_in_user_namespace (libcrun_error_t *err)
       return crun_make_error (err, errno, "stat `/proc/self/ns/user`");
     }
 
-  run_in_userns = st.st_ino == PROC_USER_INIT_INO ? 0 : 1;
+  /* The inode is definitive when it matches.  OpenVZ virtualizes the namespace
+     inode numbers exposed through procfs, so a mismatch must fall back to the
+     uid_map detection there.  */
+  if (st.st_ino == PROC_USER_INIT_INO)
+    {
+      run_in_userns = 0;
+      return run_in_userns;
+    }
+
+  if (running_in_openvz ())
+    {
+      ret = check_running_in_user_namespace_uid_map (err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+
+      run_in_userns = ret;
+      return run_in_userns;
+    }
+
+  run_in_userns = 1;
   return run_in_userns;
 }
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -51,6 +51,7 @@
 #  include <stdatomic.h>
 #else
 #  define atomic_long volatile long
+#  define atomic_int volatile int
 #endif
 #include "syscalls.h"
 
@@ -747,7 +748,7 @@ crun_dir_p (const char *path, bool nofollow, libcrun_error_t *err)
 int
 check_running_in_user_namespace (libcrun_error_t *err)
 {
-  static int run_in_userns = -1;
+  static atomic_int run_in_userns = -1;
   struct stat st;
   int ret;
 


### PR DESCRIPTION
Commit d73e66c34012 ("utils: detect initial user namespace by inode") changed check_running_in_user_namespace() to compare the inode of /proc/self/ns/user against PROC_USER_INIT_INO, so that a user namespace with a full identity mapping -- such as the one systemd >= 260 sets up for PrivateUsers=full -- is no longer mistaken for the initial one.

OpenVZ virtualizes the namespace inode numbers it exposes through procfs, so PROC_USER_INIT_INO does not identify the initial user namespace there and the new check regressed the detection inside OpenVZ containers.  This was reported for moby, which made the same change, by Sebastiaan van Stijn in https://github.com/containers/crun/issues/2150, along with the suggestion to special-case OpenVZ the way moby/sys#255 does:

  https://github.com/moby/sys/pull/255

Detect OpenVZ with the same procfs test systemd uses -- /proc/vz is exposed both on the host and inside a container, /proc/bc only on the host -- and fall back to the uid_map heuristic there.  The inode check stays the preferred path everywhere else.