### PR TITLE
exec: use systemd AttachProcessesToUnit as a fallback

### DIFF
--- a/src/libcrun/cgroup-internal.h
+++ b/src/libcrun/cgroup-internal.h
@@ -57,6 +57,9 @@ struct libcrun_cgroup_manager
   int (*destroy_cgroup) (struct libcrun_cgroup_status *cgroup_status, libcrun_error_t *err);
   /* Additional resources configuration specific to this manager.  */
   int (*update_resources) (struct libcrun_cgroup_status *cgroup_status, const char *state_root, runtime_spec_schema_config_linux_resources *resources, libcrun_error_t *err);
+  /* Move PID to the cgroup PATH (the container cgroup or its sub-cgroup) by
+     other means than writing to cgroup.procs.  Optional.  */
+  int (*attach_process) (struct libcrun_cgroup_status *cgroup_status, const char *path, pid_t pid, libcrun_error_t *err);
 };
 
 int move_process_to_cgroup (pid_t pid, const char *subsystem, const char *path, libcrun_error_t *err);

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -2274,6 +2274,53 @@ exit:
   return cleanup_sd_bus_and_return (bus, m, reply, &error, ret);
 }
 
+/* Ask systemd to move PID to PATH, which is either the container scope
+   cgroup or its sub-cgroup.  This works even when the caller has no write
+   access to the cgroup.procs file of the common ancestor of the source and
+   the destination cgroups, as it is the case for a rootless user in a login
+   session, which is outside of user@.service.  */
+static int
+libcrun_attach_process_systemd (struct libcrun_cgroup_status *cgroup_status,
+                                const char *path, pid_t pid,
+                                libcrun_error_t *err)
+{
+  const char *scope = cgroup_status->scope;
+  sd_bus_error error = SD_BUS_ERROR_NULL;
+  cleanup_free char *scope_path = NULL;
+  sd_bus_message *reply = NULL;
+  const char *subcgroup;
+  const char *last;
+  sd_bus *bus = NULL;
+  size_t len;
+  int sd_err, ret;
+
+  if (is_empty_string (scope))
+    return crun_make_error (err, 0, "cannot attach process to cgroup: no systemd scope");
+
+  /* The sub-cgroup is relative to the scope cgroup.  */
+  scope_path = get_cgroup_scope_path (path, scope);
+  if (scope_path == NULL)
+    return crun_make_error (err, 0, "cannot attach process to cgroup: empty path");
+  last = strrchr (scope_path, '/');
+  if (last == NULL || strcmp (last + 1, scope) != 0)
+    return crun_make_error (err, 0, "cannot find scope `%s` in cgroup path `%s`", scope, path);
+  len = strlen (scope_path);
+  subcgroup = path[len] ? path + len : "/";
+
+  ret = open_sd_bus_connection (&bus, err);
+  if (UNLIKELY (ret < 0))
+    return ret;
+
+  sd_err = sd_bus_call_method (bus, "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+                               "org.freedesktop.systemd1.Manager", "AttachProcessesToUnit",
+                               &error, &reply, "ssau", scope, subcgroup, 1, (uint32_t) pid);
+  if (UNLIKELY (sd_err < 0))
+    ret = crun_make_error (err, sd_bus_error_get_errno (&error), "sd-bus call AttachProcessesToUnit: %s",
+                           error.message ?: error.name);
+
+  return cleanup_sd_bus_and_return (bus, NULL, reply, &error, ret);
+}
+
 #else
 static int
 libcrun_cgroup_enter_systemd (struct libcrun_cgroup_args *args,
@@ -2307,6 +2354,18 @@ libcrun_update_resources_systemd (struct libcrun_cgroup_status *cgroup_status,
 
   return crun_make_error (err, ENOTSUP, "systemd not supported");
 }
+
+static int
+libcrun_attach_process_systemd (struct libcrun_cgroup_status *cgroup_status,
+                                const char *path, pid_t pid,
+                                libcrun_error_t *err)
+{
+  (void) cgroup_status;
+  (void) path;
+  (void) pid;
+
+  return crun_make_error (err, ENOTSUP, "systemd not supported");
+}
 #endif
 
 struct libcrun_cgroup_manager cgroup_manager_systemd = {
@@ -2314,4 +2373,5 @@ struct libcrun_cgroup_manager cgroup_manager_systemd = {
   .create_cgroup = libcrun_cgroup_enter_systemd,
   .destroy_cgroup = libcrun_destroy_cgroup_systemd,
   .update_resources = libcrun_update_resources_systemd,
+  .attach_process = libcrun_attach_process_systemd,
 };

--- a/src/libcrun/cgroup.c
+++ b/src/libcrun/cgroup.c
@@ -184,6 +184,46 @@ libcrun_cgroup_is_container_paused (struct libcrun_cgroup_status *status, bool *
 }
 
 int
+libcrun_cgroup_join_process (struct libcrun_cgroup_status *status, const char *path, pid_t pid, pid_t init_pid,
+                             libcrun_error_t *err)
+{
+  struct libcrun_cgroup_manager *cgroup_manager;
+  libcrun_error_t tmp_err = NULL;
+  int errno_;
+  int ret;
+
+  ret = libcrun_move_process_to_cgroup (pid, init_pid, path, false, err);
+  if (LIKELY (ret >= 0))
+    return ret;
+
+  /* Moving a process requires write access to cgroup.procs of the common
+     ancestor of the source and the destination cgroups, which the caller
+     may lack.  See if the cgroup manager can do it instead.  */
+  errno_ = crun_error_get_errno (err);
+  if (errno_ != EACCES && errno_ != EPERM)
+    return ret;
+
+  if (get_cgroup_manager (status->manager, &cgroup_manager, &tmp_err) < 0)
+    {
+      crun_error_release (&tmp_err);
+      return ret;
+    }
+  if (cgroup_manager->attach_process == NULL)
+    return ret;
+
+  if (UNLIKELY (cgroup_manager->attach_process (status, path, pid, &tmp_err) < 0))
+    {
+      /* Report the original error, as it is more relevant.  */
+      libcrun_debug ("Cannot attach pid %d to cgroup `%s`: %s", pid, path, tmp_err->msg);
+      crun_error_release (&tmp_err);
+      return ret;
+    }
+
+  crun_error_release (err);
+  return 0;
+}
+
+int
 libcrun_cgroup_read_pids (struct libcrun_cgroup_status *status, bool recurse, pid_t **pids, libcrun_error_t *err)
 {
   return libcrun_cgroup_read_pids_from_path (status->path, recurse, pids, err);

--- a/src/libcrun/cgroup.h
+++ b/src/libcrun/cgroup.h
@@ -103,6 +103,11 @@ int libcrun_update_cgroup_resources (struct libcrun_cgroup_status *status,
 
 int libcrun_cgroup_is_container_paused (struct libcrun_cgroup_status *status, bool *paused, libcrun_error_t *err);
 
+/* Move PID to the cgroup PATH, which is the container cgroup described by STATUS
+   or its sub-cgroup.  */
+int libcrun_cgroup_join_process (struct libcrun_cgroup_status *status, const char *path, pid_t pid, pid_t init_pid,
+                                 libcrun_error_t *err);
+
 int libcrun_cgroup_pause_unpause (struct libcrun_cgroup_status *status, const bool pause, libcrun_error_t *err);
 
 #endif

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -6465,24 +6465,19 @@ join_process_parent_helper (libcrun_context_t *context,
 
   if (need_move_to_cgroup)
     {
+      cleanup_cgroup_status struct libcrun_cgroup_status *cgroup_status = libcrun_cgroup_make_status (status);
+      cleanup_free char *final_cgroup = NULL;
+
       if (sub_cgroup)
         {
-          cleanup_free char *final_cgroup = NULL;
-
           ret = append_paths (&final_cgroup, err, status->cgroup_path, sub_cgroup, NULL);
           if (UNLIKELY (ret < 0))
             return ret;
+        }
 
-          ret = libcrun_move_process_to_cgroup (pid, status->pid, final_cgroup, false, err);
-          if (UNLIKELY (ret < 0))
-            return ret;
-        }
-      else
-        {
-          ret = libcrun_move_process_to_cgroup (pid, status->pid, status->cgroup_path, false, err);
-          if (UNLIKELY (ret < 0))
-            return ret;
-        }
+      ret = libcrun_cgroup_join_process (cgroup_status, final_cgroup ?: status->cgroup_path, pid, status->pid, err);
+      if (UNLIKELY (ret < 0))
+        return ret;
 
       /* Join the scheduler immediately after joining the cgroup.  */
       ret = libcrun_set_scheduler (pid, process, err);


### PR DESCRIPTION
Moving a process to a cgroup requires write access to `cgroup.procs` of the common ancestor of the source and the destination cgroups.

This is a problem for a rootless user running `crun exec` in a login session (e.g. via ssh), when the container is created with the systemd cgroup manager: the session scope is outside of `user@.service`, so the common ancestor is `user-$UID.slice`, owned by root. As a result, `crun exec` fails with:

```
write to `.../crun-ID.scope/container/cgroup.procs`: Permission denied
```

In such case, ask systemd to move the process by calling its `AttachProcessesToUnit` method (which is what runc does). The user systemd instance delegates the operation to the system one when it lacks privileges.

The fallback is only used if writing to `cgroup.procs` failed with `EACCES` or `EPERM`, so the common case is not affected.

Found by the runc integration tests (see #2238), where rootless tests with systemd are run via `ssh rootless@localhost`.