### PR TITLE
cgroup: destroy the cgroup if its setup fails

### DIFF
--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -359,20 +359,31 @@ libcrun_cgroup_enter (struct libcrun_cgroup_args *args, struct libcrun_cgroup_st
         {
           ret = chown_cgroups (status->path, root_uid, root_gid, err);
           if (UNLIKELY (ret < 0))
-            return ret;
+            goto fail_destroy;
         }
 
       if (args->resources)
         {
           ret = update_cgroup_resources (status->path, args->state_root, args->resources, ! status->bpf_dev_set, err);
           if (UNLIKELY (ret < 0))
-            return ret;
+            goto fail_destroy;
         }
     }
 success:
   *out = status;
   status = NULL;
   return 0;
+
+fail_destroy:
+  /* The cgroup is created, but the caller does not get its status, so it
+     cannot destroy it.  Do it here, so it is not left behind.  */
+  {
+    libcrun_error_t tmp_err = NULL;
+
+    if (UNLIKELY (cgroup_manager->destroy_cgroup (status, &tmp_err) < 0))
+      crun_error_release (&tmp_err);
+  }
+  return ret;
 }
 
 int


### PR DESCRIPTION
If `libcrun_cgroup_enter` fails after the cgroup has been created (e.g. setting a resource limit fails because of an invalid value), it returns an error without the cgroup status, so the caller has nothing to destroy and the cgroup is left behind.

For example, `crun run` with an invalid CPU period correctly fails, but leaves an empty cgroup, which in turn makes it impossible to remove its parent.

Destroy the cgroup in such case. If the cgroup creation itself fails, it is not destroyed, as it might be pre-existing.

Found by the "set cpu period with no quota (invalid period)" runc integration test (see #2238), with a check added to runc tests that the container cgroup is removed (opencontainers/runc#5455).