### PR TITLE
exec: use exit code 255 for exec failures, same paused error as runc

### DIFF
--- a/src/crun.c
+++ b/src/crun.c
@@ -53,6 +53,10 @@
 #include "mounts.h"
 #include "restore.h"
 
+/* crun exec exits with the exit code of the executed process, so use this
+   code for its own errors, to tell those apart (like runc and ssh do).  */
+#define EXIT_EXEC_FAILURE 255
+
 static struct crun_global_arguments arguments;
 
 static struct custom_handler_manager_s *handler_manager;
@@ -478,7 +482,14 @@ main (int argc, char **argv)
 
   ret = command->handler (&arguments, command_argc, command_argv, &err);
   if (ret && err)
-    libcrun_fail_with_error (err->status, "%s", err->msg);
+    {
+      if (command->value == COMMAND_EXEC)
+        {
+          libcrun_error (err->status, "%s", err->msg);
+          exit (EXIT_EXEC_FAILURE);
+        }
+      libcrun_fail_with_error (err->status, "%s", err->msg);
+    }
 
   return ret;
 }

--- a/src/libcrun/container.c
+++ b/src/libcrun/container.c
@@ -3623,7 +3623,7 @@ libcrun_container_exec_with_options (libcrun_context_t *context, const char *id,
   }
 
   if (UNLIKELY (container_paused))
-    return crun_make_error (err, 0, "the container `%s` is paused", id);
+    return crun_make_error (err, 0, "cannot exec in a paused container `%s`", id);
 
   ret = libcrun_configure_handler (context->handler_manager,
                                    context,

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -678,6 +678,18 @@ def test_exec_exit_code():
                 logger.info("test_exec_exit_code: expected exit code 42, got %d", e.returncode)
                 return -1
 
+        # Failures of exec itself use 255, to be told apart from the
+        # exit code of the executed process.
+        for args in [[cid, "/not.here"], ["no-such-container", "/init", "true"]]:
+            try:
+                run_crun_command_raw(["exec"] + args)
+                logger.info("test_exec_exit_code: expected exec %s to fail", args)
+                return -1
+            except subprocess.CalledProcessError as e:
+                if e.returncode != 255:
+                    logger.info("test_exec_exit_code: exec %s: expected exit code 255, got %d", args, e.returncode)
+                    return -1
+
         return 0
 
     except Exception as e:


### PR DESCRIPTION
1. exec: use exit code 255 for exec failures

   On success, `crun exec` exits with the exit code of the executed process. On failure of `crun exec` itself (e.g. no such container, no such executable), it exits with 1, and so the caller cannot tell it apart from the executed process exiting with 1.

   Use exit code of 255 for `crun exec` failures, like runc does since v1.1.0 (see opencontainers/runc#3073), which is the same convention as used by e.g. ssh. Add a test case.

   Note that podman (via conmon) does not rely on the `crun exec` exit code, as it gets the error details from conmon.

2. exec: use the same paused container error as runc

   When the container is paused, `crun exec` fails with ``the container `ID` is paused``, while runc uses `cannot exec in a paused container`. Use the latter (appending the container ID), as some tools and tests check for it.

Found by the "runc exec [exit codes]" and "runc exec should refuse a paused container" runc integration tests (see #2238).
