### PR TITLE
seccomp: validate the argument indices once per syscall entry

### DIFF
--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -920,7 +920,9 @@ libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_err
                       arg_cmp[k].datum_b = seccomp->syscalls[i]->args[k]->value_two;
                     }
 
-                  ret = seccomp_rule_add_array (ctx, action, syscall, args_len, arg_cmp);
+                  /* An empty "args" array means the rule is unconditional.  Do not
+                     hand over the uninitialized buffer for it.  */
+                  ret = seccomp_rule_add_array (ctx, action, syscall, args_len, args_len ? arg_cmp : NULL);
                   if (UNLIKELY (ret < 0))
                     return crun_make_error (err, -ret, "seccomp_rule_add_array");
                 }

--- a/src/libcrun/seccomp.c
+++ b/src/libcrun/seccomp.c
@@ -819,6 +819,7 @@ libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_err
   for (i = 0; i < seccomp->syscalls_len; i++)
     {
       size_t j;
+      bool multiple_args = false;
       int errno_ret = EPERM;
 
       if (seccomp->syscalls[i]->errno_ret_present)
@@ -834,6 +835,27 @@ libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_err
 
       if (action == default_action)
         continue;
+
+      /* The argument indices do not depend on the syscall name, so validate
+         them once per entry.  Doing it here also makes an invalid index an
+         error even when every name below is unknown and skipped.  */
+      if (seccomp->syscalls[i]->args != NULL)
+        {
+          uint32_t count[6] = {};
+          size_t k;
+
+          for (k = 0; k < seccomp->syscalls[i]->args_len; k++)
+            {
+              uint32_t index = seccomp->syscalls[i]->args[k]->index;
+
+              if (index >= 6)
+                return crun_make_error (err, 0, "invalid seccomp index `%u`", index);
+
+              count[index]++;
+              if (count[index] > 1)
+                multiple_args = true;
+            }
+        }
 
       for (j = 0; j < seccomp->syscalls[i]->names_len; j++)
         {
@@ -857,21 +879,6 @@ libcrun_generate_seccomp (struct libcrun_seccomp_gen_ctx_s *gen_ctx, libcrun_err
           else
             {
               size_t k;
-              bool multiple_args = false;
-              uint32_t count[6] = {};
-
-              for (k = 0; k < seccomp->syscalls[i]->args_len; k++)
-                {
-                  uint32_t index;
-
-                  index = seccomp->syscalls[i]->args[k]->index;
-                  if (index >= 6)
-                    return crun_make_error (err, 0, "invalid seccomp index `%u`", index);
-
-                  count[index]++;
-                  if (count[index] > 1)
-                    multiple_args = true;
-                }
 
               /* If multiple rules refer to the same argument, treat the rules are in OR.  */
               if (multiple_args)

--- a/tests/test_seccomp.py
+++ b/tests/test_seccomp.py
@@ -637,6 +637,60 @@ def test_seccomp_operator_missing_prefix():
 
     return run_and_expect_error(conf, ["seccomp get operator", "EQ"])
 
+def test_seccomp_invalid_arg_index():
+    """An argument index outside the 0-5 range must be rejected."""
+    conf = base_config()
+    add_all_namespaces(conf)
+
+    conf['linux']['seccomp'] = {
+        'defaultAction': 'SCMP_ACT_ALLOW',
+        'syscalls': [
+            {
+                'names': ['socket'],
+                'action': 'SCMP_ACT_ERRNO',
+                'errnoRet': 1,
+                'args': [
+                    {'index': 0, 'value': 1, 'op': 'SCMP_CMP_EQ'},
+                    {'index': 0, 'value': 2, 'op': 'SCMP_CMP_EQ'},
+                    {'index': 9, 'value': 3, 'op': 'SCMP_CMP_EQ'},
+                ]
+            }
+        ]
+    }
+
+    conf['process']['args'] = ['/init', 'true']
+
+    return run_and_expect_error(conf, ["invalid seccomp index `9`"])
+
+
+def test_seccomp_invalid_arg_index_unknown_syscall():
+    """An invalid argument index is reported even when the name is unknown.
+
+    Unknown syscall names are skipped with a warning, so the arguments have to
+    be validated independently of them, otherwise the bad index goes unnoticed.
+    """
+    conf = base_config()
+    add_all_namespaces(conf)
+
+    conf['linux']['seccomp'] = {
+        'defaultAction': 'SCMP_ACT_ALLOW',
+        'syscalls': [
+            {
+                'names': ['crun_no_such_syscall'],
+                'action': 'SCMP_ACT_ERRNO',
+                'errnoRet': 1,
+                'args': [
+                    {'index': 9, 'value': 3, 'op': 'SCMP_CMP_EQ'},
+                ]
+            }
+        ]
+    }
+
+    conf['process']['args'] = ['/init', 'true']
+
+    return run_and_expect_error(conf, ["invalid seccomp index `9`"])
+
+
 def test_seccomp_invalid_flag():
     """An unknown seccomp filter flag must be rejected."""
     conf = base_config()
@@ -671,6 +725,8 @@ all_tests = {
     "seccomp-action-missing-prefix": test_seccomp_action_missing_prefix,
     "seccomp-invalid-operator": test_seccomp_invalid_operator,
     "seccomp-operator-missing-prefix": test_seccomp_operator_missing_prefix,
+    "seccomp-invalid-arg-index": test_seccomp_invalid_arg_index,
+    "seccomp-invalid-arg-index-unknown-syscall": test_seccomp_invalid_arg_index_unknown_syscall,
     "seccomp-invalid-flag": test_seccomp_invalid_flag,
 }
 


### PR DESCRIPTION
Two small follow-ups to #2220.

### 1. Validate the argument indices once per syscall entry

The loop that checks the argument indices and detects repeated ones does not depend on the syscall name, yet it sits inside the loop over `names[]`, so it is repeated for every name of the entry.

More importantly, unknown syscall names are skipped with a warning *before* that loop is reached, so an out of range index went unnoticed whenever every name of the entry happened to be unknown to libseccomp:

```json
{"names": ["no_such_syscall"], "args": [{"index": 9, "value": 3, "op": "SCMP_CMP_EQ"}]}
```

was accepted silently, while the same `args` next to a known name was correctly rejected with ``invalid seccomp index `9` ``. A typo in a syscall name hid a second error right next to it.

Hoisting the validation to the entry level makes it run once and independently of name resolution:

| config | before | after |
|---|---|---|
| bad index, known name | ``invalid seccomp index `9` `` | ``invalid seccomp index `9` `` |
| bad index, unknown name | accepted silently | ``invalid seccomp index `9` `` |
| bad index, unknown name, no duplicate | accepted silently | ``invalid seccomp index `9` `` |
| good index, unknown name | accepted (warning) | accepted (warning) |

The last row matters: an unknown name with sane arguments is still just a warning, the behaviour is not tightened. `annotation-seccomp-fail-unknown-syscall` still passes, so the `LIBCRUN_SECCOMP_FAIL_UNKNOWN_SYSCALL` path is unaffected.

Two tests are added; `seccomp-invalid-arg-index-unknown-syscall` fails without the change.

### 2. Do not pass an uninitialized buffer for an empty rule

An `"args"` array that is present but empty leaves the local `arg_cmp[]` untouched and hands it to `seccomp_rule_add_array()` with a count of 0. libseccomp does not look at the buffer in that case, so the rule is correctly added as unconditional, but passing uninitialized memory is gratuitous and trips up tooling that tracks it. Pass NULL when there is nothing to point at.

---

`tests/test_seccomp.py` passes 21/21, and an empty `"args"` array still produces an unconditional rule.
