### PR TITLE
fix two symlink flaws in the container device setup

### DIFF
--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -4038,6 +4038,11 @@ libcrun_do_pivot_root (libcrun_container_t *container, bool no_pivot, char **roo
   return 0;
 }
 
+/* Device number of the null device, as documented in
+ * Documentation/admin-guide/devices.txt.  */
+#define DEV_NULL_MAJOR 1
+#define DEV_NULL_MINOR 3
+
 /* If one of stdin, stdout, stderr are pointing to /dev/null on
  * the outside of the container, this moves it to /dev/null inside
  * of the container. This needs to run after pivot/chroot-ing. */
@@ -4050,18 +4055,21 @@ libcrun_reopen_dev_null (libcrun_error_t *err)
   int i;
 
   /* Open /dev/null inside of the container. */
-  fd = open ("/dev/null", O_RDWR | O_CLOEXEC);
+  fd = open ("/dev/null", O_RDWR | O_CLOEXEC | O_NOFOLLOW);
   if (UNLIKELY (fd == -1))
     return crun_make_error (err, errno, "open `/dev/null`");
 
   if (UNLIKELY (fstat (fd, &dev_null) == -1))
     return crun_make_error (err, errno, "stat `/dev/null`");
 
+  if (UNLIKELY (! S_ISCHR (dev_null.st_mode) || dev_null.st_rdev != makedev (DEV_NULL_MAJOR, DEV_NULL_MINOR)))
+    return crun_make_error (err, 0, "`/dev/null` is not the null device");
+
   for (i = 0; i <= 2; i++)
     {
       if (UNLIKELY (fstat (i, &statbuf) == -1))
         return crun_make_error (err, errno, "stat fd `%d`", i);
-      if (statbuf.st_rdev == dev_null.st_rdev)
+      if (S_ISCHR (statbuf.st_mode) && statbuf.st_rdev == dev_null.st_rdev)
         {
           /* This FD is pointing to /dev/null. Point it to /dev/null inside
            * of the container. */

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -201,7 +201,7 @@ get_file_type (mode_t *mode, bool nofollow, const char *path)
 int
 create_file_if_missing_at (int dirfd, const char *file, mode_t mode, libcrun_error_t *err)
 {
-  cleanup_close int fd_write = openat (dirfd, file, O_CLOEXEC | O_CREAT | O_WRONLY, mode);
+  cleanup_close int fd_write = openat (dirfd, file, O_CLOEXEC | O_CREAT | O_WRONLY | O_NOFOLLOW, mode);
   if (fd_write < 0)
     {
       int saved_errno = errno;
@@ -209,7 +209,7 @@ create_file_if_missing_at (int dirfd, const char *file, mode_t mode, libcrun_err
       int ret;
 
       /* On errors, check if the file already exists.  */
-      ret = get_file_type_at (dirfd, &tmp_mode, false, file);
+      ret = get_file_type_at (dirfd, &tmp_mode, true, file);
       if (ret == 0 && S_ISREG (tmp_mode))
         return 0;
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -399,6 +399,46 @@ def test_userns_precreated_devices_flags():
         return (77, "no precreated device mounts (mknod path taken)")
     return 0
 
+def test_dev_null_symlink_not_reopened():
+    host_file = os.path.join(get_tests_root(), "host-file")
+    with open(host_file, "w") as f:
+        f.write("host content")
+
+    fake_dev = os.path.join(get_tests_root(), "fake-dev")
+    os.makedirs(fake_dev)
+    os.symlink("/host-file", os.path.join(fake_dev, "null"))
+
+    conf = base_config()
+    add_all_namespaces(conf)
+    conf['process']['args'] = ['/init', 'echo', 'breakout']
+    conf['mounts'] = [i for i in conf['mounts'] if not i['destination'].startswith("/dev")]
+    conf['mounts'].append({"destination": "/host-file", "type": "bind",
+                           "source": host_file, "options": ["bind", "rw"]})
+    conf['mounts'].append({"destination": "/dev", "type": "bind",
+                           "source": fake_dev, "options": ["bind", "rw"]})
+
+    output = None
+    try:
+        run_and_get_output(conf)
+    except Exception as e:
+        output = e.output.decode()
+
+    with open(host_file) as f:
+        content = f.read()
+    if content != "host content":
+        logger.error("the host file was written through `/dev/null`: %s", content)
+        return -1
+
+    if output is None:
+        logger.error("the container was not refused")
+        return -1
+
+    if "open `/dev/null`" not in output:
+        logger.error("the container failed for a different reason: %s", output)
+        return -1
+
+    return 0
+
 def test_dev_symlink_does_not_populate_outside_rootfs():
     if is_rootless():
         return (77, "requires root privileges")
@@ -538,6 +578,7 @@ def test_allow_device_read_only():
 all_tests = {
     "mknod-fifo-device": test_mknod_fifo_device,
     "mknod-char-device": test_mknod_char_device,
+    "dev-null-symlink-not-reopened": test_dev_null_symlink_not_reopened,
     "dev-symlink-does-not-populate-outside-rootfs": test_dev_symlink_does_not_populate_outside_rootfs,
     "userns-precreated-devices-flags": test_userns_precreated_devices_flags,
     "allow-device-read-only": test_allow_device_read_only,

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -439,6 +439,41 @@ def test_dev_null_symlink_not_reopened():
 
     return 0
 
+def test_dev_console_symlink_does_not_escape_rootfs():
+    escaped = os.path.join(get_tests_root(), "escaped-console")
+
+    conf = base_config()
+    add_all_namespaces(conf)
+    conf['process']['terminal'] = True
+    conf['process']['args'] = ['/init', 'true']
+    conf['mounts'] = [i for i in conf['mounts'] if not i['destination'].startswith("/dev")]
+    # a hook forces the deferred pivot_root, so the rootfs is still reached
+    # through the host file system when the devices are created.
+    conf['hooks'] = {"createRuntime": [{"path": "/bin/true"}]}
+
+    def prepare_rootfs(rootfs):
+        os.symlink(escaped, os.path.join(rootfs, "dev", "console"))
+
+    output = None
+    try:
+        run_and_get_output(conf, callback_prepare_rootfs=prepare_rootfs)
+    except Exception as e:
+        output = e.output.decode()
+
+    if os.path.lexists(escaped):
+        logger.error("`%s` was created outside the rootfs", escaped)
+        return -1
+
+    if output is None:
+        logger.error("the container was not refused")
+        return -1
+
+    if "create file `console`" not in output:
+        logger.error("the container failed for a different reason: %s", output)
+        return -1
+
+    return 0
+
 def test_dev_symlink_does_not_populate_outside_rootfs():
     if is_rootless():
         return (77, "requires root privileges")
@@ -579,6 +614,7 @@ all_tests = {
     "mknod-fifo-device": test_mknod_fifo_device,
     "mknod-char-device": test_mknod_char_device,
     "dev-null-symlink-not-reopened": test_dev_null_symlink_not_reopened,
+    "dev-console-symlink-does-not-escape-rootfs": test_dev_console_symlink_does_not_escape_rootfs,
     "dev-symlink-does-not-populate-outside-rootfs": test_dev_symlink_does_not_populate_outside_rootfs,
     "userns-precreated-devices-flags": test_userns_precreated_devices_flags,
     "allow-device-read-only": test_allow_device_read_only,


### PR DESCRIPTION
crun sets up the container devices before the `pivot_root`, so a path opened through the rootfs can still resolve against the host file system, and neither call site used `O_NOFOLLOW`:

- **CVE-2026-88265** — `libcrun_reopen_dev_null()` followed a symlinked `/dev/null` and identified the null device by `st_rdev` alone, so the std streams could be redirected to a host file.
- **CVE-2026-88264** — `create_file_if_missing_at()` created `/dev/console` without `O_NOFOLLOW`, so a symlink made rootful crun create a root owned file outside the rootfs.

Both are low severity: they are only reachable when nothing is mounted over `/dev`, so the entry from the attacker supplied rootfs stays visible. That is an unusual configuration no container engine uses: Docker, Podman, containerd, CRI-O and `crun|runc spec` all mount a tmpfs there.

See the individual commits for details.

@kolyshkin PTAL