### PR TITLE
checkpoint: fix masked directories with a non-default root

### DIFF
--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -4233,6 +4233,11 @@ libcrun_container_checkpoint (libcrun_context_t *context, const char *id, libcru
   ret = read_container_config_from_state (&container, state_root, id, err);
   if (UNLIKELY (ret < 0))
     return ret;
+
+  /* Needed to use the same paths (e.g. the shared empty directory used for
+     masked paths) as the container runtime and restore do.  */
+  container->context = context;
+
   ret = libcrun_container_checkpoint_linux (&status, container, cr_options, err);
   if (UNLIKELY (ret < 0))
     return ret;

--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -284,6 +284,20 @@ def test_cr():
     return run_cr_test(conf)
 
 
+def test_cr_masked_paths():
+    if r := _check_cr_requirements():
+        return r
+
+    conf = base_config()
+    conf['process']['args'] = ['/init', 'pause']
+    add_all_namespaces(conf)
+    # Both a directory and a file.  A masked directory is a bind mount of a
+    # shared empty directory under the state root, which is an external
+    # mount for CRIU, and must be found under the same key on restore.
+    conf['linux']['maskedPaths'] = ['/sys/firmware', '/proc/kcore']
+    return run_cr_test(conf)
+
+
 def test_cr_with_ext_ns():
     if r := _check_cr_requirements(min_criu_version=31601):
         return r
@@ -404,6 +418,7 @@ def test_cr_with_annotation_config():
 
 all_tests = {
     "checkpoint-restore": test_cr,
+    "checkpoint-restore-masked-paths": test_cr_masked_paths,
     "checkpoint-restore-ext-ns": test_cr_with_ext_ns,
     "checkpoint-restore-pre-dump": test_cr_pre_dump,
     "checkpoint-restore-with-runc-config": test_cr_with_runc_config,


### PR DESCRIPTION
A masked directory is a bind mount of a shared empty directory, which lives under the state root. As it is an external mount for CRIU, it is registered with a key which is the path of that directory, both on checkpoint and restore.

On checkpoint, `container->context` is not set, so the default state root is used instead of the one set by `--root`. As a result, restore fails with something like:

```
Error (criu/mount.c:3141): mnt: No mapping for 420:(null) mountpoint
```

This was broken since the shared empty directory is registered with CRIU (commit d8a88c06, which fixed the regression from 4004e5be, #1859), i.e. since crun 1.24. The crun tests did not catch this as they do not use masked paths; runc integration tests do (found in #2238).

Set `container->context` on checkpoint, like it is done for other operations, and add a test case.

Fixes: d8a88c06 ("criu: checkpoint correctly the shared empty directory path")