### PR TITLE
criu: only relocate the unified cgroup on restore

### DIFF
--- a/src/libcrun/criu.c
+++ b/src/libcrun/criu.c
@@ -1033,6 +1033,7 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
   cleanup_free char *bundle_cleanup = NULL;
   cleanup_free char *own_cgroups = NULL;
   cleanup_close int work_fd = -1;
+  int cgroup_mode;
   int ret_out;
   size_t i;
   int ret;
@@ -1330,7 +1331,22 @@ libcrun_container_restore_linux_criu (libcrun_container_status_t *status, libcru
 
   if (status->cgroup_path)
     {
-      ret = libcriu_wrapper->criu_add_cg_root (NULL, status->cgroup_path);
+      cgroup_mode = libcrun_get_cgroup_mode (err);
+      if (UNLIKELY (cgroup_mode < 0))
+        {
+          ret = cgroup_mode;
+          goto out_umount;
+        }
+
+      /* With cgroup v2, the cgroup path is only meaningful for the unified
+         hierarchy, so only relocate that one.  A NULL controller would make
+         CRIU relocate every hierarchy the container is in, named cgroup v1
+         ones included.  As CRIU dumps such a hierarchy from wherever the
+         container is in it, which is its root, as crun leaves named
+         hierarchies alone, every checkpoint and restore would then copy the
+         whole hierarchy into itself.  */
+      ret = libcriu_wrapper->criu_add_cg_root (cgroup_mode == CGROUP_MODE_UNIFIED ? "" : NULL,
+                                               status->cgroup_path);
       if (UNLIKELY (ret != 0))
         {
           ret = crun_make_error (err, 0, "error setting CRIU cgroup root to `%s`", status->cgroup_path);

--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -325,6 +325,60 @@ def test_cr_with_ext_ns():
     return run_cr_test(conf)
 
 
+def test_cr_named_cgroup_hierarchy():
+    if r := _check_cr_requirements():
+        return r
+    if not is_cgroup_v2_unified():
+        return 77, "requires cgroup v2"
+
+    # A named cgroup v1 hierarchy, such as the ones left behind by the CRIU
+    # test suite.  Every process is in its root.  crun leaves it alone, so
+    # the restore must not create the container cgroup in it: otherwise
+    # every checkpoint/restore cycle copies the hierarchy into itself.
+    name = "crun-test-%d-%d" % (os.getpid(), int(time.monotonic() * 1000))
+    mnt = tempfile.mkdtemp()
+    try:
+        subprocess.run(["mount", "-t", "cgroup", "-o", "none,name=" + name, "cgroup", mnt],
+                       check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        os.rmdir(mnt)
+        return 77, "cannot mount a named cgroup v1 hierarchy"
+
+    def cgroups():
+        return [os.path.join(root, d)[len(mnt):] for root, dirs, _ in os.walk(mnt) for d in dirs]
+
+    try:
+        conf = base_config()
+        conf['process']['args'] = ['/init', 'pause']
+        add_all_namespaces(conf)
+        ret = run_cr_test(conf)
+        if ret != 0:
+            return ret
+        created = cgroups()
+        if created:
+            logger.info("cgroups created in the name=%s hierarchy: %s", name, created)
+            return -1
+        return 0
+    finally:
+        # The container processes may take a moment to go away after delete.
+        deadline = time.monotonic() + 5
+        while True:
+            for root, dirs, _ in os.walk(mnt, topdown=False):
+                for d in dirs:
+                    try:
+                        os.rmdir(os.path.join(root, d))
+                    except OSError:
+                        pass
+            left = cgroups()
+            if not left or time.monotonic() > deadline:
+                break
+            time.sleep(0.1)
+        if left:
+            logger.info("cannot remove cgroups from the name=%s hierarchy: %s", name, left)
+        subprocess.run(["umount", mnt], check=False)
+        os.rmdir(mnt)
+
+
 def _remove_file(filename):
     try:
         os.remove(filename)
@@ -420,6 +474,7 @@ all_tests = {
     "checkpoint-restore": test_cr,
     "checkpoint-restore-masked-paths": test_cr_masked_paths,
     "checkpoint-restore-ext-ns": test_cr_with_ext_ns,
+    "checkpoint-restore-named-cgroup-hierarchy": test_cr_named_cgroup_hierarchy,
     "checkpoint-restore-pre-dump": test_cr_pre_dump,
     "checkpoint-restore-with-runc-config": test_cr_with_runc_config,
     "checkpoint-restore-with-crun-config": test_cr_with_crun_config,


### PR DESCRIPTION
On restore, crun passes the container cgroup path to CRIU as the new root for a `NULL` controller, which CRIU applies to *every* hierarchy the dumped task is in, named cgroup v1 ones included.

With cgroup v2, crun leaves named v1 hierarchies alone, so the container sits in the root of any such hierarchy, and CRIU dumps it from there, i.e. the whole hierarchy. On restore, all of it is recreated under the container cgroup path, so every checkpoint/restore doubles the hierarchy.

On a host with named hierarchies left over from the CRIU test suite (`name=zdtmtst` etc.), repeated test runs piled up ~4.6M cgroups (one of the hierarchies had exactly 2^19-1), ~30 GB of per-cpu and ~29 GB of unreclaimable slab memory, CRIU dumps spinning for minutes, and eventually a global OOM.

With cgroup v2, only relocate the unified hierarchy (`""` controller), which is what the cgroup path is meant for; keep `NULL` with cgroup v1. runc is not affected, as it passes a root per controller.

The added `checkpoint-restore-named-cgroup-hierarchy` test mounts a named cgroup v1 hierarchy for the duration of a checkpoint and restore, and checks that no cgroups were created in it (skipped unless root on a cgroup v2 host). Without the fix it fails with `cgroups created in the name=crun-test-... hierarchy: ['/test-tmpXXXX']`; with the fix it passes.

(the criu tests side of the fix: https://github.com/checkpoint-restore/criu/pull/3142)