### PR TITLE
linux: fix idmapped bind mounts with a relative source

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -5426,7 +5426,7 @@ maybe_get_idmapped_mount (libcrun_container_t *container, runtime_spec_schema_co
 
   if (is_bind_mount (mnt, &recursive_bind_mount, &nofollow))
     {
-      newfs_fd = syscall_open_tree (-1, mnt->source, (recursive_bind_mount ? AT_RECURSIVE : 0) | AT_NO_AUTOMOUNT | (nofollow ? AT_SYMLINK_NOFOLLOW : 0) | OPEN_TREE_CLOEXEC | OPEN_TREE_CLONE);
+      newfs_fd = syscall_open_tree (AT_FDCWD, mnt->source, (recursive_bind_mount ? AT_RECURSIVE : 0) | AT_NO_AUTOMOUNT | (nofollow ? AT_SYMLINK_NOFOLLOW : 0) | OPEN_TREE_CLOEXEC | OPEN_TREE_CLONE);
       if (UNLIKELY (newfs_fd < 0))
         return crun_make_error (err, errno, "open `%s`", mnt->source);
     }

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -923,10 +923,6 @@ def test_idmapped_mounts_without_userns():
             f.write("")
         os.chown(target, 0, 0)
 
-        conf = base_config()
-        add_all_namespaces(conf, userns=False)
-        conf['process']['args'] = ['/init', 'owner', '/foo/file']
-
         mountMappings = [
             {
                 "containerID": 0,
@@ -935,18 +931,25 @@ def test_idmapped_mounts_without_userns():
             }
         ]
 
-        options = ["bind", "ro", "idmap"]
-        mount_opt = {"destination": "/foo", "type": "bind", "source": source_dir, "options": options}
-        mount_opt["uidMappings"] = mountMappings
-        mount_opt["gidMappings"] = mountMappings
+        # Test both an absolute and a relative (to the bundle, which is
+        # created in the tests root directory) source.
+        for source in [source_dir, os.path.join("..", os.path.basename(source_dir))]:
+            conf = base_config()
+            add_all_namespaces(conf, userns=False)
+            conf['process']['args'] = ['/init', 'owner', '/foo/file']
 
-        conf['mounts'].append(mount_opt)
-        out, _ = run_and_get_output(conf, hide_stderr=True)
+            options = ["bind", "ro", "idmap"]
+            mount_opt = {"destination": "/foo", "type": "bind", "source": source, "options": options}
+            mount_opt["uidMappings"] = mountMappings
+            mount_opt["gidMappings"] = mountMappings
 
-        if "1000:1000" not in out:
-            logger.info("idmap without userns test failed: expected '1000:1000' in output")
-            logger.info("actual output: %s", out)
-            return 1
+            conf['mounts'].append(mount_opt)
+            out, _ = run_and_get_output(conf, hide_stderr=True)
+
+            if "1000:1000" not in out:
+                logger.info("idmap without userns test failed (source %s): expected '1000:1000' in output", source)
+                logger.info("actual output: %s", out)
+                return 1
     finally:
         shutil.rmtree(source_dir)
 


### PR DESCRIPTION
For an idmapped bind mount, the source is opened by open_tree(2) with the dirfd of -1 rather than `AT_FDCWD`, so a relative source (which is relative to the bundle directory, where crun runs from) fails with:

```
open `source-1/`: Bad file descriptor
```

Use `AT_FDCWD`, and extend the "idmapped mounts without userns" test to also check a relative source.

This is broken since idmapped mounts were introduced in crun 1.5.

Found by the runc integration tests (all of `idmap.bats`, see #2238).

Fixes: b02a68d4 ("linux: honor mount mappings")
