### PR TITLE
Do not crash on a null in the configuration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -339,6 +339,7 @@ PYTHON_TESTS = tests/test_capabilities.py \
 	tests/test_net_device.py \
 	tests/test_cgroup_resources.py \
 	tests/test_error_handling.py \
+	tests/test_null_config_values.py \
 	tests/test_custom_handler.py
 
 if BUILD_STATIC_TESTS

--- a/src/exec.c
+++ b/src/exec.c
@@ -277,9 +277,10 @@ crun_command_exec (struct crun_global_arguments *global_args, int argc, char **a
       process = xmalloc0 (sizeof (*process));
       int i;
 
-      process->args_len = argc;
-      process->args = xmalloc0 ((argc + 1) * sizeof (*process->args));
-      for (i = 0; i < argc - first_arg; i++)
+      /* argv[first_arg] is the container id, the command follows it.  */
+      process->args_len = argc - first_arg - 1;
+      process->args = xmalloc0 ((process->args_len + 1) * sizeof (*process->args));
+      for (i = 0; i < (int) process->args_len; i++)
         process->args[i] = xstrdup (argv[first_arg + i + 1]);
       process->args[i] = NULL;
       if (exec_options.cwd)

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -508,6 +508,11 @@ gen_annotations (json_gen_ctx *gen, json_map_string_string *annotations)
 
   for (i = 0; i < annotations->len; i++)
     {
+      /* An annotation whose value is null in the document is parsed into a
+         NULL, which cannot be emitted as a JSON string; leave it out.  */
+      if (annotations->keys[i] == NULL || annotations->values[i] == NULL)
+        continue;
+
       GEN_STR (gen, annotations->keys[i]);
       GEN_STR (gen, annotations->values[i]);
     }
@@ -851,8 +856,15 @@ setup_environment (runtime_spec_schema_config_schema *def, uid_t container_uid, 
       size_t i;
 
       for (i = 0; i < def->process->env_len; i++)
-        if (putenv (def->process->env[i]) < 0)
-          return crun_make_error (err, errno, "putenv `%s`", def->process->env[i]);
+        {
+          /* A null element of the array of variables is parsed into a NULL,
+             which putenv(3) cannot be handed.  */
+          if (def->process->env[i] == NULL)
+            return crun_make_error (err, EINVAL, "environment variable is not specified");
+
+          if (putenv (def->process->env[i]) < 0)
+            return crun_make_error (err, errno, "putenv `%s`", def->process->env[i]);
+        }
     }
 
   if (getenv ("HOME") == NULL)

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -784,7 +784,14 @@ get_mount_flags_or_option (const char *name, int current_flags, unsigned long *e
 {
   int found;
   __attribute__ ((unused)) cleanup_free char *prev = NULL;
-  unsigned long flags = get_mount_flags (name, current_flags, &found, extra_flags, rec_clear, rec_set);
+  unsigned long flags;
+
+  /* A null element of the array of options in the configuration is parsed
+     into a NULL, which is not an option to be honored.  */
+  if (name == NULL)
+    return 0;
+
+  flags = get_mount_flags (name, current_flags, &found, extra_flags, rec_clear, rec_set);
   if (found)
     {
       /* MS_SYNCHRONOUS and MS_DIRSYNC cannot be set through fsmount()
@@ -1087,7 +1094,7 @@ mount_option_exists (runtime_spec_schema_defs_mount *mnt, const char *option)
 {
   size_t i;
   for (i = 0; i < mnt->options_len; i++)
-    if (strcmp (mnt->options[i], option) == 0)
+    if (mnt->options[i] != NULL && strcmp (mnt->options[i], option) == 0)
       return true;
   return false;
 }
@@ -3684,7 +3691,7 @@ mount_inherits_mountpoint_mode (runtime_spec_schema_defs_mount *mount)
     return false;
 
   for (i = 0; i < mount->options_len; i++)
-    if (has_prefix (mount->options[i], "mode="))
+    if (mount->options[i] != NULL && has_prefix (mount->options[i], "mode="))
       return false;
 
   return true;
@@ -4732,6 +4739,11 @@ libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err)
       int ret;
       char *it;
 
+      /* A sysctl whose value is null in the document is parsed into a NULL,
+         and there is nothing to write to the file.  */
+      if (def->linux->sysctl->keys[i] == NULL || def->linux->sysctl->values[i] == NULL)
+        return crun_make_error (err, EINVAL, "sysctl value is not specified");
+
       name = xstrdup (def->linux->sysctl->keys[i]);
       for (it = name; *it; it++)
         if (*it == '.')
@@ -5283,6 +5295,9 @@ is_bind_mount (runtime_spec_schema_defs_mount *mnt, bool *recursive, bool *src_n
 
   for (i = 0; i < mnt->options_len; i++)
     {
+      if (mnt->options[i] == NULL)
+        continue;
+
       if (strcmp (mnt->options[i], "bind") == 0)
         {
           ret = true;
@@ -5315,6 +5330,9 @@ get_idmapped_option (runtime_spec_schema_defs_mount *mnt, bool *recursive)
 
   for (i = 0; i < mnt->options_len; i++)
     {
+      if (mnt->options[i] == NULL)
+        continue;
+
       if (has_prefix (mnt->options[i], "idmap"))
         {
           *recursive = false;

--- a/src/libcrun/scheduler.c
+++ b/src/libcrun/scheduler.c
@@ -209,6 +209,9 @@ libcrun_set_scheduler (pid_t pid, runtime_spec_schema_config_schema_process *pro
     {
       char *key = process->scheduler->flags[s];
 
+      if (key == NULL)
+        return crun_make_error (err, EINVAL, "scheduler flag is not specified");
+
       if (strcmp (key, "SCHED_FLAG_RESET_ON_FORK") == 0)
         attr.sched_flags |= SCHED_FLAG_RESET_ON_FORK;
       else if (strcmp (key, "SCHED_FLAG_RECLAIM") == 0)

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -249,6 +249,9 @@ libcrun_apply_seccomp (int infd, int listener_receiver_fd, const char *receiver_
       size_t i = 0;
       for (i = 0; i < seccomp_flags_len; i++)
         {
+          if (seccomp_flags[i] == NULL)
+            return crun_make_error (err, EINVAL, "seccomp flag is not specified");
+
           if (strcmp (seccomp_flags[i], "SECCOMP_FILTER_FLAG_TSYNC") == 0)
             flags |= SECCOMP_FILTER_FLAG_TSYNC;
           else if (strcmp (seccomp_flags[i], "SECCOMP_FILTER_FLAG_SPEC_ALLOW") == 0)
@@ -754,6 +757,9 @@ libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_err
       char *end, lowercase_arch[32] = {
         0,
       };
+
+      if (arch == NULL)
+        return crun_make_error (err, EINVAL, "seccomp architecture is not specified");
 
       if (has_prefix (arch, "SCMP_ARCH_"))
         arch += 10;

--- a/tests/test_null_config_values.py
+++ b/tests/test_null_config_values.py
@@ -1,0 +1,155 @@
+#!/bin/env python3
+# crun - OCI runtime written in C
+#
+# Copyright (C) 2017, 2018, 2019 Giuseppe Scrivano <giuseppe@scrivano.org>
+# crun is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# crun is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with crun.  If not, see <http://www.gnu.org/licenses/>.
+
+# A null in the configuration where a string is expected is parsed into a
+# NULL pointer, since a NULL is how a field that is not present is
+# represented.  Every place walking such a value has to cope with it, so
+# put a null in each string of a configuration, one at a time, and check
+# that crun says what is wrong instead of dying.
+#
+# Built with the sanitizers, this also catches the undefined behavior of
+# handing a NULL to a function declared not to take one.
+
+import copy
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from tests_utils import *
+
+
+def full_config():
+    """A configuration touching as many string-valued fields as possible."""
+    conf = base_config()
+    add_all_namespaces(conf)
+
+    conf['process']['args'] = ['/init', 'true']
+    conf['process']['env'] = ['PATH=/bin', 'TERM=xterm']
+    conf['process']['scheduler'] = {'policy': 'SCHED_OTHER',
+                                    'flags': ['SCHED_FLAG_RESET_ON_FORK']}
+    conf['process']['rlimits'] = [{'type': 'RLIMIT_NOFILE', 'hard': 1024, 'soft': 1024}]
+    conf['annotations'] = {'run.oci.a': '1', 'org.systemd.property.CPUWeight': '100'}
+    conf['hooks'] = {
+        'createRuntime': [{'path': '/bin/true', 'args': ['true', 'x'], 'env': ['A=1']}],
+        'poststop': [{'path': '/bin/true', 'args': ['true', 'y'], 'env': ['B=2']}],
+    }
+    conf['linux']['sysctl'] = {'net.ipv4.ip_forward': '0'}
+    conf['linux']['resources'] = {'unified': {'memory.high': 'max'}}
+    conf['linux']['seccomp'] = {
+        'defaultAction': 'SCMP_ACT_ALLOW',
+        'architectures': ['SCMP_ARCH_X86_64'],
+        'flags': ['SECCOMP_FILTER_FLAG_LOG'],
+        'syscalls': [{'names': ['mkdir', 'rmdir'], 'action': 'SCMP_ACT_ERRNO'}],
+    }
+    return conf
+
+
+def walk_strings(node, path=''):
+    """Yield (path, container, key) for every string in the structure."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            p = '%s.%s' % (path, k) if path else k
+            if isinstance(v, str):
+                yield p, node, k
+            else:
+                yield from walk_strings(v, p)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            p = '%s[%d]' % (path, i)
+            if isinstance(v, str):
+                yield p, node, i
+            else:
+                yield from walk_strings(v, p)
+
+
+def run_config(conf, cid, root, bundle):
+    """Run a container to completion, return (returncode, output)."""
+    with open(os.path.join(bundle, 'config.json'), 'w') as f:
+        json.dump(conf, f)
+
+    # The output goes to a file rather than a pipe: the container process
+    # inherits stderr, so reading a pipe to the end of file would wait for
+    # the container itself.
+    log = os.path.join(bundle, 'out.log')
+    with open(log, 'w+b') as lf:
+        p = subprocess.run([get_crun_path(), '--root', root, 'run', '--bundle', bundle, cid],
+                           stdout=lf, stderr=lf, stdin=subprocess.DEVNULL,
+                           timeout=60, close_fds=False)
+
+    with open(log, 'rb') as lf:
+        out = lf.read().decode(errors='replace')
+
+    subprocess.run([get_crun_path(), '--root', root, 'delete', '-f', cid],
+                   capture_output=True, close_fds=False)
+    return p.returncode, out
+
+
+def test_null_config_values():
+    with tempfile.TemporaryDirectory() as bundle:
+        root = os.path.join(bundle, 'state')
+        os.makedirs(os.path.join(bundle, 'rootfs'))
+        shutil.copy(get_init_path(), os.path.join(bundle, 'rootfs', 'init'))
+
+        conf = full_config()
+
+        # A configuration that does not run makes the whole test vacuous.
+        rc, out = run_config(copy.deepcopy(conf), 'null-base', root, bundle)
+        if rc != 0:
+            logger.info("the unmodified configuration does not run (rc %d): %s", rc, out)
+            return -1
+
+        paths = [p for p, _, _ in walk_strings(conf)]
+        logger.info("checking a null in each of %d strings", len(paths))
+
+        failed = []
+        for n, (path, _, _) in enumerate(walk_strings(conf)):
+            variant = copy.deepcopy(conf)
+            for p, holder, key in walk_strings(variant):
+                if p == path:
+                    holder[key] = None
+                    break
+
+            rc, out = run_config(variant, 'null-%d' % n, root, bundle)
+
+            # A negative code is death by a signal, and the sanitizers say so
+            # in the output.  Without them, a container process that died on a
+            # NULL leaves the runtime with a broken channel and no error of
+            # its own, which is what the remaining markers are about.
+            crashed = (rc < 0
+                       or 'runtime error:' in out
+                       or 'Sanitizer' in out
+                       or 'read from the init process' in out
+                       or 'read FD: connection closed' in out
+                       or 'sync socket: Broken pipe' in out)
+            if crashed:
+                logger.info("null in %s: rc %d, output: %s", path, rc, out[:400])
+                failed.append(path)
+
+        if failed:
+            logger.info("crashed on a null in: %s", ', '.join(failed))
+            return -1
+
+    return 0
+
+
+all_tests = {
+    "null-config-values": test_null_config_values,
+}
+
+if __name__ == "__main__":
+    tests_main(all_tests)


### PR DESCRIPTION
A JSON null where the configuration expects a string is parsed into a NULL
pointer, which is how libocispec represents a field that is not present.
The code walking these values took a C string for granted, so a document
that is merely invalid, rather than malicious, killed the runtime:

```console
$ jq '.mounts[1].options' config.json
[
  "nosuid",
  null
]
$ crun run nullopt
Segmentation fault (core dumped)
```

The first commit is an unrelated bug found on the way: the array of
arguments built for `crun exec` was one element too long, and its length
counted the crun arguments along with the command.

The second commit checks for a NULL where such a value is used, and what
it does depends on what the value means. An option of a mount is
free-form, so a null one is skipped, as an option that is not there; a
value that selects a behavior -- a seccomp flag or architecture, a
scheduler flag, an environment variable, a sysctl -- is rejected with
EINVAL, the way an unknown value in the same place already is; an
annotation whose value is null is left out of the state, which cannot hold
a null. Five of the loops over the options of a mount go through
`get_mount_flags_or_option()`, so the check for those lives there.

The third commit is a test that builds a configuration touching as many
string-valued fields as possible and puts a null in each of its strings in
turn -- 87 of them as it stands -- expecting the runtime to report what is
wrong instead of dying. On the tree before the fix it names 37 offending
fields.

A container process that dies on a NULL leaves the runtime with a broken
channel and no error of its own, which is what the test looks for besides
a signal. Built with the sanitizers, the same test also reports the
undefined behavior of handing a NULL to a function declared not to take
one, which is how two of the fields (`process.scheduler.flags` and
`linux.sysctl`) turned up.

The first case came from the fuzzer; a two hour run of all ten targets on
this branch, with ASan and UBSan, found nothing.
