### PR TITLE
cgroup: refuse to run in a frozen cgroup

### DIFF
--- a/src/libcrun/cgroup-cgroupfs.c
+++ b/src/libcrun/cgroup-cgroupfs.c
@@ -64,6 +64,12 @@ libcrun_precreate_cgroup_cgroupfs (struct libcrun_cgroup_args *args, int *dirfd,
 
   *dirfd = -1;
 
+  /* The container process is created directly in the cgroup, so check it
+     now: once it is there, it is too late.  */
+  ret = libcrun_cgroup_ensure_not_frozen (sub_path, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
   ret = append_paths (&cgroup_path, err, CGROUP_ROOT, sub_path, NULL);
   if (UNLIKELY (ret < 0))
     return ret;
@@ -108,6 +114,7 @@ libcrun_cgroup_enter_cgroupfs (struct libcrun_cgroup_args *args, struct libcrun_
 {
   pid_t pid = args->pid;
   int cgroup_mode;
+  int ret;
 
   cgroup_mode = libcrun_get_cgroup_mode (err);
   if (UNLIKELY (cgroup_mode < 0))
@@ -122,8 +129,6 @@ libcrun_cgroup_enter_cgroupfs (struct libcrun_cgroup_args *args, struct libcrun_
 
   if (cgroup_mode == CGROUP_MODE_UNIFIED)
     {
-      int ret;
-
       ret = enable_controllers (out->path, err);
       if (UNLIKELY (ret < 0))
         {
@@ -151,6 +156,10 @@ libcrun_cgroup_enter_cgroupfs (struct libcrun_cgroup_args *args, struct libcrun_
             return ret;
         }
     }
+
+  ret = libcrun_cgroup_ensure_not_frozen (out->path, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
 
   return enter_cgroup (cgroup_mode, pid, 0, out->path, true, err);
 }

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -2037,6 +2037,7 @@ libcrun_cgroup_enter_systemd (struct libcrun_cgroup_args *args,
 {
   runtime_spec_schema_config_linux_resources *resources = args->resources;
   const char *cgroup_path = args->cgroup_path;
+  cleanup_free char *scope_path = NULL;
   cleanup_free char *scope = NULL;
   cleanup_free char *path = NULL;
   cleanup_free char *slice = NULL;
@@ -2085,25 +2086,31 @@ libcrun_cgroup_enter_systemd (struct libcrun_cgroup_args *args,
   if (UNLIKELY (ret < 0))
     return ret;
 
-  /* Verify that systemd has actually installed the eBPF device filter if one was requested. */
+  /* Remove the suffix that was added by systemd_finalize.  */
+  if (is_empty_string (suffix))
+    scope_path = xstrdup (path);
+  else
+    {
+      size_t path_len = strlen (path);
+      size_t suffix_len = strlen (suffix);
+
+      scope_path = strndup (path, path_len - suffix_len - 1);
+      if (UNLIKELY (scope_path == NULL))
+        OOM ();
+    }
+
+  /* The cgroup path is chosen by systemd, so it cannot be checked before
+     the container process is moved there.  Check the scope, as the
+     sub-cgroup is created by us, and would appear not frozen even if
+     the scope is.  */
+  ret = libcrun_cgroup_ensure_not_frozen (scope_path, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  /* Verify that systemd has actually installed the eBPF device filter if one was requested.
+     eBPF programs are attached to the systemd scope, not the subgroup.  */
   if (out->bpf_dev_set)
     {
-      cleanup_free char *scope_path = NULL;
-
-      /* eBPF programs are attached to the systemd scope, not the subgroup.
-         Remove the suffix that was added by systemd_finalize. */
-      if (is_empty_string (suffix))
-        scope_path = xstrdup (path);
-      else
-        {
-          size_t path_len = strlen (path);
-          size_t suffix_len = strlen (suffix);
-
-          scope_path = strndup (path, path_len - suffix_len - 1);
-          if (UNLIKELY (scope_path == NULL))
-            OOM ();
-        }
-
       ret = verify_ebpf_device_filter_installed (scope_path, err);
       if (UNLIKELY (ret < 0))
         return ret;

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -741,6 +741,53 @@ libcrun_cgroup_pause_unpause_path (const char *cgroup_path, const bool pause, li
   return libcrun_cgroup_pause_unpause_with_mode (cgroup_path, cgroup_mode, pause, err);
 }
 
+/* Fail if the cgroup at CGROUP_PATH exists and is frozen: a process in a
+   frozen cgroup cannot make any progress, so the container creation would
+   hang forever.  */
+int
+libcrun_cgroup_ensure_not_frozen (const char *cgroup_path, libcrun_error_t *err)
+{
+  cleanup_free char *content = NULL;
+  cleanup_free char *path = NULL;
+  const char *frozen;
+  int cgroup_mode;
+  int ret;
+
+  cgroup_mode = libcrun_get_cgroup_mode (err);
+  if (UNLIKELY (cgroup_mode < 0))
+    return cgroup_mode;
+
+  if (cgroup_mode == CGROUP_MODE_UNIFIED)
+    {
+      frozen = "1";
+      ret = append_paths (&path, err, CGROUP_ROOT, cgroup_path, "cgroup.freeze", NULL);
+    }
+  else
+    {
+      frozen = "FROZEN";
+      ret = append_paths (&path, err, CGROUP_ROOT "/freezer", cgroup_path, "freezer.state", NULL);
+    }
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  ret = read_all_file (path, &content, NULL, err);
+  if (UNLIKELY (ret < 0))
+    {
+      /* Either the cgroup does not exist yet, or there is no freezer.  */
+      if (crun_error_get_errno (err) == ENOENT)
+        {
+          crun_error_release (err);
+          return 0;
+        }
+      return ret;
+    }
+
+  if (strstr (content, frozen))
+    return crun_make_error (err, 0, "container's cgroup unexpectedly frozen");
+
+  return 0;
+}
+
 int
 cgroup_killall_path (const char *path, int signal, libcrun_error_t *err)
 {

--- a/src/libcrun/cgroup-utils.h
+++ b/src/libcrun/cgroup-utils.h
@@ -42,4 +42,6 @@ int destroy_cgroup_path (const char *path, int mode, libcrun_error_t *err);
 
 int get_cgroup_dirfd_path (int dirfd, char **path, libcrun_error_t *err);
 
+int libcrun_cgroup_ensure_not_frozen (const char *cgroup_path, libcrun_error_t *err);
+
 #endif


### PR DESCRIPTION
If the container cgroup already exists and is frozen, the container process cannot make any progress, and `crun run`/`crun create` hangs forever, with no indication of what is going on.

Refuse to use a frozen cgroup, like runc does:

- with cgroupfs, check it before the container process is put into the cgroup (for cgroup v2, it is created right in it by clone3 with `CLONE_INTO_CGROUP`, so the check must happen before that);
- with systemd, the cgroup path is only known after the scope is created, so check it right after that. Check the scope cgroup itself, not the sub-cgroup created by crun inside it, as the latter is not frozen on its own.

The error message is the same as in runc: `container's cgroup unexpectedly frozen`.

Found by the "runc run/create should refuse pre-existing frozen cgroup" runc integration test (see #2238; the test also needed a fix for systemd, see opencontainers/runc#5455).