### PR TITLE
restore: fix --manage-cgroups-mode, put CRIU into the container cgroup

### DIFF
--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -1037,6 +1037,66 @@ libcrun_move_process_to_cgroup (pid_t pid, pid_t init_pid, const char *path, boo
   return enter_cgroup (cgroup_mode, pid, init_pid, path, create_if_missing, err);
 }
 
+/* Move the current process to the cgroups listed in CONTENT, as read from
+   /proc/self/cgroup earlier.  Used to undo libcrun_move_process_to_cgroup.  */
+int
+libcrun_move_self_to_cgroups (const char *content, libcrun_error_t *err)
+{
+  cleanup_free char *buf = xstrdup (content);
+  char *saveptr = NULL;
+  char *controller;
+  char *path;
+  int cgroup_mode;
+  bool has_data;
+  int ret;
+
+  cgroup_mode = libcrun_get_cgroup_mode (err);
+  if (UNLIKELY (cgroup_mode < 0))
+    return cgroup_mode;
+
+  for (has_data = read_proc_cgroup (buf, &saveptr, NULL, &controller, &path);
+       has_data;
+       has_data = read_proc_cgroup (NULL, &saveptr, NULL, &controller, &path))
+    {
+      const char *subsystem = NULL;
+
+      if (cgroup_mode == CGROUP_MODE_UNIFIED)
+        {
+          /* Ignore named v1 hierarchies, if any.  */
+          if (controller[0] != '\0')
+            continue;
+        }
+      else
+        {
+          cleanup_free char *subsystem_path = NULL;
+
+          /* Use the same names as enter_cgroup_v1 does.  */
+          if (has_prefix (controller, "name="))
+            controller += 5;
+          subsystem = controller[0] == '\0' ? "unified" : controller;
+          if (strcmp (subsystem, "net_prio,net_cls") == 0)
+            subsystem = "net_cls,net_prio";
+          if (strcmp (subsystem, "cpuacct,cpu") == 0)
+            subsystem = "cpu,cpuacct";
+
+          ret = append_paths (&subsystem_path, err, CGROUP_ROOT, subsystem, NULL);
+          if (UNLIKELY (ret < 0))
+            return ret;
+          ret = crun_path_exists (subsystem_path, err);
+          if (UNLIKELY (ret < 0))
+            return ret;
+          if (ret == 0)
+            continue;
+        }
+
+      ret = move_process_to_cgroup (0, subsystem, path, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
+    }
+
+  return 0;
+}
+
 int
 libcrun_get_cgroup_dirfd (struct libcrun_cgroup_status *status, const char *sub_cgroup, libcrun_error_t *err)
 {

--- a/src/libcrun/cgroup-utils.h
+++ b/src/libcrun/cgroup-utils.h
@@ -24,6 +24,8 @@
 
 int libcrun_move_process_to_cgroup (pid_t pid, pid_t init_pid, const char *path, bool create_if_missing, libcrun_error_t *err);
 
+int libcrun_move_self_to_cgroups (const char *content, libcrun_error_t *err);
+
 int libcrun_cgroups_create_symlinks (int dirfd, libcrun_error_t *err);
 
 int libcrun_get_cgroup_process (pid_t pid, char **path, bool absolute, libcrun_error_t *err);

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -4394,8 +4394,11 @@ libcrun_container_restore (libcrun_context_t *context, const char *id, libcrun_c
         if (UNLIKELY (ret < 0))
           return ret;
 
-        /* Use the container first process PID to setup the cgroup.  */
+        /* Use the container first process PID to setup the cgroup.  The
+           restored processes are already in the cgroup, as CRIU was run
+           there, and the controllers were enabled by precreate_cgroup.  */
         cg.pid = status.pid;
+        cg.joined = true;
       }
     else
       {

--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -946,6 +946,20 @@ prepare_restore_mounts (runtime_spec_schema_config_schema *def, char *root, libc
   return 0;
 }
 
+/* Move the current process back to CGROUPS, as read from /proc/self/cgroup.
+   A failure is not fatal, so only warn about it.  */
+static void
+move_back_to_cgroups (const char *cgroups)
+{
+  libcrun_error_t tmp_err = NULL;
+
+  if (UNLIKELY (libcrun_move_self_to_cgroups (cgroups, &tmp_err) < 0))
+    {
+      libcrun_warning ("cannot move back to the original cgroup: %s", tmp_err->msg);
+      crun_error_release (&tmp_err);
+    }
+}
+
 int
 libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcrun_container_t *container,
                                       libcrun_checkpoint_restore_t *cr_options, libcrun_error_t *err)
@@ -957,6 +971,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
   cleanup_close int image_fd = -1;
   cleanup_free char *root = NULL;
   cleanup_free char *bundle_cleanup = NULL;
+  cleanup_free char *own_cgroups = NULL;
   cleanup_close int work_fd = -1;
   int ret_out;
   size_t i;
@@ -1276,10 +1291,34 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
       goto out_umount;
     }
 
+  /* Like runc does, put CRIU into the container cgroup for the time of
+   * restore, so the restored tasks are created there. It is necessary in
+   * the "ignore" mode, where CRIU does not deal with cgroups at all, and
+   * does not hurt otherwise. As CRIU is our child, do it by moving
+   * ourselves there, and move back once the restore is done. */
+  if (! is_empty_string (status->cgroup_path))
+    {
+      ret = read_all_file (PROC_SELF_CGROUP, &own_cgroups, NULL, err);
+      if (UNLIKELY (ret < 0))
+        goto out_umount;
+
+      ret = libcrun_move_process_to_cgroup (0, 0, status->cgroup_path, false, err);
+      if (UNLIKELY (ret < 0))
+        {
+          /* Some of the cgroups might have been joined already.  */
+          move_back_to_cgroups (own_cgroups);
+          goto out_umount;
+        }
+    }
+
   /* criu_restore() returns the PID of the process of the restored process
    * tree. This PID will not be the same as status->pid if the container is
    * running in a PID namespace. But it will always be > 0. */
   ret = libcriu_wrapper->criu_restore_child ();
+
+  if (own_cgroups)
+    move_back_to_cgroups (own_cgroups);
+
   if (UNLIKELY (ret <= 0))
     {
       show_criu_log (cr_options->work_path, CRIU_RESTORE_LOG_FILE);

--- a/src/restore.c
+++ b/src/restore.c
@@ -166,6 +166,8 @@ crun_command_restore (struct crun_global_arguments *global_args, int argc, char 
   int first_arg;
   int ret;
 
+  cr_options.manage_cgroups_mode = -1;
+
   argp_parse (&run_argp, argc, argv, ARGP_IN_ORDER, &first_arg, &cr_options);
   crun_assert_n_args (argc - first_arg, 1, 2);
 
@@ -195,8 +197,6 @@ crun_command_restore (struct crun_global_arguments *global_args, int argc, char 
   ret = init_libcrun_context (&crun_context, argv[first_arg], global_args, err);
   if (UNLIKELY (ret < 0))
     return ret;
-
-  cr_options.manage_cgroups_mode = -1;
 
   if (cr_options.image_path == NULL)
     {


### PR DESCRIPTION
1. restore: put CRIU into the container cgroup

   In the "ignore" cgroup mode CRIU does not deal with cgroups at all, so the restored tasks end up in the cgroup of CRIU itself, i.e. that of crun. With cgroupfs, crun then moves the container init into the container cgroup, but it is too late: other container processes (restored or forked by init in the meantime, as CRIU has already resumed the tasks) stay behind. With systemd, it does not work at all: the scope is left with no processes and is removed, and the container is reported as stopped.

   Do what runc does: always put CRIU into the container cgroup for the time of restore, so that the restored tasks are created there. As CRIU is a child of crun, do it by moving crun itself, and move it back once the restore is done.

   As a result, moving the container init into the (pre-created) cgroup after the restore is no longer needed, so skip it, like it is done for a container created with CLONE_INTO_CGROUP.

2. restore: fix --manage-cgroups-mode

   The default value for `manage_cgroups_mode` is set after the command line options are parsed, overriding whatever is set by `--manage-cgroups-mode`. As a result, `crun restore` always uses the "soft" mode. In particular, restoring into a different cgroup with "ignore" mode fails with something like:

   ```
   Error (criu/cgroup.c:1187): cg: Can't move 1 into unified//old/cgroup.procs (-1/-1): No such file or directory
   Error (criu/cgroup.c:1245): cg: couldn't set cgns prefix unified//old/cgroup.procs: No such file or directory
   Error (criu/cgroup.c:1338): cg: failed preparing cgns
   ```

   Set the default before parsing the options, like `crun checkpoint` does.

   Fixes: c954b1b6 ("criu: use a process to initialize the cgroup")

Found by the runc integration tests (see #2238): "checkpoint then restore into a different cgroup (via --manage-cgroups-mode ignore)", and, once the second fix makes the ignore mode actually work, most of the checkpoint tests with the systemd cgroup manager.

Confirmed by the runc integration tests in #2238.

